### PR TITLE
Add quiet mode to test suite and remove verbose package banners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,13 +61,17 @@ Each backend implements `PrintComponentInitialization` and `PrintComponentEquati
 
 ```bash
 # Run all tests (recommended - runs unit tests + regression tests)
-wolframscript -f test/AllTests.wl
-
-# Alternative: Run via bash script
 ./test/run_tests.sh
+
+# Quiet mode - shows only checkmark on success or failures on error
+./test/run_tests.sh --quiet
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate
+
+# Alternative: Run via wolframscript directly
+wolframscript -script test/AllTests.wl           # verbose
+wolframscript -script test/AllTests.wl -quiet    # quiet mode
 ```
 
 The test suite includes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,17 @@ Each backend implements `PrintComponentInitialization` and `PrintComponentEquati
 
 ```bash
 # Run all tests (recommended - runs unit tests + regression tests)
-wolframscript -f test/AllTests.wl
-
-# Alternative: Run via bash script
 ./test/run_tests.sh
+
+# Quiet mode - shows only checkmark on success or failures on error
+./test/run_tests.sh --quiet
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate
+
+# Alternative: Run via wolframscript directly
+wolframscript -script test/AllTests.wl           # verbose
+wolframscript -script test/AllTests.wl -quiet    # quiet mode
 ```
 
 The test suite includes:

--- a/README.md
+++ b/README.md
@@ -49,11 +49,15 @@ Generato GHG_rhs.wl
 
 ```bash
 # Run all tests (recommended - runs unit tests + regression tests)
-wolframscript -f test/AllTests.wl
-
-# Alternative: Run via bash script
 ./test/run_tests.sh
+
+# Quiet mode - shows only checkmark on success or failures on error
+./test/run_tests.sh --quiet
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate
+
+# Alternative: Run via wolframscript directly
+wolframscript -script test/AllTests.wl           # verbose
+wolframscript -script test/AllTests.wl -quiet    # quiet mode
 ```

--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -6,12 +6,6 @@
 
 BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`"}];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Basic`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
-
 GetCheckInputEquations::usage = "GetCheckInputEquations[] returns True if input equation checking is enabled.";
 
 SetCheckInputEquations::usage = "SetCheckInputEquations[bool] enables or disables checking of input equations.";

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -8,12 +8,6 @@ Needs["Generato`Basic`"];
 
 Needs["Generato`ParseMode`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Component`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
-
 GetMapComponentToVarlist::usage = "GetMapComponentToVarlist[] returns the Association mapping tensor components to varlist indices.";
 
 SetProcessNewVarlist::usage = "SetProcessNewVarlist[bool] sets whether the next varlist is treated as a new varlist for index numbering.";

--- a/src/Derivation.wl
+++ b/src/Derivation.wl
@@ -4,12 +4,6 @@
 
 BeginPackage["Generato`Derivation`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Derivation`, {2024, 1, 18}"];
-
-System`Print["------------------------------------------------------------"];
-
 TestEQN::usage = "TestEQN[bool, label] prints 'SUCCEED' if bool is True, otherwise prints 'FAILED' and aborts.";
 
 Begin["`Private`"];

--- a/src/Interface.wl
+++ b/src/Interface.wl
@@ -12,12 +12,6 @@ Needs["Generato`Component`"];
 
 Needs["Generato`Varlist`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Interface`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
-
 DefTensors::usage = "DefTensors[var1, var2, ...] defines tensors without setting their components.";
 
 GridTensors::usage = "GridTensors[var1, var2, ...] defines tensors with grid point indices, sets their components, and returns the varlist.";

--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -4,12 +4,6 @@
 
 BeginPackage["Generato`ParseMode`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`ParseMode`, {2024, 7, 06}"];
-
-System`Print["------------------------------------------------------------"];
-
 GetParseMode::usage = "GetParseMode[key] returns True if the specified parsing mode is active, False otherwise.";
 
 SetParseMode::usage = "SetParseMode[key->value] sets the specified parsing mode.";

--- a/src/Varlist.wl
+++ b/src/Varlist.wl
@@ -10,12 +10,6 @@ Needs["Generato`ParseMode`"];
 
 Needs["Generato`Component`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Varlist`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
-
 ParseVarlist::usage = "ParseVarlist[varlist, chartname] processes a varlist, setting or printing components for each tensor.\nParseVarlist[{ExtraReplaceRules->rules}, varlist, chartname] processes with additional replacement rules.";
 
 ParseVar::usage = "ParseVar[var] parses a variable specification and returns {varname, symmetry, printname}.";

--- a/src/Writefile.wl
+++ b/src/Writefile.wl
@@ -10,12 +10,6 @@ Needs["Generato`Basic`"];
 
 Needs["Generato`Component`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Writefile`, {2025, 1, 23}"];
-
-System`Print["------------------------------------------------------------"];
-
 SetMainPrint::usage = "SetMainPrint[content] sets the content to be written as the main body of the output file.";
 
 GetMainPrint::usage = "GetMainPrint[] returns and evaluates the content set by SetMainPrint.";

--- a/src/stencils/FiniteDifferenceStencils.wl
+++ b/src/stencils/FiniteDifferenceStencils.wl
@@ -6,12 +6,6 @@
 
 BeginPackage["Generato`FiniteDifferenceStencils`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`FiniteDifferenceStencils`, {2025, 1, 21}"];
-
-System`Print["------------------------------------------------------------"];
-
 GetFiniteDifferenceCoefficients::usage = "GetFiniteDifferenceCoefficients[sample, order] returns the finite difference coefficients for the given sample points and derivative order.";
 
 GetCenteringStencils::usage = "GetCenteringStencils[order] returns the centering stencil points for the given accuracy order.";

--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -3,8 +3,6 @@
 (* BasicTests.wl *)
 (* Unit tests for Generato`Basic module *)
 
-Print["Loading BasicTests.wl..."];
-
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
@@ -173,5 +171,3 @@ VerificationTest[
 SetPVerbose[False];
 SetGridPointIndex[""];
 SetTilePointIndex[""];
-
-Print["BasicTests.wl completed."];

--- a/test/unit/ComponentTests.wl
+++ b/test/unit/ComponentTests.wl
@@ -3,8 +3,6 @@
 (* ComponentTests.wl *)
 (* Unit tests for Generato`Component module *)
 
-Print["Loading ComponentTests.wl..."];
-
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
@@ -145,5 +143,3 @@ SetUseLetterForTensorComponent[False];
 SetTempVariableType["double"];
 SetInterfaceWithNonCoordBasis[False];
 SetSuffixName[""];
-
-Print["ComponentTests.wl completed."];

--- a/test/unit/DerivationTests.wl
+++ b/test/unit/DerivationTests.wl
@@ -3,8 +3,6 @@
 (* DerivationTests.wl *)
 (* Unit tests for Generato`Derivation module *)
 
-Print["Loading DerivationTests.wl..."];
-
 (* Load the Derivation package *)
 Needs["Generato`Derivation`", FileNameJoin[{Environment["GENERATO"], "src/Derivation.wl"}]];
 
@@ -53,5 +51,3 @@ VerificationTest[
   True,
   TestID -> "TestEQN-RecoveryAfterAbort"
 ];
-
-Print["DerivationTests.wl completed."];

--- a/test/unit/FiniteDifferenceStencilsTests.wl
+++ b/test/unit/FiniteDifferenceStencilsTests.wl
@@ -3,8 +3,6 @@
 (* FiniteDifferenceStencilsTests.wl *)
 (* Unit tests for Generato`FiniteDifferenceStencils module *)
 
-Print["Loading FiniteDifferenceStencilsTests.wl..."];
-
 (* Load the stencils package *)
 Needs["Generato`FiniteDifferenceStencils`", FileNameJoin[{Environment["GENERATO"], "src/stencils/FiniteDifferenceStencils.wl"}]];
 
@@ -123,5 +121,3 @@ VerificationTest[
   True,
   TestID -> "GetUpwindCoefficients-HasSymmetricAndAntisymmetric"
 ];
-
-Print["FiniteDifferenceStencilsTests.wl completed."];

--- a/test/unit/InterfaceTests.wl
+++ b/test/unit/InterfaceTests.wl
@@ -4,8 +4,6 @@
 (* Unit tests for Generato`Interface module *)
 (* Tests: GridTensors, TileTensors, TempTensors *)
 
-Print["Loading InterfaceTests.wl..."];
-
 (* Load Generato if not already loaded *)
 If[!MemberQ[$Packages, "Generato`Interface`"],
   Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
@@ -122,5 +120,3 @@ VerificationTest[
   True,
   TestID -> "SetComponents-UseTilePointIndex"
 ];
-
-Print["InterfaceTests.wl completed."];

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -3,8 +3,6 @@
 (* ParseModeTests.wl *)
 (* Unit tests for Generato`ParseMode module *)
 
-Print["Loading ParseModeTests.wl..."];
-
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
@@ -214,5 +212,3 @@ CleanParsePrintCompInitMode[];
 CleanParsePrintCompEQNMode[];
 CleanParsePrintCompInitTensorType[];
 CleanParsePrintCompInitStorageType[];
-
-Print["ParseModeTests.wl completed."];

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -4,8 +4,6 @@
 (* Unit tests for Generato`Varlist module *)
 (* Tests: ParseVar, DefineTensor *)
 
-Print["Loading VarlistTests.wl..."];
-
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
@@ -157,5 +155,3 @@ VerificationTest[
   True,
   TestID -> "ParseVarlist-BasicSmoke"
 ];
-
-Print["VarlistTests.wl completed."];

--- a/test/unit/WritefileTests.wl
+++ b/test/unit/WritefileTests.wl
@@ -3,8 +3,6 @@
 (* WritefileTests.wl *)
 (* Unit tests for Generato`Writefile module *)
 
-Print["Loading WritefileTests.wl..."];
-
 (* Load Generato which includes Writefile *)
 If[!MemberQ[$Packages, "Generato`Writefile`"],
   Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
@@ -99,5 +97,3 @@ VerificationTest[
   True,
   TestID -> "WriteToFile-NoHeaderMacro"
 ];
-
-Print["WritefileTests.wl completed."];


### PR DESCRIPTION
## Summary
- Add `--quiet`/`-q` flag to `run_tests.sh` that shows only checkmark on success or failure messages on error
- Add `-quiet` flag to `AllTests.wl` with the same behavior
- Remove verbose package loading banners from all `src/*.wl` modules
- Remove "Loading/completed" print statements from unit test files
- Update documentation in AGENTS.md, CLAUDE.md, and README.md

## Test plan
- [ ] Run `./test/run_tests.sh` to verify normal verbose mode still works
- [ ] Run `./test/run_tests.sh --quiet` to verify quiet mode shows only checkmark on success
- [ ] Run `wolframscript -script test/AllTests.wl` for verbose output
- [ ] Run `wolframscript -script test/AllTests.wl -quiet` for quiet output
- [ ] Verify failure cases show appropriate error messages in quiet mode