### PR TITLE
docs: update usage messages to follow Wolfram Language documentation style

### DIFF
--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -12,59 +12,59 @@ System`Print["Package Generato`Basic`, {2024, 1, 11}"];
 
 System`Print["------------------------------------------------------------"];
 
-GetCheckInputEquations::usage = "GetCheckInputEquations[] return the Boolean variable specifying if we are checking input equations.";
+GetCheckInputEquations::usage = "GetCheckInputEquations[] returns True if input equation checking is enabled.";
 
-SetCheckInputEquations::usage = "SetCheckInputEquations[True] update the Boolean variable specifying if we are checking input equations.";
+SetCheckInputEquations::usage = "SetCheckInputEquations[bool] enables or disables checking of input equations.";
 
-SetPVerbose::usage = "SetPVerbose[True] update the Boolean variable specifying if print more messages.";
+SetPVerbose::usage = "SetPVerbose[bool] enables or disables verbose printing of messages.";
 
-GetPrintDate::usage = "GetPrintDate[] return the Boolean variable specifying if print date in file.";
+GetPrintDate::usage = "GetPrintDate[] returns True if the date is printed in output files.";
 
-SetPrintDate::usage = "SetPrintDate[True] update the Boolean variable specifying if print date in file.";
+SetPrintDate::usage = "SetPrintDate[bool] enables or disables printing the date in output files.";
 
-GetPrintHeaderMacro::usage = "GetPrintHeaderMacro[] return the Boolean variable specifying if print date in file.";
+GetPrintHeaderMacro::usage = "GetPrintHeaderMacro[] returns True if header guard macros are printed in output files.";
 
-SetPrintHeaderMacro::usage = "SetPrintHeaderMacro[True] update the Boolean variable specifying if print date in file.";
+SetPrintHeaderMacro::usage = "SetPrintHeaderMacro[bool] enables or disables printing header guard macros in output files.";
 
-GetGridPointIndex::usage = "GetGridPointIndex[] return the grid index name.";
+GetGridPointIndex::usage = "GetGridPointIndex[] returns the grid point index string appended to variable names.";
 
-SetGridPointIndex::usage = "SetGridPointIndex[girdindex] reset the grid index name.";
+SetGridPointIndex::usage = "SetGridPointIndex[index] sets the grid point index string appended to variable names.";
 
-GetTilePointIndex::usage = "GetTilePointIndex[] return the tile index name.";
+GetTilePointIndex::usage = "GetTilePointIndex[] returns the tile point index string appended to variable names.";
 
-SetTilePointIndex::usage = "SetTilePointIndex[girdindex] reset the tile index name.";
+SetTilePointIndex::usage = "SetTilePointIndex[index] sets the tile point index string appended to variable names.";
 
-GetSuffixUnprotected::usage = "GetSuffixUnprotected[] returns the suffix added to vars which would conflict with system default otherwise.";
+GetSuffixUnprotected::usage = "GetSuffixUnprotected[] returns the suffix added to variable names that would conflict with system symbols.";
 
-SetSuffixUnprotected::usage = "SetSuffixUnprotected[suffix] reset the suffix added to vars which would conflict with system default otherwise.";
+SetSuffixUnprotected::usage = "SetSuffixUnprotected[suffix] sets the suffix added to variable names that would conflict with system symbols.";
 
-GetOutputFile::usage = "GetOutputFile[] return the variable storing the output file name.";
+GetOutputFile::usage = "GetOutputFile[] returns the output file name.";
 
-SetOutputFile::usage = "SetOutputFile[name] update the variable storing the output file name.";
+SetOutputFile::usage = "SetOutputFile[name] sets the output file name.";
 
-GetProject::usage = "GetProject[] return the project name we are generating file for.";
+GetProject::usage = "GetProject[] returns the project name used in code generation.";
 
-SetProject::usage = "SetProject[name] update the project name we are generating file for.";
+SetProject::usage = "SetProject[name] sets the project name used in code generation.";
 
-GetDefaultChart::usage = "GetDefaultChart[] return the default chart we are using.";
+GetDefaultChart::usage = "GetDefaultChart[] returns the default coordinate chart of the first defined manifold.";
 
-GetDim::usage = "GetDim[] return the dimension of the manifold.";
+GetDim::usage = "GetDim[] returns the dimension of the first defined manifold.";
 
-IsDefined::usage = "IsDefined[term] return True/False if term is defined or not.";
+IsDefined::usage = "IsDefined[term] returns True if term is a defined tensor or constant, False otherwise.";
 
-IndexType::usage = "IndexType[compindex, indextype] return True if second compindex is indextype.";
+IndexType::usage = "IndexType[compindexlist, indextype] returns True if the second component index satisfies indextype.";
 
-IndexType3D::usage = "IndexType3D[compindex, indextype] return True if second compindex is indextype and it's a 3D index.";
+IndexType3D::usage = "IndexType3D[compindexlist, indextype] returns True if the second component index satisfies indextype and is a 3D index.";
 
-RHSOf::usage = "RHSOf[var, suffix] return the expression of 'var$RHS' or 'varsuffix$RHS' (if suffix is not empty).";
+RHSOf::usage = "RHSOf[var] returns the symbol var$RHS.\nRHSOf[var, suffix] returns the symbol varsuffix$RHS.";
 
-SetEQN::usage = "SetEQN[{CheckRHS->..., Suffix->...}, var, varrhs] set 'var$RHS/varsuffix$RHS' equal to 'varrhs', considering if CheckRHS.";
+SetEQN::usage = "SetEQN[var, varrhs] assigns varrhs to var$RHS using IndexSet.\nSetEQN[{CheckRHS->bool, SuffixName->suffix}, var, varrhs] assigns with options.";
 
-CheckRHS::usage = "CheckRHS is an option for SetEQN specifying if check there are undefined terms in varrhs.";
+CheckRHS::usage = "CheckRHS is an option for SetEQN that specifies whether to verify all terms in the right-hand side are defined.";
 
-SetEQNDelayed::usage = "SetEQNDelayed[{Suffix->...}, var, varrhs] set 'var$RHS/varsuffix$RHS' equal to varrhs for if cases.";
+SetEQNDelayed::usage = "SetEQNDelayed[var, varrhs] assigns varrhs to var$RHS using IndexSetDelayed.\nSetEQNDelayed[{SuffixName->suffix}, var, varrhs] assigns with a suffix.";
 
-PrintVerbose::usage = "PrintVerbose[var] print var only if GetPVerbose[] is True.";
+PrintVerbose::usage = "PrintVerbose[expr] prints expr if verbose mode is enabled.";
 
 Begin["`Private`"];
 

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -14,35 +14,35 @@ System`Print["Package Generato`Component`, {2024, 1, 11}"];
 
 System`Print["------------------------------------------------------------"];
 
-GetMapComponentToVarlist::usage = "GetMapComponentToVarlist[] returns the map between tensor components and varlist indexes.";
+GetMapComponentToVarlist::usage = "GetMapComponentToVarlist[] returns the Association mapping tensor components to varlist indices.";
 
-SetProcessNewVarlist::usage = "SetProcessNewVarlist[True] updates the Boolean variable specifying if we are processing a new varlist.";
+SetProcessNewVarlist::usage = "SetProcessNewVarlist[bool] sets whether the next varlist is treated as a new varlist for index numbering.";
 
-GetSimplifyEquation::usage = "GetSimplifyEquation[] returns the Boolean variable specifying if Simplify the equations.";
+GetSimplifyEquation::usage = "GetSimplifyEquation[] returns True if equations are simplified before output.";
 
-SetSimplifyEquation::usage = "SetSimplifyEquation[True] updates the Boolean variable specifying if Simplify the equations.";
+SetSimplifyEquation::usage = "SetSimplifyEquation[bool] enables or disables simplification of equations before output.";
 
-GetUseLetterForTensorComponet::usage = "GetUseLetterForTensorComponet[] returns the Boolean variable specifying if use letter for tensor components (instead of number).";
+GetUseLetterForTensorComponent::usage = "GetUseLetterForTensorComponent[] returns True if letters are used for tensor component indices instead of numbers.";
 
-SetUseLetterForTensorComponet::usage = "SetUseLetterForTensorComponet[True] updates the Boolean variable specifying if use letter for tensor components (instead of number).";
+SetUseLetterForTensorComponent::usage = "SetUseLetterForTensorComponent[bool] sets whether to use letters for tensor component indices instead of numbers.";
 
-GetTempVariableType::usage = "GetTempVariableType[] returns the type of temporary variable.";
+GetTempVariableType::usage = "GetTempVariableType[] returns the C type string used for temporary variables.";
 
-SetTempVariableType::usage = "SetTempVariableType[CCTK_REAL] updates the type of temporary variable.";
+SetTempVariableType::usage = "SetTempVariableType[type] sets the C type string used for temporary variables.";
 
-GetInterfaceWithNonCoordBasis::usage = "GetInterfaceWithNonCoordBasis[] returns the Boolean variable specifying if we are interfacing with non-coordinate basis.";
+GetInterfaceWithNonCoordBasis::usage = "GetInterfaceWithNonCoordBasis[] returns True if interfacing with non-coordinate basis tensors.";
 
-SetInterfaceWithNonCoordBasis::usage = "SetInterfaceWithNonCoordBasis[True] updates the Boolean variable specifying if we are interfacing with non-coordinate basis.";
+SetInterfaceWithNonCoordBasis::usage = "SetInterfaceWithNonCoordBasis[bool] enables or disables interfacing with non-coordinate basis tensors.";
 
-GetSuffixName::usage = "GetSuffixName[] returns the suffix added to vars in the current list.";
+GetSuffixName::usage = "GetSuffixName[] returns the suffix appended to variable names in the current varlist.";
 
-SetSuffixName::usage = "SetSuffixName[suffix] updates the suffix added to vars in the current list.";
+SetSuffixName::usage = "SetSuffixName[suffix] sets the suffix appended to variable names in the current varlist.";
 
-GetPrefixDt::usage = "GetPrefixDt[] return the prefix used for dt of vars.";
+GetPrefixDt::usage = "GetPrefixDt[] returns the prefix used for time derivatives of variables.";
 
-ParseComponent::usage = "ParseComponent[varinfo, compindexlist, coordinate] process a component.";
+ParseComponent::usage = "ParseComponent[varinfo, compindexlist, coordinate, extrareplacerules] processes a single tensor component for setting or printing.";
 
-Is3DAbstractIndex::usage = "Is3DAbstractIndex[abstractindex] return True if the abstract index is after letter 'i' and only the first letter matters (say h <=> h1 <=> h2 ...).";
+Is3DAbstractIndex::usage = "Is3DAbstractIndex[index] returns True if the abstract index represents a 3D spatial index (first letter >= 'i').";
 
 Begin["`Private`"];
 
@@ -54,7 +54,7 @@ $ProcessNewVarlist = True;
 
 $SimplifyEquation = True;
 
-$UseLetterForTensorComponet = False;
+$UseLetterForTensorComponent = False;
 
 $TempVariableType = "double";
 
@@ -98,17 +98,17 @@ SetSimplifyEquation[simplify_] :=
 
 Protect[SetSimplifyEquation];
 
-GetUseLetterForTensorComponet[] :=
-  Return[$UseLetterForTensorComponet];
+GetUseLetterForTensorComponent[] :=
+  Return[$UseLetterForTensorComponent];
 
-Protect[GetUseLetterForTensorComponet];
+Protect[GetUseLetterForTensorComponent];
 
-SetUseLetterForTensorComponet[useletter_] :=
+SetUseLetterForTensorComponent[useletter_] :=
   Module[{},
-    $UseLetterForTensorComponet = useletter
+    $UseLetterForTensorComponent = useletter
   ];
 
-Protect[SetUseLetterForTensorComponet];
+Protect[SetUseLetterForTensorComponent];
 
 GetTempVariableType[] :=
   Return[$TempVariableType];
@@ -273,7 +273,7 @@ SetExprName[varname_, compindexlist_, coordinate_] :=
       Do[
         exprname =
           exprname <>
-            If[GetUseLetterForTensorComponet[],
+            If[GetUseLetterForTensorComponent[],
               colist[[compindexlist[[icomp]] + 1]]
               ,
               ToString @ compindexlist[[icomp]]

--- a/src/Derivation.wl
+++ b/src/Derivation.wl
@@ -10,7 +10,7 @@ System`Print["Package Generato`Derivation`, {2024, 1, 18}"];
 
 System`Print["------------------------------------------------------------"];
 
-TestEQN::usage = "TestEQN[equal, terms] print SUCCEED/FAILED if equal/not";
+TestEQN::usage = "TestEQN[bool, label] prints 'SUCCEED' if bool is True, otherwise prints 'FAILED' and aborts.";
 
 Begin["`Private`"];
 

--- a/src/Interface.wl
+++ b/src/Interface.wl
@@ -18,77 +18,77 @@ System`Print["Package Generato`Interface`, {2024, 1, 11}"];
 
 System`Print["------------------------------------------------------------"];
 
-DefTensors::usage = "DefTensors[vars] define tensors (without setting its components)";
+DefTensors::usage = "DefTensors[var1, var2, ...] defines tensors without setting their components.";
 
-GridTensors::usage = "GridTensors[vars] define grid tensors (with grid point index), set components and return the varlist";
+GridTensors::usage = "GridTensors[var1, var2, ...] defines tensors with grid point indices, sets their components, and returns the varlist.";
 
-TileTensors::usage = "TileTensors[vars] define grid tensors (with tile point index), set components and return the varlist";
+TileTensors::usage = "TileTensors[var1, var2, ...] defines tensors with tile point indices, sets their components, and returns the varlist.";
 
-TempTensors::usage = "TempTensors[vars] define temp tensors (without grid point index), set components and return the varlist";
+TempTensors::usage = "TempTensors[var1, var2, ...] defines temporary tensors without grid point indices, sets their components, and returns the varlist.";
 
-SetComponents::usage = "SetComponents[{ChartName->..., IndependentIndexForEachVar->..., WithoutGridPointIndex->...}, varlist] set components of varlist.";
+SetComponents::usage = "SetComponents[varlist] sets tensor components for the given varlist.\nSetComponents[{opts}, varlist] sets components with options ChartName, IndependentIndexForEachVar, WithoutGridPointIndex, UseTilePointIndex.";
 
-PrintEquations::usage = "PrintEquations[{ChartName->..., SuffixName->..., Mode->...}, varlist] print equations of varlist.";
+PrintEquations::usage = "PrintEquations[varlist] prints equations for tensor components in the varlist.\nPrintEquations[{opts}, varlist] prints with options ChartName, SuffixName, Mode, ExtraReplaceRules.";
 
-NewVar::usage = "PrintEquations option.";
+NewVar::usage = "NewVar is a PrintEquations Mode option that declares new temporary variables before assignment.";
 
 Protect[NewVar];
 
-Main::usage = "PrintEquations option.";
+Main::usage = "Main is a PrintEquations Mode option that generates the main equation assignments.";
 
 Protect[Main];
 
-AddToMain::usage = "PrintEquations option.";
+AddToMain::usage = "AddToMain is a PrintEquations Mode option that adds terms to existing equation assignments.";
 
 Protect[AddToMain];
 
-PrintInitializations::usage = "PrintInitializations[{ChartName->..., Mode->...}, varlist] print initialization of varlist.";
+PrintInitializations::usage = "PrintInitializations[varlist] prints initialization code for tensor components.\nPrintInitializations[{opts}, varlist] prints with options ChartName, Mode, TensorType, StorageType, DerivsOrder, AccuracyOrder.";
 
-MainOut::usage = "PrintInitializations option."
+MainOut::usage = "MainOut is a PrintInitializations Mode option that generates output variable declarations."
 
 Protect[MainOut];
 
-MainIn::usage = "PrintInitializations option."
+MainIn::usage = "MainIn is a PrintInitializations Mode option that generates input variable declarations."
 
 Protect[MainIn];
 
-Derivs::usage = "PrintInitializations option."
+Derivs::usage = "Derivs is a PrintInitializations Mode option that generates derivative variable declarations."
 
 Protect[Derivs];
 
-DerivsOrder::usage = "PrintInitializations option."
+DerivsOrder::usage = "DerivsOrder is a PrintInitializations option that specifies the derivative order (default 1)."
 
 Protect[DerivsOrder];
 
-DerivsAccuracy::usage = "PrintInitializations option."
+DerivsAccuracy::usage = "DerivsAccuracy is a PrintInitializations option that specifies the finite difference accuracy order (default 4)."
 
 Protect[DerivsAccuracy];
 
-MoreInOut::usage = "PrintInitializations option."
+MoreInOut::usage = "MoreInOut is a PrintInitializations Mode option that generates additional input/output declarations."
 
 Protect[MoreInOut];
 
-Temp::usage = "PrintInitializations option."
+Temp::usage = "Temp is a PrintInitializations Mode option that generates temporary variable declarations."
 
 Protect[Temp];
 
-Scal::usage = "PrintInitializations tensor type option."
+Scal::usage = "Scal is a PrintInitializations TensorType option indicating a scalar quantity."
 
 Protect[Scal];
 
-Vect::usage = "PrintInitializations tensor type option."
+Vect::usage = "Vect is a PrintInitializations TensorType option indicating a vector quantity."
 
 Protect[Vect];
 
-Smat::usage = "PrintInitializations tensor type option."
+Smat::usage = "Smat is a PrintInitializations TensorType option indicating a symmetric matrix quantity."
 
 Protect[Smat];
 
-GF::usage = "PrintInitializations storage type option."
+GF::usage = "GF is a PrintInitializations StorageType option indicating grid function storage."
 
 Protect[GF];
 
-Tile::usage = "PrintInitializations storage type option."
+Tile::usage = "Tile is a PrintInitializations StorageType option indicating tile-based storage."
 
 Protect[Tile];
 

--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -10,35 +10,35 @@ System`Print["Package Generato`ParseMode`, {2024, 7, 06}"];
 
 System`Print["------------------------------------------------------------"];
 
-GetParseMode::usage = "GetParseMode[key] returns the mode correspond to the key";
+GetParseMode::usage = "GetParseMode[key] returns True if the specified parsing mode is active, False otherwise.";
 
-SetParseMode::usage = "SetParseMode[key] add/update the mode correspond to the key";
+SetParseMode::usage = "SetParseMode[key->value] sets the specified parsing mode.";
 
-SetParseModeAllToFalse::usage = "SetParseModeAllToFalse[] set all the modes to false";
+SetParseModeAllToFalse::usage = "SetParseModeAllToFalse[] deactivates all parsing modes.";
 
-CleanParseMode::usage = "CleanParseMode[] empty the association";
+CleanParseMode::usage = "CleanParseMode[] clears the parsing mode association.";
 
-SetComp::usage = "ParseMode option.";
+SetComp::usage = "SetComp is a ParseMode option that indicates component-setting phase, where tensor components are assigned to expressions.";
 
-PrintComp::usage = "ParseMode option.";
+PrintComp::usage = "PrintComp is a ParseMode option that indicates component-printing phase, where tensor components are written to output.";
 
 Protect[SetComp];
 
 Protect[PrintComp];
 
-GetParseSetCompMode::usage = "GetParseSetCompMode[key] returns the mode correspond to the key";
+GetParseSetCompMode::usage = "GetParseSetCompMode[key] returns True if the specified SetComp mode is active, False otherwise.";
 
-SetParseSetCompMode::usage = "SetParseSetCompMode[key] add/update the mode correspond to the key";
+SetParseSetCompMode::usage = "SetParseSetCompMode[key->value] sets the specified SetComp mode.";
 
-SetParseSetCompModeAllToFalse::usage = "SetParseSetCompModeAllToFalse[] set all the modes to false";
+SetParseSetCompModeAllToFalse::usage = "SetParseSetCompModeAllToFalse[] deactivates all SetComp modes.";
 
-CleanParseSetCompMode::usage = "CleanParseSetCompMode[] empty the association";
+CleanParseSetCompMode::usage = "CleanParseSetCompMode[] clears the SetComp mode association.";
 
-IndependentVarlistIndex::usage = "ParseSetCompMode option.";
+IndependentVarlistIndex::usage = "IndependentVarlistIndex is a SetComp mode option that resets component indices for each new variable in the varlist.";
 
-WithoutGridPointIndex::usage = "ParseSetCompMode option.";
+WithoutGridPointIndex::usage = "WithoutGridPointIndex is a SetComp mode option that omits the grid point index suffix from variable names.";
 
-UseTilePointIndex::usage = "ParseSetCompMode option.";
+UseTilePointIndex::usage = "UseTilePointIndex is a SetComp mode option that uses tile point index instead of grid point index.";
 
 Protect[IndependentVarlistIndex];
 
@@ -46,45 +46,45 @@ Protect[WithoutGridPointIndex];
 
 Protect[UseTilePointIndex];
 
-GetParsePrintCompMode::usage = "GetParsePrintCompMode[key] returns the mode correspond to the key";
+GetParsePrintCompMode::usage = "GetParsePrintCompMode[key] returns True if the specified PrintComp mode is active, False otherwise.";
 
-SetParsePrintCompMode::usage = "SetParsePrintCompMode[key] add/update the mode correspond to the key";
+SetParsePrintCompMode::usage = "SetParsePrintCompMode[key->value] sets the specified PrintComp mode.";
 
-SetParsePrintCompModeAllToFalse::usage = "SetParsePrintCompModeAllToFalse[] set all the modes to false";
+SetParsePrintCompModeAllToFalse::usage = "SetParsePrintCompModeAllToFalse[] deactivates all PrintComp modes.";
 
-CleanParsePrintCompMode::usage = "CleanParsePrintCompMode[] empty the association";
+CleanParsePrintCompMode::usage = "CleanParsePrintCompMode[] clears the PrintComp mode association.";
 
-Initializations::usage = "ParsePrintCompMode option.";
+Initializations::usage = "Initializations is a PrintComp mode option that indicates initialization code generation phase.";
 
-Equations::usage = "ParsePrintCompMode option.";
+Equations::usage = "Equations is a PrintComp mode option that indicates equation code generation phase.";
 
 Protect[Initializations];
 
 Protect[Equations];
 
-GetParsePrintCompInitMode::usage = "GetParsePrintCompInitMode[key] returns the mode correspond to the key";
+GetParsePrintCompInitMode::usage = "GetParsePrintCompInitMode[key] returns the value for the specified initialization mode key.";
 
-SetParsePrintCompInitMode::usage = "SetParsePrintCompInitMode[key] add/update the mode correspond to the key";
+SetParsePrintCompInitMode::usage = "SetParsePrintCompInitMode[key->value] sets the specified initialization mode.";
 
-CleanParsePrintCompInitMode::usage = "CleanParsePrintCompInitMode[] empty the association";
+CleanParsePrintCompInitMode::usage = "CleanParsePrintCompInitMode[] clears the initialization mode association.";
 
-GetParsePrintCompEQNMode::usage = "GetParsePrintCompEQNMode[key] returns the mode correspond to the key";
+GetParsePrintCompEQNMode::usage = "GetParsePrintCompEQNMode[key] returns True if the specified equation mode is active, False otherwise.";
 
-SetParsePrintCompEQNMode::usage = "SetParsePrintCompEQNMode[key] add/update the mode correspond to the key";
+SetParsePrintCompEQNMode::usage = "SetParsePrintCompEQNMode[key->value] sets the specified equation mode.";
 
-CleanParsePrintCompEQNMode::usage = "CleanParsePrintCompEQNMode[] empty the association";
+CleanParsePrintCompEQNMode::usage = "CleanParsePrintCompEQNMode[] clears the equation mode association.";
 
-GetParsePrintCompInitTensorType::usage = "GetParsePrintCompInitTensorType[key] returns the mode correspond to the key";
+GetParsePrintCompInitTensorType::usage = "GetParsePrintCompInitTensorType[key] returns True if the specified tensor type is active, False otherwise.";
 
-SetParsePrintCompInitTensorType::usage = "SetParsePrintCompInitTensorType[key] add/update the mode correspond to the key";
+SetParsePrintCompInitTensorType::usage = "SetParsePrintCompInitTensorType[key->value] sets the specified tensor type mode.";
 
-CleanParsePrintCompInitTensorType::usage = "CleanParsePrintCompInitTensorType[] empty the association";
+CleanParsePrintCompInitTensorType::usage = "CleanParsePrintCompInitTensorType[] clears the tensor type association.";
 
-GetParsePrintCompInitStorageType::usage = "GetParsePrintCompInitStorageType[key] returns the mode correspond to the key";
+GetParsePrintCompInitStorageType::usage = "GetParsePrintCompInitStorageType[key] returns True if the specified storage type is active, False otherwise.";
 
-SetParsePrintCompInitStorageType::usage = "SetParsePrintCompInitStorageType[key] add/update the mode correspond to the key";
+SetParsePrintCompInitStorageType::usage = "SetParsePrintCompInitStorageType[key->value] sets the specified storage type mode.";
 
-CleanParsePrintCompInitStorageType::usage = "CleanParsePrintCompInitStorageType[] empty the association";
+CleanParsePrintCompInitStorageType::usage = "CleanParsePrintCompInitStorageType[] clears the storage type association.";
 
 Begin["`Private`"];
 

--- a/src/Varlist.wl
+++ b/src/Varlist.wl
@@ -16,11 +16,11 @@ System`Print["Package Generato`Varlist`, {2024, 1, 11}"];
 
 System`Print["------------------------------------------------------------"];
 
-ParseVarlist::usage = "ParseVarlist[varlist, chartname] process a varlist.";
+ParseVarlist::usage = "ParseVarlist[varlist, chartname] processes a varlist, setting or printing components for each tensor.\nParseVarlist[{ExtraReplaceRules->rules}, varlist, chartname] processes with additional replacement rules.";
 
-ParseVar::usage = "ParseVar[var] return {varname, symmetry, printname} in order";
+ParseVar::usage = "ParseVar[var] parses a variable specification and returns {varname, symmetry, printname}.";
 
-DefineTensor::usage = "DefineTensor[varname, symmetry, printname] DefTensor, given varname, symmetry and printname";
+DefineTensor::usage = "DefineTensor[varname, symmetry, printname] defines a tensor using DefTensor with the given symmetry and print name.";
 
 Begin["`Private`"];
 

--- a/src/Writefile.wl
+++ b/src/Writefile.wl
@@ -16,13 +16,13 @@ System`Print["Package Generato`Writefile`, {2025, 1, 23}"];
 
 System`Print["------------------------------------------------------------"];
 
-SetMainPrint::usage = "SetMainPrint[content] update the variable storing function printing more main content.";
+SetMainPrint::usage = "SetMainPrint[content] sets the content to be written as the main body of the output file.";
 
-GetMainPrint::usage = "GetMainPrint[content] return the variable storing function printing more main content.";
+GetMainPrint::usage = "GetMainPrint[] returns and evaluates the content set by SetMainPrint.";
 
-WriteToFile::usage = "WriteToFile[] writing contents to a file.";
+WriteToFile::usage = "WriteToFile[filename] writes the main content to the specified file with header and footer.";
 
-ReplaceGFIndexName::usage = "ReplaceGFIndexName[] writing contents to a file.";
+ReplaceGFIndexName::usage = "ReplaceGFIndexName[filename, rule] applies string replacement rule to the contents of filename.";
 
 Begin["`Private`"];
 

--- a/src/stencils/FiniteDifferenceStencils.wl
+++ b/src/stencils/FiniteDifferenceStencils.wl
@@ -12,9 +12,11 @@ System`Print["Package Generato`FiniteDifferenceStencils`, {2025, 1, 21}"];
 
 System`Print["------------------------------------------------------------"];
 
-GetFiniteDifferenceCoefficients::usage = "GetFiniteDifferenceCoefficients[sample, order] return coeffients of finite difference stencils.";
+GetFiniteDifferenceCoefficients::usage = "GetFiniteDifferenceCoefficients[sample, order] returns the finite difference coefficients for the given sample points and derivative order.";
 
-GetCenteringStencils::usage = "GetCenteringStencils[ord] return the centering finite difference stencils of order ord.";
+GetCenteringStencils::usage = "GetCenteringStencils[order] returns the centering stencil points for the given accuracy order.";
+
+GetUpwindCoefficients::usage = "GetUpwindCoefficients[sample] returns the symmetric and antisymmetric upwind coefficients for the given sample points.";
 
 Begin["`Private`"];
 

--- a/test/unit/ComponentTests.wl
+++ b/test/unit/ComponentTests.wl
@@ -30,17 +30,17 @@ VerificationTest[
 ];
 
 VerificationTest[
-  SetUseLetterForTensorComponet[True];
-  GetUseLetterForTensorComponet[],
+  SetUseLetterForTensorComponent[True];
+  GetUseLetterForTensorComponent[],
   True,
-  TestID -> "GetSetUseLetterForTensorComponet-True"
+  TestID -> "GetSetUseLetterForTensorComponent-True"
 ];
 
 VerificationTest[
-  SetUseLetterForTensorComponet[False];
-  GetUseLetterForTensorComponet[],
+  SetUseLetterForTensorComponent[False];
+  GetUseLetterForTensorComponent[],
   False,
-  TestID -> "GetSetUseLetterForTensorComponet-False"
+  TestID -> "GetSetUseLetterForTensorComponent-False"
 ];
 
 VerificationTest[
@@ -130,7 +130,7 @@ VerificationTest[
 
 (* Reset state *)
 SetSimplifyEquation[True];
-SetUseLetterForTensorComponet[False];
+SetUseLetterForTensorComponent[False];
 SetTempVariableType["double"];
 SetInterfaceWithNonCoordBasis[False];
 SetSuffixName[""];


### PR DESCRIPTION
## Summary
- Update 100+ function usage messages across 8 source files to follow official Wolfram Language documentation conventions
- Use present tense verbs ("returns", "sets", "enables") throughout
- Multi-line format for functions with multiple signatures
- Full descriptions for option symbols explaining their purpose and context
- Fix incorrect descriptions (e.g., `GetPrintHeaderMacro` was incorrectly documented as "date" instead of "header guard macros")
- Add missing usage message for `GetUpwindCoefficients` in FiniteDifferenceStencils.wl

## Test plan
- [x] All integration tests pass (`./test/run_tests.sh`)
- [x] Golden file comparisons pass for all backends