### PR TITLE
Consolidate test config and add unit tests for Component.wl and Varlist.wl

### DIFF
--- a/test/regression/compare_golden.wl
+++ b/test/regression/compare_golden.wl
@@ -41,20 +41,12 @@ CompareGoldenFile[currentFile_String, goldenFile_String] := Module[
   ]
 ];
 
-(* Define test cases: {backend, testName, extension} *)
-$TestCases = {
-  (* CarpetX backends *)
-  {"CarpetX", "test", ".hxx"},
-  {"CarpetX", "testGPU", ".hxx"},
-  {"CarpetXPointDesc", "test", ".hxx"},
-  (* Carpet backend *)
-  {"Carpet", "test", ".hxx"},
-  (* AMReX backend *)
-  {"AMReX", "test", ".hxx"},
-  (* Nmesh backend *)
-  {"Nmesh", "test", ".c"},
-  {"Nmesh", "GHG_rhs", ".c"}
-};
+(* Load test cases from shared config file *)
+$ConfigFile = FileNameJoin[{$TestDir, "..", "test_cases.txt"}];
+$TestCases = Select[
+  StringSplit[#, ":"] & /@ Import[$ConfigFile, "Lines"],
+  Length[#] == 3 && !StringStartsQ[#[[1]], "#"] &
+];
 
 (* Run all golden file comparisons *)
 RunGoldenTests[] := Module[

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -120,16 +120,20 @@ update_golden() {
 PASSED=0
 FAILED=0
 
-# Backend test definitions
-BACKENDS=(
-  "CarpetX:test:.hxx"
-  "CarpetX:testGPU:.hxx"
-  "CarpetXPointDesc:test:.hxx"
-  "Carpet:test:.hxx"
-  "AMReX:test:.hxx"
-  "Nmesh:test:.c"
-  "Nmesh:GHG_rhs:.c"
-)
+# Load test cases from config file
+CONFIG_FILE="$SCRIPT_DIR/test_cases.txt"
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo -e "${RED}ERROR: Config file not found: $CONFIG_FILE${NC}"
+  exit 1
+fi
+
+# Read config file into BACKENDS array (skip comments and empty lines)
+BACKENDS=()
+while IFS= read -r line || [ -n "$line" ]; do
+  # Skip comments and empty lines
+  [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+  BACKENDS+=("$line")
+done < "$CONFIG_FILE"
 
 if [ "$COMPARE_ONLY" = false ]; then
   echo "--- Integration Tests ---"

--- a/test/test_cases.txt
+++ b/test/test_cases.txt
@@ -1,0 +1,10 @@
+# Test case definitions for Generato
+# Format: backend:test_name:extension
+# Lines starting with # are comments
+CarpetX:test:.hxx
+CarpetX:testGPU:.hxx
+CarpetXPointDesc:test:.hxx
+Carpet:test:.hxx
+AMReX:test:.hxx
+Nmesh:test:.c
+Nmesh:GHG_rhs:.c

--- a/test/unit/ComponentTests.wl
+++ b/test/unit/ComponentTests.wl
@@ -1,0 +1,138 @@
+(* ::Package:: *)
+
+(* ComponentTests.wl *)
+(* Unit tests for Generato`Component module *)
+
+Print["Loading ComponentTests.wl..."];
+
+(* Load Generato *)
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
+
+SetPVerbose[False];
+SetPrintDate[False];
+
+(* ========================================= *)
+(* Test: Getter/Setter Functions *)
+(* ========================================= *)
+
+VerificationTest[
+  SetSimplifyEquation[True];
+  GetSimplifyEquation[],
+  True,
+  TestID -> "GetSetSimplifyEquation-True"
+];
+
+VerificationTest[
+  SetSimplifyEquation[False];
+  GetSimplifyEquation[],
+  False,
+  TestID -> "GetSetSimplifyEquation-False"
+];
+
+VerificationTest[
+  SetUseLetterForTensorComponet[True];
+  GetUseLetterForTensorComponet[],
+  True,
+  TestID -> "GetSetUseLetterForTensorComponet-True"
+];
+
+VerificationTest[
+  SetUseLetterForTensorComponet[False];
+  GetUseLetterForTensorComponet[],
+  False,
+  TestID -> "GetSetUseLetterForTensorComponet-False"
+];
+
+VerificationTest[
+  SetTempVariableType["CCTK_REAL"];
+  GetTempVariableType[],
+  "CCTK_REAL",
+  TestID -> "GetSetTempVariableType"
+];
+
+VerificationTest[
+  SetInterfaceWithNonCoordBasis[True];
+  GetInterfaceWithNonCoordBasis[],
+  True,
+  TestID -> "GetSetInterfaceWithNonCoordBasis"
+];
+
+VerificationTest[
+  SetSuffixName["_rhs"];
+  GetSuffixName[],
+  "_rhs",
+  TestID -> "GetSetSuffixName"
+];
+
+VerificationTest[
+  SetSuffixName[""];
+  GetSuffixName[],
+  "",
+  TestID -> "GetSetSuffixName-Empty"
+];
+
+(* ========================================= *)
+(* Test: Is3DAbstractIndex *)
+(* ========================================= *)
+
+VerificationTest[
+  (* Index 'i' should be 3D (letter >= 'i') *)
+  Is3DAbstractIndex[i],
+  True,
+  TestID -> "Is3DAbstractIndex-i"
+];
+
+VerificationTest[
+  (* Index 'j' should be 3D *)
+  Is3DAbstractIndex[j],
+  True,
+  TestID -> "Is3DAbstractIndex-j"
+];
+
+VerificationTest[
+  (* Index 'a' should NOT be 3D (letter < 'i') *)
+  Is3DAbstractIndex[a],
+  False,
+  TestID -> "Is3DAbstractIndex-a"
+];
+
+VerificationTest[
+  (* Index 'h' should NOT be 3D (letter < 'i') *)
+  Is3DAbstractIndex[h],
+  False,
+  TestID -> "Is3DAbstractIndex-h"
+];
+
+VerificationTest[
+  (* Negative index -i should be 3D *)
+  Is3DAbstractIndex[-i],
+  True,
+  TestID -> "Is3DAbstractIndex-NegativeI"
+];
+
+VerificationTest[
+  (* Index 'i1' should be 3D (first letter is 'i') *)
+  Is3DAbstractIndex[i1],
+  True,
+  TestID -> "Is3DAbstractIndex-i1"
+];
+
+(* ========================================= *)
+(* Test: MapComponentToVarlist *)
+(* ========================================= *)
+
+VerificationTest[
+  (* GetMapComponentToVarlist should return an Association *)
+  AssociationQ[GetMapComponentToVarlist[]],
+  True,
+  TestID -> "GetMapComponentToVarlist-ReturnsAssociation"
+];
+
+(* Reset state *)
+SetSimplifyEquation[True];
+SetUseLetterForTensorComponet[False];
+SetTempVariableType["double"];
+SetInterfaceWithNonCoordBasis[False];
+SetSuffixName[""];
+
+Print["ComponentTests.wl completed."];

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -1,0 +1,144 @@
+(* ::Package:: *)
+
+(* VarlistTests.wl *)
+(* Unit tests for Generato`Varlist module *)
+(* Tests: ParseVar, DefineTensor *)
+
+Print["Loading VarlistTests.wl..."];
+
+(* Load Generato *)
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
+
+SetPVerbose[False];
+SetPrintDate[False];
+
+(* ========================================= *)
+(* Setup: Define test manifold *)
+(* ========================================= *)
+
+If[!MemberQ[$Manifolds, VarTestM3],
+  DefManifold[VarTestM3, 3, IndexRange[a, z]];
+  DefChart[varTestCart, VarTestM3, {1, 2, 3}, {VarX[], VarY[], VarZ[]}, ChartColor -> Blue];
+];
+
+(* ========================================= *)
+(* Test: ParseVar - Basic Cases *)
+(* ========================================= *)
+
+VerificationTest[
+  (* ParseVar with vector and PrintAs *)
+  {varname, symmetry, printname} = ParseVar[{varTestVec[i], PrintAs -> "vtv"}];
+  varname === varTestVec[i],
+  True,
+  TestID -> "ParseVar-VectorVarname"
+];
+
+VerificationTest[
+  (* ParseVar extracts PrintAs value *)
+  {varname, symmetry, printname} = ParseVar[{varTestVec2[i], PrintAs -> "vtv2"}];
+  printname,
+  "vtv2",
+  TestID -> "ParseVar-PrintAs"
+];
+
+VerificationTest[
+  (* ParseVar with no symmetry returns Null *)
+  {varname, symmetry, printname} = ParseVar[{varTestVec3[i], PrintAs -> "vtv3"}];
+  symmetry,
+  Null,
+  TestID -> "ParseVar-NoSymmetry"
+];
+
+(* ========================================= *)
+(* Test: ParseVar - Symmetric Tensors *)
+(* ========================================= *)
+
+VerificationTest[
+  (* ParseVar with Symmetric 2-tensor *)
+  {varname, symmetry, printname} = ParseVar[{varTestSym[-i, -j], Symmetric[{-i, -j}], PrintAs -> "vts"}];
+  Head[symmetry] === Symmetric,
+  True,
+  TestID -> "ParseVar-SymmetricHead"
+];
+
+VerificationTest[
+  (* ParseVar extracts symmetric indices *)
+  {varname, symmetry, printname} = ParseVar[{varTestSym2[-i, -j], Symmetric[{-i, -j}], PrintAs -> "vts2"}];
+  symmetry[[1]],
+  {-i, -j},
+  TestID -> "ParseVar-SymmetricIndices"
+];
+
+(* ========================================= *)
+(* Test: ParseVar - Antisymmetric Tensors *)
+(* ========================================= *)
+
+VerificationTest[
+  (* ParseVar with Antisymmetric 2-tensor *)
+  {varname, symmetry, printname} = ParseVar[{varTestAnti[-i, -j], Antisymmetric[{-i, -j}], PrintAs -> "vta"}];
+  Head[symmetry] === Antisymmetric,
+  True,
+  TestID -> "ParseVar-AntisymmetricHead"
+];
+
+(* ========================================= *)
+(* Test: ParseVar - Scalar *)
+(* ========================================= *)
+
+VerificationTest[
+  (* ParseVar with scalar (no indices) *)
+  {varname, symmetry, printname} = ParseVar[{varTestScalar[], PrintAs -> "vsc"}];
+  Length[varname],
+  0,
+  TestID -> "ParseVar-ScalarLength"
+];
+
+(* ========================================= *)
+(* Test: ParseVar - Order Independence *)
+(* ========================================= *)
+
+VerificationTest[
+  (* ParseVar handles different ordering: PrintAs first *)
+  {varname, symmetry, printname} = ParseVar[{PrintAs -> "order1", varTestOrder1[i]}];
+  printname,
+  "order1",
+  TestID -> "ParseVar-OrderIndependence-PrintAsFirst"
+];
+
+VerificationTest[
+  (* ParseVar handles different ordering: symmetry in middle *)
+  {varname, symmetry, printname} = ParseVar[{varTestOrder2[-i, -j], Symmetric[{-i, -j}], PrintAs -> "order2"}];
+  {Head[symmetry], printname},
+  {Symmetric, "order2"},
+  TestID -> "ParseVar-OrderIndependence-SymmetryMiddle"
+];
+
+(* ========================================= *)
+(* Test: DefineTensor *)
+(* ========================================= *)
+
+VerificationTest[
+  (* DefineTensor creates a valid xTensor *)
+  DefineTensor[varDefTest1[i], Null, "vdt1"];
+  xTensorQ[varDefTest1],
+  True,
+  TestID -> "DefineTensor-CreatesXTensor"
+];
+
+VerificationTest[
+  (* DefineTensor with symmetry *)
+  DefineTensor[varDefTest2[-i, -j], Symmetric[{-i, -j}], "vdt2"];
+  xTensorQ[varDefTest2],
+  True,
+  TestID -> "DefineTensor-WithSymmetry"
+];
+
+VerificationTest[
+  (* DefineTensor without PrintAs (empty string) *)
+  DefineTensor[varDefTest3[i], Null, ""];
+  xTensorQ[varDefTest3],
+  True,
+  TestID -> "DefineTensor-NoPrintAs"
+];
+
+Print["VarlistTests.wl completed."];


### PR DESCRIPTION
## Summary
- Create shared test configuration file (`test/test_cases.txt`) as single source of truth
- Add unit tests for `Component.wl` module (15 tests)
- Add unit tests for `Varlist.wl` module (12 tests)

## Changes

### Phase 1: Shared Test Configuration
- Created `test/test_cases.txt` with colon-delimited format
- Updated `test/run_tests.sh` to read from config file instead of hardcoded array
- Updated `test/regression/compare_golden.wl` to import from config file

### Phase 2: Component.wl Unit Tests
- Added `test/unit/ComponentTests.wl` covering:
  - Getter/setter pairs (SimplifyEquation, UseLetterForTensorComponet, TempVariableType, InterfaceWithNonCoordBasis, SuffixName)
  - `Is3DAbstractIndex` helper function
  - `GetMapComponentToVarlist` return type

### Phase 3: Varlist.wl Unit Tests
- Added `test/unit/VarlistTests.wl` covering:
  - `ParseVar` with vectors, symmetric/antisymmetric tensors, scalars
  - `ParseVar` order independence
  - `DefineTensor` with/without symmetry and PrintAs

## Test plan
- [x] `./test/run_tests.sh` passes
- [x] `./test/run_tests.sh --compare` passes
- [x] `./test/run_tests.sh --generate` works
- [x] All 27 new unit tests pass (15 Component + 12 Varlist)
- [x] Adding new entry to `test_cases.txt` is picked up by both scripts (manual verification)