### PR TITLE
docs: recommend wolframscript as primary test runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,14 +60,14 @@ Each backend implements `PrintComponentInitialization` and `PrintComponentEquati
 ## Running Tests
 
 ```bash
-# Run all tests (regenerate outputs, compare against golden files, cleanup)
+# Run all tests (recommended - runs unit tests + regression tests)
+wolframscript -f test/AllTests.wl
+
+# Alternative: Run via bash script
 ./test/run_tests.sh
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate
-
-# Run via Wolfram (unit tests + regression tests)
-wolframscript -f test/AllTests.wl
 ```
 
 The test suite includes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,14 +60,14 @@ Each backend implements `PrintComponentInitialization` and `PrintComponentEquati
 ## Running Tests
 
 ```bash
-# Run all tests (regenerate outputs, compare against golden files, cleanup)
+# Run all tests (recommended - runs unit tests + regression tests)
+wolframscript -f test/AllTests.wl
+
+# Alternative: Run via bash script
 ./test/run_tests.sh
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate
-
-# Run via Wolfram (unit tests + regression tests)
-wolframscript -f test/AllTests.wl
 ```
 
 The test suite includes:

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Generato GHG_rhs.wl
 ## Running Tests
 
 ```bash
-# Run all tests (regenerate outputs, compare against golden files, cleanup)
+# Run all tests (recommended - runs unit tests + regression tests)
+wolframscript -f test/AllTests.wl
+
+# Alternative: Run via bash script
 ./test/run_tests.sh
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate
-
-# Run via Wolfram (unit tests + regression tests)
-wolframscript -f test/AllTests.wl
 ```


### PR DESCRIPTION
## Summary
- Reorder Running Tests documentation in AGENTS.md, CLAUDE.md, and README.md
- List `wolframscript -f test/AllTests.wl` first as the recommended method
- Keep `./test/run_tests.sh` as an alternative option

## Test plan
- [ ] Verify documentation renders correctly on GitHub