### PR TITLE
fix: correct dphi index and remove ChartName from testDerivs

### DIFF
--- a/test/CarpetX/testDerivs.wl
+++ b/test/CarpetX/testDerivs.wl
@@ -28,7 +28,7 @@ MetricInBasis[euclid, cart, DiagonalMatrix[{1, 1, 1}]];
 (* Variables for derivative test *)
 EvolVarlist = GridTensors[{phi[], PrintAs -> "phi"}];
 
-DerivVarlist = GridTensors[{dphi[i], PrintAs -> "dphi"}];
+DerivVarlist = GridTensors[{dphi[-i], PrintAs -> "dphi"}];
 
 TempVarlist = TempTensors[{psi[], PrintAs -> "psi"}];
 
@@ -44,7 +44,7 @@ SetMainPrint[
   (* Test Mode->Derivs with DerivsOrder and AccuracyOrder *)
   PrintInitializations[{Mode -> "Derivs", TensorType -> "Vect", DerivsOrder -> 1, AccuracyOrder -> 4}, DerivVarlist];
   pr[];
-  PrintEquations[{Mode -> "Temp", ChartName -> cart}, TempVarlist];
+  PrintEquations[{Mode -> "Temp"}, TempVarlist];
 ];
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetXGPU.wl"}]];

--- a/test/golden/CarpetX/testDerivs.hxx.golden
+++ b/test/golden/CarpetX/testDerivs.hxx.golden
@@ -14,7 +14,7 @@ const auto dphi3 = calcderivs1_3(phi, p.i, p.j, p.k);
 const vreal
 psi
 =
-dphi1*dphi1 + dphi2*dphi2 + dphi3*dphi3
+Power(dphi1,2) + Power(dphi2,2) + Power(dphi3,2)
 ;
 
 


### PR DESCRIPTION
## Summary
- Fix `dphi[i]` to use proper covariant index notation `dphi[-i]`
- Remove unnecessary `ChartName -> cart` parameter from `PrintEquations` call
- Update golden file to reflect output changes (Power() syntax for squared terms)

## Test plan
- [ ] Verify `wolframscript -f test/AllTests.wl` passes
- [ ] Confirm golden file matches generated output