### PR TITLE
refactor: reuse existing test manifold in InterfaceTests.wl and Varli…

### DIFF
--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -64,9 +64,11 @@ VerificationTest[
 (* ========================================= *)
 
 (* Setup a simple manifold for equation tests *)
-DefManifold[TestM3, 3, IndexRange[a, z]];
-DefChart[testCart, TestM3, {1, 2, 3}, {TX[], TY[], TZ[]}, ChartColor -> Blue];
-DefMetric[1, testEuclid[-i, -j], testCD];
+If[!MemberQ[$Manifolds, TestM3],
+  DefManifold[TestM3, 3, IndexRange[a, z]];
+  DefChart[testCart, TestM3, {1, 2, 3}, {TX[], TY[], TZ[]}, ChartColor -> Blue];
+  DefMetric[1, testEuclid[-i, -j], testCD];
+];
 
 (* Define test tensors *)
 testVarlist = GridTensors[{testVec[i], PrintAs -> "tv"}];

--- a/test/unit/InterfaceTests.wl
+++ b/test/unit/InterfaceTests.wl
@@ -15,13 +15,14 @@ SetPVerbose[False];
 SetPrintDate[False];
 
 (* ========================================= *)
-(* Setup: Define test manifold *)
+(* Setup: Use existing test manifold from BasicTests *)
 (* ========================================= *)
 
-If[!xTensorQ[intTestVec],
-  DefManifold[IntTestM3, 3, IndexRange[a, z]];
-  DefChart[intTestCart, IntTestM3, {1, 2, 3}, {IntX[], IntY[], IntZ[]}, ChartColor -> Blue];
-  DefMetric[1, intTestEuclid[-i, -j], intTestCD];
+(* Reuse TestM3 manifold if it exists, otherwise define it *)
+If[!MemberQ[$Manifolds, TestM3],
+  DefManifold[TestM3, 3, IndexRange[a, z]];
+  DefChart[testCart, TestM3, {1, 2, 3}, {TX[], TY[], TZ[]}, ChartColor -> Blue];
+  DefMetric[1, testEuclid[-i, -j], testCD];
 ];
 
 (* ========================================= *)

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -13,12 +13,14 @@ SetPVerbose[False];
 SetPrintDate[False];
 
 (* ========================================= *)
-(* Setup: Define test manifold *)
+(* Setup: Use existing test manifold from BasicTests *)
 (* ========================================= *)
 
-If[!MemberQ[$Manifolds, VarTestM3],
-  DefManifold[VarTestM3, 3, IndexRange[a, z]];
-  DefChart[varTestCart, VarTestM3, {1, 2, 3}, {VarX[], VarY[], VarZ[]}, ChartColor -> Blue];
+(* Reuse TestM3 manifold if it exists, otherwise define it *)
+If[!MemberQ[$Manifolds, TestM3],
+  DefManifold[TestM3, 3, IndexRange[a, z]];
+  DefChart[testCart, TestM3, {1, 2, 3}, {TX[], TY[], TZ[]}, ChartColor -> Blue];
+  DefMetric[1, testEuclid[-i, -j], testCD];
 ];
 
 (* ========================================= *)


### PR DESCRIPTION
…stTests.wl

Update test setup to check for the existence of TestM3 manifold before defining it, reducing redundancy in test configurations.