### PR TITLE
test: add comprehensive test coverage for untested modules

### DIFF
--- a/test/CarpetX/testDerivs.wl
+++ b/test/CarpetX/testDerivs.wl
@@ -1,0 +1,50 @@
+(* ::Package:: *)
+
+(* testDerivs.wl *)
+(* Integration test for Mode->Derivs with finite difference stencils *)
+
+(* (c) Liwei Ji, 01/2026 *)
+
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
+
+SetPVerbose[False];
+
+SetPrintDate[False];
+
+SetGridPointIndex[""];
+
+SetTempVariableType["vreal"];
+
+DefManifold[M3, 3, IndexRange[a, z]];
+
+DefChart[cart, M3, {1, 2, 3}, {X[], Y[], Z[]}, ChartColor -> Blue];
+
+DefMetric[1, euclid[-i, -j], CD];
+
+MetricInBasis[euclid, -cart, DiagonalMatrix[{1, 1, 1}]];
+
+MetricInBasis[euclid, cart, DiagonalMatrix[{1, 1, 1}]];
+
+(* Variables for derivative test *)
+EvolVarlist = GridTensors[{phi[], PrintAs -> "phi"}];
+
+DerivVarlist = GridTensors[{dphi[i], PrintAs -> "dphi"}];
+
+TempVarlist = TempTensors[{psi[], PrintAs -> "psi"}];
+
+(* Simple equation using the derivative *)
+SetEQN[psi[], euclid[i, j] dphi[-i] dphi[-j]];
+
+SetOutputFile[FileNameJoin[{Directory[], "testDerivs.hxx"}]];
+
+SetMainPrint[
+  pr[];
+  PrintInitializations[{Mode -> "MainIn"}, EvolVarlist];
+  pr[];
+  (* Test Mode->Derivs with DerivsOrder and AccuracyOrder *)
+  PrintInitializations[{Mode -> "Derivs", TensorType -> "Vect", DerivsOrder -> 1, AccuracyOrder -> 4}, DerivVarlist];
+  pr[];
+  PrintEquations[{Mode -> "Temp"}, TempVarlist];
+];
+
+Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetXGPU.wl"}]];

--- a/test/CarpetX/testDerivs.wl
+++ b/test/CarpetX/testDerivs.wl
@@ -44,7 +44,7 @@ SetMainPrint[
   (* Test Mode->Derivs with DerivsOrder and AccuracyOrder *)
   PrintInitializations[{Mode -> "Derivs", TensorType -> "Vect", DerivsOrder -> 1, AccuracyOrder -> 4}, DerivVarlist];
   pr[];
-  PrintEquations[{Mode -> "Temp"}, TempVarlist];
+  PrintEquations[{Mode -> "Temp", ChartName -> cart}, TempVarlist];
 ];
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetXGPU.wl"}]];

--- a/test/CarpetX/testTile.wl
+++ b/test/CarpetX/testTile.wl
@@ -1,0 +1,54 @@
+(* ::Package:: *)
+
+(* testTile.wl *)
+(* Integration test for TileTensors with Tile storage type *)
+
+(* (c) Liwei Ji, 01/2026 *)
+
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
+
+SetPVerbose[False];
+
+SetPrintDate[False];
+
+SetGridPointIndex[""];
+
+SetTilePointIndex["[[tI]]"];
+
+SetTempVariableType["vreal"];
+
+DefManifold[M3, 3, IndexRange[a, z]];
+
+DefChart[cart, M3, {1, 2, 3}, {X[], Y[], Z[]}, ChartColor -> Blue];
+
+DefMetric[1, euclid[-i, -j], CD];
+
+MetricInBasis[euclid, -cart, DiagonalMatrix[{1, 1, 1}]];
+
+MetricInBasis[euclid, cart, DiagonalMatrix[{1, 1, 1}]];
+
+(* Use TileTensors for tile-based storage *)
+TileVarlist = TileTensors[{tileU[i], PrintAs -> "tile"}];
+
+GridVarlist = GridTensors[{gridU[i], PrintAs -> "grid"}];
+
+TempVarlist = TempTensors[{tempU[i], PrintAs -> "temp"}];
+
+(* Simple equation: temp = grid, tile = temp *)
+SetEQN[tempU[i_], gridU[i]];
+
+SetEQN[tileU[i_], tempU[i]];
+
+SetOutputFile[FileNameJoin[{Directory[], "testTile.hxx"}]];
+
+SetMainPrint[
+  pr[];
+  PrintInitializations[{Mode -> "MainOut"}, TileVarlist];
+  PrintInitializations[{Mode -> "MainIn", StorageType -> "Tile"}, GridVarlist];
+  pr[];
+  PrintEquations[{Mode -> "Temp"}, TempVarlist];
+  pr[];
+  PrintEquations[{Mode -> "Main"}, TileVarlist];
+];
+
+Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetX.wl"}]];

--- a/test/golden/CarpetX/testDerivs.hxx.golden
+++ b/test/golden/CarpetX/testDerivs.hxx.golden
@@ -14,8 +14,7 @@ const auto dphi3 = calcderivs1_3(phi, p.i, p.j, p.k);
 const vreal
 psi
 =
-Power(dphi(List(1,-cart)),2) + Power(dphi(List(2,-cart)),2) +
-  Power(dphi(List(3,-cart)),2)
+dphi1*dphi1 + dphi2*dphi2 + dphi3*dphi3
 ;
 
 

--- a/test/golden/CarpetX/testDerivs.hxx.golden
+++ b/test/golden/CarpetX/testDerivs.hxx.golden
@@ -1,0 +1,24 @@
+/* testDerivs.hxx */
+/* Produced with Generato */
+
+#ifndef TESTDERIVS_HXX
+#define TESTDERIVS_HXX
+
+
+const auto phi = gf_phi;
+
+const auto dphi1 = calcderivs1_1(phi, p.i, p.j, p.k);
+const auto dphi2 = calcderivs1_2(phi, p.i, p.j, p.k);
+const auto dphi3 = calcderivs1_3(phi, p.i, p.j, p.k);
+
+const vreal
+psi
+=
+Power(dphi(List(1,-cart)),2) + Power(dphi(List(2,-cart)),2) +
+  Power(dphi(List(3,-cart)),2)
+;
+
+
+#endif // #ifndef TESTDERIVS_HXX
+
+/* testDerivs.hxx */

--- a/test/golden/CarpetX/testTile.hxx.golden
+++ b/test/golden/CarpetX/testTile.hxx.golden
@@ -1,0 +1,49 @@
+/* testTile.hxx */
+/* Produced with Generato */
+
+#ifndef TESTTILE_HXX
+#define TESTTILE_HXX
+
+
+const GF3D2<CCTK_REAL> &local_tileU1[[tI]] = gf_tileU(0);
+const GF3D2<CCTK_REAL> &local_tileU2[[tI]] = gf_tileU(1);
+const GF3D2<CCTK_REAL> &local_tileU3[[tI]] = gf_tileU(2);
+const vreal gridU1 = tmp_gridU(0);
+const vreal gridU2 = tmp_gridU(1);
+const vreal gridU3 = tmp_gridU(2);
+
+vreal
+tempU1
+=
+gridU1
+;
+
+vreal
+tempU2
+=
+gridU2
+;
+
+vreal
+tempU3
+=
+gridU3
+;
+
+
+local_tileU1[tI].store(mask, index2,
+tempU1
+);
+
+local_tileU2[tI].store(mask, index2,
+tempU2
+);
+
+local_tileU3[tI].store(mask, index2,
+tempU3
+);
+
+
+#endif // #ifndef TESTTILE_HXX
+
+/* testTile.hxx */

--- a/test/test_cases.txt
+++ b/test/test_cases.txt
@@ -3,6 +3,8 @@
 # Lines starting with # are comments
 CarpetX:test:.hxx
 CarpetX:testGPU:.hxx
+CarpetX:testTile:.hxx
+CarpetX:testDerivs:.hxx
 CarpetXPointDesc:test:.hxx
 Carpet:test:.hxx
 AMReX:test:.hxx

--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -100,6 +100,75 @@ VerificationTest[
   TestID -> "SetEQN-WithSuffix-NoError"
 ];
 
+(* ========================================= *)
+(* Test: GetCheckInputEquations / SetCheckInputEquations *)
+(* ========================================= *)
+
+VerificationTest[
+  SetCheckInputEquations[True];
+  GetCheckInputEquations[],
+  True,
+  TestID -> "GetSetCheckInputEquations-True"
+];
+
+VerificationTest[
+  SetCheckInputEquations[False];
+  GetCheckInputEquations[],
+  False,
+  TestID -> "GetSetCheckInputEquations-False"
+];
+
+(* ========================================= *)
+(* Test: GetPrintHeaderMacro / SetPrintHeaderMacro *)
+(* ========================================= *)
+
+VerificationTest[
+  SetPrintHeaderMacro[True];
+  GetPrintHeaderMacro[],
+  True,
+  TestID -> "GetSetPrintHeaderMacro-True"
+];
+
+VerificationTest[
+  SetPrintHeaderMacro[False];
+  GetPrintHeaderMacro[],
+  False,
+  TestID -> "GetSetPrintHeaderMacro-False"
+];
+
+(* ========================================= *)
+(* Test: GetSuffixUnprotected / SetSuffixUnprotected *)
+(* ========================================= *)
+
+VerificationTest[
+  SetSuffixUnprotected["_test"];
+  GetSuffixUnprotected[],
+  "_test",
+  TestID -> "GetSetSuffixUnprotected-String"
+];
+
+(* ========================================= *)
+(* Test: GetDefaultChart *)
+(* ========================================= *)
+
+VerificationTest[
+  (* GetDefaultChart should return a symbol *)
+  Head[GetDefaultChart[]] === Symbol || GetDefaultChart[] === Null,
+  True,
+  TestID -> "GetDefaultChart-ReturnsSymbolOrNull"
+];
+
+(* ========================================= *)
+(* Test: GetDim *)
+(* ========================================= *)
+
+VerificationTest[
+  (* GetDim should return an integer *)
+  IntegerQ[GetDim[]],
+  True,
+  TestID -> "GetDim-ReturnsInteger"
+];
+
 (* Reset to clean state *)
 SetPVerbose[False];
 SetGridPointIndex[""];

--- a/test/unit/ComponentTests.wl
+++ b/test/unit/ComponentTests.wl
@@ -128,6 +128,17 @@ VerificationTest[
   TestID -> "GetMapComponentToVarlist-ReturnsAssociation"
 ];
 
+(* ========================================= *)
+(* Test: GetPrefixDt *)
+(* ========================================= *)
+
+VerificationTest[
+  (* GetPrefixDt should return a string *)
+  StringQ[GetPrefixDt[]],
+  True,
+  TestID -> "GetPrefixDt-ReturnsString"
+];
+
 (* Reset state *)
 SetSimplifyEquation[True];
 SetUseLetterForTensorComponent[False];

--- a/test/unit/DerivationTests.wl
+++ b/test/unit/DerivationTests.wl
@@ -1,0 +1,57 @@
+(* ::Package:: *)
+
+(* DerivationTests.wl *)
+(* Unit tests for Generato`Derivation module *)
+
+Print["Loading DerivationTests.wl..."];
+
+(* Load the Derivation package *)
+Needs["Generato`Derivation`", FileNameJoin[{Environment["GENERATO"], "src/Derivation.wl"}]];
+
+(* ========================================= *)
+(* Test: TestEQN with True condition *)
+(* ========================================= *)
+
+VerificationTest[
+  (* TestEQN should not abort when condition is True *)
+  TestEQN[True, "TrueCondition"];
+  True,
+  True,
+  TestID -> "TestEQN-TrueCondition-NoAbort"
+];
+
+VerificationTest[
+  (* TestEQN with empty label *)
+  TestEQN[True, ""];
+  True,
+  True,
+  TestID -> "TestEQN-TrueCondition-EmptyLabel"
+];
+
+(* ========================================= *)
+(* Test: TestEQN with False condition *)
+(* Should abort - use CheckAbort to catch *)
+(* ========================================= *)
+
+VerificationTest[
+  (* TestEQN should abort when condition is False *)
+  result = CheckAbort[
+    TestEQN[False, "FalseCondition"];
+    "did-not-abort",
+    "aborted"
+  ];
+  result,
+  "aborted",
+  TestID -> "TestEQN-FalseCondition-Aborts"
+];
+
+VerificationTest[
+  (* Verify we can continue after catching the abort *)
+  CheckAbort[TestEQN[False, "Test"], "caught"];
+  TestEQN[True, "Recovery"];
+  True,
+  True,
+  TestID -> "TestEQN-RecoveryAfterAbort"
+];
+
+Print["DerivationTests.wl completed."];

--- a/test/unit/FiniteDifferenceStencilsTests.wl
+++ b/test/unit/FiniteDifferenceStencilsTests.wl
@@ -1,0 +1,127 @@
+(* ::Package:: *)
+
+(* FiniteDifferenceStencilsTests.wl *)
+(* Unit tests for Generato`FiniteDifferenceStencils module *)
+
+Print["Loading FiniteDifferenceStencilsTests.wl..."];
+
+(* Load the stencils package *)
+Needs["Generato`FiniteDifferenceStencils`", FileNameJoin[{Environment["GENERATO"], "src/stencils/FiniteDifferenceStencils.wl"}]];
+
+(* ========================================= *)
+(* Test: GetCenteringStencils *)
+(* ========================================= *)
+
+VerificationTest[
+  GetCenteringStencils[2],
+  {-1, 0, 1},
+  TestID -> "GetCenteringStencils-Order2"
+];
+
+VerificationTest[
+  GetCenteringStencils[4],
+  {-2, -1, 0, 1, 2},
+  TestID -> "GetCenteringStencils-Order4"
+];
+
+VerificationTest[
+  GetCenteringStencils[6],
+  {-3, -2, -1, 0, 1, 2, 3},
+  TestID -> "GetCenteringStencils-Order6"
+];
+
+VerificationTest[
+  GetCenteringStencils[8],
+  {-4, -3, -2, -1, 0, 1, 2, 3, 4},
+  TestID -> "GetCenteringStencils-Order8"
+];
+
+VerificationTest[
+  GetCenteringStencils[10],
+  {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5},
+  TestID -> "GetCenteringStencils-Order10"
+];
+
+VerificationTest[
+  GetCenteringStencils[12],
+  {-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6},
+  TestID -> "GetCenteringStencils-Order12"
+];
+
+(* ========================================= *)
+(* Test: GetFiniteDifferenceCoefficients *)
+(* Verify against known analytical values *)
+(* ========================================= *)
+
+(* 2nd-order centered 1st derivative: coefficients for f'(x) *)
+VerificationTest[
+  coeffs = GetFiniteDifferenceCoefficients[{-1, 0, 1}, 1];
+  {Subscript[c, -1], Subscript[c, 0], Subscript[c, 1]} /. coeffs,
+  {-1/2, 0, 1/2},
+  TestID -> "GetFiniteDifferenceCoefficients-Order2-Deriv1"
+];
+
+(* 4th-order centered 1st derivative *)
+VerificationTest[
+  coeffs = GetFiniteDifferenceCoefficients[{-2, -1, 0, 1, 2}, 1];
+  {Subscript[c, -2], Subscript[c, -1], Subscript[c, 0], Subscript[c, 1], Subscript[c, 2]} /. coeffs,
+  {1/12, -2/3, 0, 2/3, -1/12},
+  TestID -> "GetFiniteDifferenceCoefficients-Order4-Deriv1"
+];
+
+(* 2nd-order centered 2nd derivative: coefficients for f''(x) *)
+VerificationTest[
+  coeffs = GetFiniteDifferenceCoefficients[{-1, 0, 1}, 2];
+  {Subscript[c, -1], Subscript[c, 0], Subscript[c, 1]} /. coeffs,
+  {1, -2, 1},
+  TestID -> "GetFiniteDifferenceCoefficients-Order2-Deriv2"
+];
+
+(* 4th-order centered 2nd derivative *)
+VerificationTest[
+  coeffs = GetFiniteDifferenceCoefficients[{-2, -1, 0, 1, 2}, 2];
+  {Subscript[c, -2], Subscript[c, -1], Subscript[c, 0], Subscript[c, 1], Subscript[c, 2]} /. coeffs,
+  {-1/12, 4/3, -5/2, 4/3, -1/12},
+  TestID -> "GetFiniteDifferenceCoefficients-Order4-Deriv2"
+];
+
+(* Test error handling: insufficient points *)
+VerificationTest[
+  GetFiniteDifferenceCoefficients[{0, 1}, 2],
+  Null,
+  {GetFiniteDifferenceCoefficients::shortSample},
+  TestID -> "GetFiniteDifferenceCoefficients-InsufficientPoints"
+];
+
+(* ========================================= *)
+(* Test: GetUpwindCoefficients *)
+(* Verify symmetric/antisymmetric decomposition *)
+(* ========================================= *)
+
+(* 2nd-order upwind *)
+VerificationTest[
+  coeffs = GetUpwindCoefficients[{-1, 0, 1}];
+  ListQ[coeffs] && Length[coeffs] > 0,
+  True,
+  TestID -> "GetUpwindCoefficients-Order2-ReturnsList"
+];
+
+(* 4th-order upwind *)
+VerificationTest[
+  coeffs = GetUpwindCoefficients[{-2, -1, 0, 1, 2}];
+  ListQ[coeffs] && Length[coeffs] > 0,
+  True,
+  TestID -> "GetUpwindCoefficients-Order4-ReturnsList"
+];
+
+(* Verify symmetry property: upwind + downwind = 2 * symmetric part *)
+VerificationTest[
+  sample = {-1, 0, 1};
+  coeffs = GetUpwindCoefficients[sample];
+  (* Check that we got symmetric (cs) and antisymmetric (ca) coefficients *)
+  MemberQ[coeffs[[All, 1]], Subscript[cs, 1]] && MemberQ[coeffs[[All, 1]], Subscript[ca, 0]],
+  True,
+  TestID -> "GetUpwindCoefficients-HasSymmetricAndAntisymmetric"
+];
+
+Print["FiniteDifferenceStencilsTests.wl completed."];

--- a/test/unit/InterfaceTests.wl
+++ b/test/unit/InterfaceTests.wl
@@ -69,4 +69,58 @@ VerificationTest[
   TestID -> "TempTensors-ReturnsList"
 ];
 
+(* ========================================= *)
+(* Test: DefTensors *)
+(* ========================================= *)
+
+VerificationTest[
+  (* DefTensors should define tensors without setting components *)
+  defList = DefTensors[{intDefTest[i], PrintAs -> "idt"}];
+  ListQ[defList],
+  True,
+  TestID -> "DefTensors-ReturnsList"
+];
+
+VerificationTest[
+  (* DefTensors with symmetric tensor *)
+  defList = DefTensors[{intDefSym[-i, -j], Symmetric[{-i, -j}], PrintAs -> "ids"}];
+  Length[defList] >= 1,
+  True,
+  TestID -> "DefTensors-SymmetricTensor"
+];
+
+(* ========================================= *)
+(* Test: TileTensors *)
+(* ========================================= *)
+
+VerificationTest[
+  (* TileTensors should return a list *)
+  tileList = TileTensors[{intTileTest[i], PrintAs -> "itile"}];
+  ListQ[tileList],
+  True,
+  TestID -> "TileTensors-ReturnsList"
+];
+
+(* ========================================= *)
+(* Test: SetComponents options *)
+(* ========================================= *)
+
+VerificationTest[
+  (* SetComponents with WithoutGridPointIndex *)
+  varlist = {{intNoGP[i], PrintAs -> "ing"}};
+  SetComponents[{WithoutGridPointIndex -> True}, varlist];
+  True,
+  True,
+  TestID -> "SetComponents-WithoutGridPointIndex"
+];
+
+VerificationTest[
+  (* SetComponents with UseTilePointIndex *)
+  varlist = {{intTileGP[i], PrintAs -> "itg"}};
+  SetComponents[{UseTilePointIndex -> True}, varlist];
+  True,
+  True,
+  TestID -> "SetComponents-UseTilePointIndex"
+];
+
 Print["InterfaceTests.wl completed."];

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -143,4 +143,19 @@ VerificationTest[
   TestID -> "DefineTensor-NoPrintAs"
 ];
 
+(* ========================================= *)
+(* Test: ParseVarlist *)
+(* ========================================= *)
+
+VerificationTest[
+  (* ParseVarlist should process a list of variable definitions *)
+  (* This is a basic smoke test - full functionality tested via GridTensors *)
+  varlist = {{parseVarlistTest[i], PrintAs -> "pvt"}};
+  SetParseMode[{SetComp -> True, PrintComp -> False}];
+  ParseVarlist[varlist, testCart];
+  True,
+  True,
+  TestID -> "ParseVarlist-BasicSmoke"
+];
+
 Print["VarlistTests.wl completed."];

--- a/test/unit/WritefileTests.wl
+++ b/test/unit/WritefileTests.wl
@@ -1,0 +1,103 @@
+(* ::Package:: *)
+
+(* WritefileTests.wl *)
+(* Unit tests for Generato`Writefile module *)
+
+Print["Loading WritefileTests.wl..."];
+
+(* Load Generato which includes Writefile *)
+If[!MemberQ[$Packages, "Generato`Writefile`"],
+  Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
+];
+
+SetPVerbose[False];
+SetPrintDate[False];
+
+(* ========================================= *)
+(* Test: SetMainPrint / GetMainPrint *)
+(* ========================================= *)
+
+VerificationTest[
+  (* SetMainPrint should store content *)
+  SetMainPrint[Print["test content"]];
+  GetMainPrint[] =!= Null,
+  True,
+  TestID -> "SetMainPrint-StoresContent"
+];
+
+VerificationTest[
+  (* SetMainPrint has HoldAll - content should not evaluate until GetMainPrint *)
+  testVar = 0;
+  SetMainPrint[testVar = 42];
+  beforeGet = testVar;
+  GetMainPrint[];
+  afterGet = testVar;
+  {beforeGet, afterGet},
+  {0, 42},
+  TestID -> "SetMainPrint-HoldAllBehavior"
+];
+
+(* ========================================= *)
+(* Test: ReplaceGFIndexName *)
+(* ========================================= *)
+
+VerificationTest[
+  (* Create a temp file, apply replacement, verify result *)
+  tempFile = FileNameJoin[{$TemporaryDirectory, "test_replace_gf.txt"}];
+  Export[tempFile, "gf_var[[ijk]] = value;", "Text"];
+  ReplaceGFIndexName[tempFile, "[[ijk]]" -> "[i][j][k]"];
+  result = Import[tempFile, "Text"];
+  DeleteFile[tempFile];
+  StringContainsQ[result, "[i][j][k]"],
+  True,
+  TestID -> "ReplaceGFIndexName-AppliesReplacement"
+];
+
+VerificationTest[
+  (* Multiple replacements *)
+  tempFile = FileNameJoin[{$TemporaryDirectory, "test_replace_multi.txt"}];
+  Export[tempFile, "a[[ijk]] + b[[ijk]]", "Text"];
+  ReplaceGFIndexName[tempFile, "[[ijk]]" -> ""];
+  result = Import[tempFile, "Text"];
+  DeleteFile[tempFile];
+  result,
+  "a + b\n",
+  TestID -> "ReplaceGFIndexName-MultipleReplacements"
+];
+
+(* ========================================= *)
+(* Test: WriteToFile *)
+(* ========================================= *)
+
+VerificationTest[
+  (* WriteToFile should create a file with header and footer *)
+  tempFile = FileNameJoin[{$TemporaryDirectory, "test_write.hxx"}];
+  SetPrintHeaderMacro[True];
+  SetMainPrint[Global`pr["// test content"]];
+  WriteToFile[tempFile];
+  result = Import[tempFile, "Text"];
+  DeleteFile[tempFile];
+  (* Check for header comment and macro guards *)
+  StringContainsQ[result, "/* test_write.hxx */"] &&
+  StringContainsQ[result, "#ifndef TEST_WRITE_HXX"] &&
+  StringContainsQ[result, "// test content"],
+  True,
+  TestID -> "WriteToFile-CreatesFileWithHeader"
+];
+
+VerificationTest[
+  (* WriteToFile without header macro *)
+  tempFile = FileNameJoin[{$TemporaryDirectory, "test_write_nomacro.hxx"}];
+  SetPrintHeaderMacro[False];
+  SetMainPrint[Global`pr["// content only"]];
+  WriteToFile[tempFile];
+  result = Import[tempFile, "Text"];
+  DeleteFile[tempFile];
+  (* Should have comment but no macro guards *)
+  StringContainsQ[result, "/* test_write_nomacro.hxx */"] &&
+  !StringContainsQ[result, "#ifndef"],
+  True,
+  TestID -> "WriteToFile-NoHeaderMacro"
+];
+
+Print["WritefileTests.wl completed."];


### PR DESCRIPTION
## Summary

- Add unit tests for 3 previously untested modules: FiniteDifferenceStencils.wl, Derivation.wl, Writefile.wl
- Expand unit test coverage for Interface.wl, Basic.wl, Component.wl, and Varlist.wl
- Add 2 new integration tests with golden files: testTile (TileTensors) and testDerivs (Mode->Derivs)
- Unit test count increases from 62 to ~97 tests
- Integration test count increases from 7 to 9 tests

## Test plan

- [x] All unit tests pass: `wolframscript -f test/AllTests.wl`
- [x] All 9 golden file regression tests pass
- [x] New integration tests generate expected output patterns