### PR TITLE
feat: add ParseMode unit tests with Clean functions

### DIFF
--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -16,6 +16,8 @@ SetParseMode::usage = "SetParseMode[key] add/update the mode correspond to the k
 
 SetParseModeAllToFalse::usage = "SetParseModeAllToFalse[] set all the modes to false";
 
+CleanParseMode::usage = "CleanParseMode[] empty the association";
+
 SetComp::usage = "ParseMode option.";
 
 PrintComp::usage = "ParseMode option.";
@@ -29,6 +31,8 @@ GetParseSetCompMode::usage = "GetParseSetCompMode[key] returns the mode correspo
 SetParseSetCompMode::usage = "SetParseSetCompMode[key] add/update the mode correspond to the key";
 
 SetParseSetCompModeAllToFalse::usage = "SetParseSetCompModeAllToFalse[] set all the modes to false";
+
+CleanParseSetCompMode::usage = "CleanParseSetCompMode[] empty the association";
 
 IndependentVarlistIndex::usage = "ParseSetCompMode option.";
 
@@ -47,6 +51,8 @@ GetParsePrintCompMode::usage = "GetParsePrintCompMode[key] returns the mode corr
 SetParsePrintCompMode::usage = "SetParsePrintCompMode[key] add/update the mode correspond to the key";
 
 SetParsePrintCompModeAllToFalse::usage = "SetParsePrintCompModeAllToFalse[] set all the modes to false";
+
+CleanParsePrintCompMode::usage = "CleanParsePrintCompMode[] empty the association";
 
 Initializations::usage = "ParsePrintCompMode option.";
 
@@ -125,6 +131,11 @@ SetParseModeAllToFalse[] :=
 
 Protect[SetParseModeAllToFalse];
 
+CleanParseMode[] :=
+  Module[{},
+    $ParseModeAssociation = <||>
+  ];
+
 GetParseSetCompMode[key_] :=
   Return[
     If[KeyExistsQ[$ParseSetCompModeAssociation, key],
@@ -150,6 +161,11 @@ SetParseSetCompModeAllToFalse[] :=
 
 Protect[SetParseSetCompModeAllToFalse];
 
+CleanParseSetCompMode[] :=
+  Module[{},
+    $ParseSetCompModeAssociation = <||>
+  ];
+
 GetParsePrintCompMode[key_] :=
   Return[
     If[KeyExistsQ[$ParsePrintCompModeAssociation, key],
@@ -174,6 +190,11 @@ SetParsePrintCompModeAllToFalse[] :=
   ];
 
 Protect[SetParsePrintCompModeAllToFalse];
+
+CleanParsePrintCompMode[] :=
+  Module[{},
+    $ParsePrintCompModeAssociation = <||>
+  ];
 
 GetParsePrintCompInitMode[key_] :=
   Return[

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -1,0 +1,218 @@
+(* ::Package:: *)
+
+(* ParseModeTests.wl *)
+(* Unit tests for Generato`ParseMode module *)
+
+Print["Loading ParseModeTests.wl..."];
+
+(* Load Generato *)
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
+
+SetPVerbose[False];
+SetPrintDate[False];
+
+(* ========================================= *)
+(* Test: ParseMode (Level 1) *)
+(* ========================================= *)
+
+VerificationTest[
+  CleanParseMode[];
+  SetParseMode[<|SetComp -> True|>];
+  GetParseMode[SetComp],
+  True,
+  TestID -> "ParseMode-SetComp-True"
+];
+
+VerificationTest[
+  CleanParseMode[];
+  SetParseMode[<|PrintComp -> True|>];
+  GetParseMode[PrintComp],
+  True,
+  TestID -> "ParseMode-PrintComp-True"
+];
+
+VerificationTest[
+  CleanParseMode[];
+  GetParseMode[NonExistentKey],
+  False,
+  TestID -> "ParseMode-NonExistentKey-ReturnsFalse"
+];
+
+VerificationTest[
+  CleanParseMode[];
+  SetParseMode[<|SetComp -> True, PrintComp -> True|>];
+  SetParseModeAllToFalse[];
+  {GetParseMode[SetComp], GetParseMode[PrintComp]},
+  {False, False},
+  TestID -> "ParseMode-SetAllToFalse"
+];
+
+(* ========================================= *)
+(* Test: ParseSetCompMode (Level 2) *)
+(* ========================================= *)
+
+VerificationTest[
+  CleanParseSetCompMode[];
+  SetParseSetCompMode[<|IndependentVarlistIndex -> True|>];
+  GetParseSetCompMode[IndependentVarlistIndex],
+  True,
+  TestID -> "ParseSetCompMode-IndependentVarlistIndex-True"
+];
+
+VerificationTest[
+  CleanParseSetCompMode[];
+  SetParseSetCompMode[<|WithoutGridPointIndex -> True|>];
+  GetParseSetCompMode[WithoutGridPointIndex],
+  True,
+  TestID -> "ParseSetCompMode-WithoutGridPointIndex-True"
+];
+
+VerificationTest[
+  CleanParseSetCompMode[];
+  SetParseSetCompMode[<|UseTilePointIndex -> True|>];
+  GetParseSetCompMode[UseTilePointIndex],
+  True,
+  TestID -> "ParseSetCompMode-UseTilePointIndex-True"
+];
+
+VerificationTest[
+  CleanParseSetCompMode[];
+  GetParseSetCompMode[NonExistentKey],
+  False,
+  TestID -> "ParseSetCompMode-NonExistentKey-ReturnsFalse"
+];
+
+VerificationTest[
+  CleanParseSetCompMode[];
+  SetParseSetCompMode[<|IndependentVarlistIndex -> True, WithoutGridPointIndex -> True, UseTilePointIndex -> True|>];
+  SetParseSetCompModeAllToFalse[];
+  {GetParseSetCompMode[IndependentVarlistIndex], GetParseSetCompMode[WithoutGridPointIndex], GetParseSetCompMode[UseTilePointIndex]},
+  {False, False, False},
+  TestID -> "ParseSetCompMode-SetAllToFalse"
+];
+
+(* ========================================= *)
+(* Test: ParsePrintCompMode (Level 3) *)
+(* ========================================= *)
+
+VerificationTest[
+  CleanParsePrintCompMode[];
+  SetParsePrintCompMode[<|Initializations -> True|>];
+  GetParsePrintCompMode[Initializations],
+  True,
+  TestID -> "ParsePrintCompMode-Initializations-True"
+];
+
+VerificationTest[
+  CleanParsePrintCompMode[];
+  SetParsePrintCompMode[<|Equations -> True|>];
+  GetParsePrintCompMode[Equations],
+  True,
+  TestID -> "ParsePrintCompMode-Equations-True"
+];
+
+VerificationTest[
+  CleanParsePrintCompMode[];
+  GetParsePrintCompMode[NonExistentKey],
+  False,
+  TestID -> "ParsePrintCompMode-NonExistentKey-ReturnsFalse"
+];
+
+VerificationTest[
+  CleanParsePrintCompMode[];
+  SetParsePrintCompMode[<|Initializations -> True, Equations -> True|>];
+  SetParsePrintCompModeAllToFalse[];
+  {GetParsePrintCompMode[Initializations], GetParsePrintCompMode[Equations]},
+  {False, False},
+  TestID -> "ParsePrintCompMode-SetAllToFalse"
+];
+
+(* ========================================= *)
+(* Test: ParsePrintCompInitMode (Level 4) *)
+(* ========================================= *)
+
+VerificationTest[
+  CleanParsePrintCompInitMode[];
+  SetParsePrintCompInitMode[<|"TestKey" -> "TestValue"|>];
+  GetParsePrintCompInitMode["TestKey"],
+  "TestValue",
+  TestID -> "ParsePrintCompInitMode-SetGet"
+];
+
+VerificationTest[
+  CleanParsePrintCompInitMode[];
+  GetParsePrintCompInitMode["NonExistentKey"],
+  False,
+  TestID -> "ParsePrintCompInitMode-NonExistentKey-ReturnsFalse"
+];
+
+(* ========================================= *)
+(* Test: ParsePrintCompEQNMode (Level 5) *)
+(* ========================================= *)
+
+VerificationTest[
+  CleanParsePrintCompEQNMode[];
+  SetParsePrintCompEQNMode[<|"TestKey" -> "TestValue"|>];
+  GetParsePrintCompEQNMode["TestKey"],
+  "TestValue",
+  TestID -> "ParsePrintCompEQNMode-SetGet"
+];
+
+VerificationTest[
+  CleanParsePrintCompEQNMode[];
+  GetParsePrintCompEQNMode["NonExistentKey"],
+  False,
+  TestID -> "ParsePrintCompEQNMode-NonExistentKey-ReturnsFalse"
+];
+
+(* ========================================= *)
+(* Test: ParsePrintCompInitTensorType (Level 6) *)
+(* ========================================= *)
+
+VerificationTest[
+  CleanParsePrintCompInitTensorType[];
+  SetParsePrintCompInitTensorType[<|"TestKey" -> "TestValue"|>];
+  GetParsePrintCompInitTensorType["TestKey"],
+  "TestValue",
+  TestID -> "ParsePrintCompInitTensorType-SetGet"
+];
+
+VerificationTest[
+  CleanParsePrintCompInitTensorType[];
+  GetParsePrintCompInitTensorType["NonExistentKey"],
+  False,
+  TestID -> "ParsePrintCompInitTensorType-NonExistentKey-ReturnsFalse"
+];
+
+(* ========================================= *)
+(* Test: ParsePrintCompInitStorageType (Level 7) *)
+(* ========================================= *)
+
+VerificationTest[
+  CleanParsePrintCompInitStorageType[];
+  SetParsePrintCompInitStorageType[<|"TestKey" -> "TestValue"|>];
+  GetParsePrintCompInitStorageType["TestKey"],
+  "TestValue",
+  TestID -> "ParsePrintCompInitStorageType-SetGet"
+];
+
+VerificationTest[
+  CleanParsePrintCompInitStorageType[];
+  GetParsePrintCompInitStorageType["NonExistentKey"],
+  False,
+  TestID -> "ParsePrintCompInitStorageType-NonExistentKey-ReturnsFalse"
+];
+
+(* ========================================= *)
+(* Cleanup *)
+(* ========================================= *)
+
+CleanParseMode[];
+CleanParseSetCompMode[];
+CleanParsePrintCompMode[];
+CleanParsePrintCompInitMode[];
+CleanParsePrintCompEQNMode[];
+CleanParsePrintCompInitTensorType[];
+CleanParsePrintCompInitStorageType[];
+
+Print["ParseModeTests.wl completed."];


### PR DESCRIPTION
## Summary

Add unit test coverage for the `Generato`ParseMode` module with 21 tests covering all 7 hierarchical mode levels.

### Changes

- Add `CleanParseMode`, `CleanParseSetCompMode`, and `CleanParsePrintCompMode` functions to reset association state between tests
- Create `test/unit/ParseModeTests.wl` with comprehensive test coverage:
  - Level 1 (ParseMode): 4 tests - SetComp/PrintComp modes
  - Level 2 (ParseSetCompMode): 5 tests - IndependentVarlistIndex, WithoutGridPointIndex, UseTilePointIndex
  - Level 3 (ParsePrintCompMode): 4 tests - Initializations, Equations
  - Levels 4-7 (dynamic keys): 8 tests - Get/Set and non-existent key behavior

### Why

The ParseMode module previously only had `SetAllToFalse` functions which append to associations rather than clearing them, making test isolation difficult. The new `Clean*` functions enable proper test isolation.

## Test plan

- [x] All unit tests pass: `wolframscript -f test/AllTests.wl`
- [x] Golden file comparison passes: `./test/run_tests.sh --compare`