### PR TITLE
fix: enable regression tests in AllTests.wl with proper generation and cleanup

### DIFF
--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -50,7 +50,62 @@ If[Length[$AllTests] > 0,
 Print["--- Regression Tests (Golden Files) ---"];
 Print[""];
 
-(* Load and run golden file comparisons *)
+(* Load test cases from config file *)
+$ConfigFile = FileNameJoin[{$TestDir, "test_cases.txt"}];
+$TestCases = Select[
+  StringSplit[#, ":"] & /@ Import[$ConfigFile, "Lines"],
+  Length[#] == 3 && !StringStartsQ[#[[1]], "#"] &
+];
+
+(* Generate outputs for each test case *)
+Print["Generating test outputs..."];
+Print[""];
+
+$GenerationFailed = False;
+Do[
+  {backend, testName, ext} = testCase;
+  testFile = FileNameJoin[{$TestDir, backend, testName <> ".wl"}];
+
+  If[FileExistsQ[testFile],
+    Print["  Generating: ", backend, "/", testName, ".wl"];
+    (* Run Generato from the test directory *)
+    result = Run["cd " <> FileNameJoin[{$TestDir, backend}] <> " && \"$GENERATO/Generato\" " <> testName <> ".wl 2>&1"];
+    If[result != 0,
+      Print["    FAILED to generate ", testName, ext];
+      $GenerationFailed = True;
+    ],
+    Print["  SKIP: ", testFile, " not found"];
+  ],
+  {testCase, $TestCases}
+];
+
+Print[""];
+
+If[$GenerationFailed,
+  Print["ERROR: Some outputs failed to generate"];
+  Exit[1]
+];
+
+(* Load golden file comparison module *)
 Get[FileNameJoin[{$TestDir, "regression", "compare_golden.wl"}]];
 
-(* Note: compare_golden.wl will call Exit[] with appropriate status *)
+(* Run golden file comparisons *)
+$RegressionResult = GoldenTest`RunGoldenTests[];
+
+(* Cleanup generated output files *)
+Print[""];
+Print["Cleaning up generated files..."];
+Do[
+  {backend, testName, ext} = testCase;
+  outputFile = FileNameJoin[{$TestDir, backend, testName <> ext}];
+  If[FileExistsQ[outputFile],
+    DeleteFile[outputFile];
+  ],
+  {testCase, $TestCases}
+];
+
+(* Exit with appropriate status *)
+If[$RegressionResult === $Failed,
+  Exit[1],
+  Exit[0]
+];

--- a/test/regression/compare_golden.wl
+++ b/test/regression/compare_golden.wl
@@ -74,17 +74,23 @@ RunGoldenTests[] := Module[
   If[failed > 0,
     Print[""];
     Print["REGRESSION DETECTED"];
-    Exit[1],
+    If[Length[$ScriptCommandLine] > 0 && MemberQ[StringContainsQ[#, "compare_golden.wl"] & /@ $ScriptCommandLine, True],
+      Exit[1],
+      $Failed
+    ],
     Print[""];
     Print["ALL TESTS PASSED"];
-    Exit[0]
+    If[Length[$ScriptCommandLine] > 0 && MemberQ[StringContainsQ[#, "compare_golden.wl"] & /@ $ScriptCommandLine, True],
+      Exit[0],
+      True
+    ]
   ]
 ];
 
 End[];
 EndPackage[];
 
-(* Run tests when executed directly *)
-If[Length[$ScriptCommandLine] > 0,
+(* Run tests only when executed directly (not when loaded via Get[]) *)
+If[Length[$ScriptCommandLine] > 0 && MemberQ[StringContainsQ[#, "compare_golden.wl"] & /@ $ScriptCommandLine, True],
   RunGoldenTests[]
 ];


### PR DESCRIPTION
## Summary

- Fix `wolframscript -f test/AllTests.wl` to properly run regression tests by generating output files before comparison
- Add cleanup logic to remove generated files after test completion
- Fix auto-run detection in `compare_golden.wl` to distinguish standalone execution from being loaded via `Get[]`

## Test plan

- [x] Run `wolframscript -f test/AllTests.wl` - all unit tests and 7/7 regression tests pass
- [x] Verify exit code is 0 when tests pass
- [x] Verify no `.hxx` or `.c` files remain in test directories after completion
- [x] Verify standalone `wolframscript -f test/regression/compare_golden.wl` still works
- [x] Verify `Get["test/regression/compare_golden.wl"]` in REPL loads without auto-running