### PR TITLE
feat: add quiet mode for test output

### DIFF
--- a/Generato
+++ b/Generato
@@ -3,7 +3,7 @@
 # Generato Script (c) 2023 Liwei Ji
 # A script to process *.wl files, generate corresponding .hxx files, and clean up trailing spaces.
 
-echo "Generato (c) 2023 Liwei Ji"
+[[ "$QUIET" != "1" ]] && echo "Generato (c) 2023 Liwei Ji"
 
 # Function to display help message
 show_help() {
@@ -44,19 +44,20 @@ for input_file in "$@"; do
   output_file="${base_name}.hxx"
 
   # Run wolframscript on the input file
-  echo "Processing '$input_file'..."
+  [[ "$QUIET" != "1" ]] && echo "Processing '$input_file'..."
   wolframscript -f "$input_file"
 
   # Check if the expected output file was created
   if [[ -f "$output_file" ]]; then
     # Remove trailing spaces from the output file
-    echo "Removing trailing spaces in '$output_file'..."
+    [[ "$QUIET" != "1" ]] && echo "Removing trailing spaces in '$output_file'..."
     sed -i.bak -E 's/[[:space:]]+$//' "$output_file" && rm "${output_file}.bak"
   else
     echo "Error: Expected output file '$output_file' not found."
   fi
 
-  echo
+  [[ "$QUIET" != "1" ]] && echo
 done
 
-echo "DONE."
+[[ "$QUIET" != "1" ]] && echo "DONE."
+exit 0

--- a/codes/Nmesh.wl
+++ b/codes/Nmesh.wl
@@ -127,9 +127,9 @@ PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
 *)
 
 Module[{outputfile = GetOutputFile[], filepointer},
-  System`Print["Writing to \"", outputfile, "\"...\n"];
+  If[Environment["QUIET"] =!= "1", System`Print["Writing to \"", outputfile, "\"...\n"]];
   If[FileExistsQ[outputfile],
-    System`Print["\"", outputfile, "\" already exist, replacing it ...\n"];
+    If[Environment["QUIET"] =!= "1", System`Print["\"", outputfile, "\" already exist, replacing it ...\n"]];
     DeleteFile[outputfile]
   ];
   (* define pr *)
@@ -156,6 +156,6 @@ Module[{outputfile = GetOutputFile[], filepointer},
   $MainPrint[];
   pr[];
   pr["/* " <> FileNameTake[outputfile] <> " */"];
-  System`Print["Done generating \"", outputfile, "\"\n"];
+  If[Environment["QUIET"] =!= "1", System`Print["Done generating \"", outputfile, "\"\n"]];
   Close[filepointer]
 ];

--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -4,13 +4,17 @@
 
 (* (c) Liwei Ji, 01/2024 *)
 
-BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`"}];
+(* Suppress xAct loading banners in quiet mode *)
+If[Environment["QUIET"] === "1",
+  Block[{Print}, BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`"}]],
+  BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`"}]
+];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Basic`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`Basic`, {2024, 1, 11}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 GetCheckInputEquations::usage = "GetCheckInputEquations[] returns True if input equation checking is enabled.";
 
@@ -73,6 +77,9 @@ Begin["`Private`"];
 $CheckInputEquations = False;
 
 $PVerbose = False;
+
+(* Quiet mode - suppress all output when QUIET=1 environment variable is set *)
+$QuietMode = (Environment["QUIET"] === "1");
 
 $PrintDate = True;
 

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -8,11 +8,11 @@ Needs["Generato`Basic`"];
 
 Needs["Generato`ParseMode`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Component`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`Component`, {2024, 1, 11}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 GetMapComponentToVarlist::usage = "GetMapComponentToVarlist[] returns the Association mapping tensor components to varlist indices.";
 

--- a/src/Derivation.wl
+++ b/src/Derivation.wl
@@ -4,11 +4,11 @@
 
 BeginPackage["Generato`Derivation`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Derivation`, {2024, 1, 18}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`Derivation`, {2024, 1, 18}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 TestEQN::usage = "TestEQN[bool, label] prints 'SUCCEED' if bool is True, otherwise prints 'FAILED' and aborts.";
 

--- a/src/Generato.wl
+++ b/src/Generato.wl
@@ -26,7 +26,7 @@
 
 <<stencils/FiniteDifferenceStencils.wl
 
-System`Print[];
+If[Environment["QUIET"] =!= "1", System`Print[]];
 
 (***********)
 

--- a/src/Interface.wl
+++ b/src/Interface.wl
@@ -12,11 +12,11 @@ Needs["Generato`Component`"];
 
 Needs["Generato`Varlist`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Interface`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`Interface`, {2024, 1, 11}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 DefTensors::usage = "DefTensors[var1, var2, ...] defines tensors without setting their components.";
 

--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -4,11 +4,11 @@
 
 BeginPackage["Generato`ParseMode`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`ParseMode`, {2024, 7, 06}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`ParseMode`, {2024, 7, 06}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 GetParseMode::usage = "GetParseMode[key] returns True if the specified parsing mode is active, False otherwise.";
 

--- a/src/Varlist.wl
+++ b/src/Varlist.wl
@@ -10,11 +10,11 @@ Needs["Generato`ParseMode`"];
 
 Needs["Generato`Component`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Varlist`, {2024, 1, 11}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`Varlist`, {2024, 1, 11}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 ParseVarlist::usage = "ParseVarlist[varlist, chartname] processes a varlist, setting or printing components for each tensor.\nParseVarlist[{ExtraReplaceRules->rules}, varlist, chartname] processes with additional replacement rules.";
 

--- a/src/Writefile.wl
+++ b/src/Writefile.wl
@@ -10,11 +10,11 @@ Needs["Generato`Basic`"];
 
 Needs["Generato`Component`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`Writefile`, {2025, 1, 23}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`Writefile`, {2025, 1, 23}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 SetMainPrint::usage = "SetMainPrint[content] sets the content to be written as the main body of the output file.";
 
@@ -46,9 +46,9 @@ Protect[SetMainPrint];
 
 WriteToFile[outputfile_] :=
   Module[{},
-    System`Print["Writing to \"", outputfile, "\"...\n"];
+    If[Environment["QUIET"] =!= "1", System`Print["Writing to \"", outputfile, "\"...\n"]];
     If[FileExistsQ[outputfile],
-      System`Print["\"", outputfile, "\" already exist, replacing it ...\n"];
+      If[Environment["QUIET"] =!= "1", System`Print["\"", outputfile, "\" already exist, replacing it ...\n"]];
       DeleteFile[outputfile]
     ];
     (* define pr *)
@@ -84,7 +84,7 @@ WriteToFile[outputfile_] :=
       Global`pr[]
     ];
     Global`pr["/* " <> FileNameTake[outputfile] <> " */"];
-    System`Print["Done generating \"", outputfile, "\"\n"];
+    If[Environment["QUIET"] =!= "1", System`Print["Done generating \"", outputfile, "\"\n"]];
     Close[filepointer]
   ];
 

--- a/src/stencils/FiniteDifferenceStencils.wl
+++ b/src/stencils/FiniteDifferenceStencils.wl
@@ -6,11 +6,11 @@
 
 BeginPackage["Generato`FiniteDifferenceStencils`"];
 
-System`Print["------------------------------------------------------------"];
-
-System`Print["Package Generato`FiniteDifferenceStencils`, {2025, 1, 21}"];
-
-System`Print["------------------------------------------------------------"];
+If[Environment["QUIET"] =!= "1",
+  System`Print["------------------------------------------------------------"];
+  System`Print["Package Generato`FiniteDifferenceStencils`, {2025, 1, 21}"];
+  System`Print["------------------------------------------------------------"];
+];
 
 GetFiniteDifferenceCoefficients::usage = "GetFiniteDifferenceCoefficients[sample, order] returns the finite difference coefficients for the given sample points and derivative order.";
 

--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -26,6 +26,7 @@ RunPhase[phaseName_String, phaseCode_] := Module[{},
   ];
   $PhaseSuccess
 ];
+SetAttributes[RunPhase, HoldAll];
 
 QuietPrint[""];
 QuietPrint["========================================"];

--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -6,11 +6,32 @@
 
 $TestDir = DirectoryName[$InputFileName];
 
-Print[""];
-Print["========================================"];
-Print["  Generato Test Suite"];
-Print["========================================"];
-Print[""];
+(* Quiet mode support *)
+$QuietMode = (Environment["QUIET"] === "1");
+QuietPrint[args___] := If[!$QuietMode, Print[args]];
+(* Suppress all Print output during package loading in quiet mode *)
+QuietGet[file_] := If[$QuietMode, Block[{Print}, Get[file]], Get[file]];
+
+(* Phase tracking for quiet mode *)
+$PhaseSuccess = True;
+
+RunPhase[phaseName_String, phaseCode_] := Module[{},
+  $PhaseSuccess = True;
+  Check[phaseCode, $PhaseSuccess = False];
+  If[$QuietMode,
+    If[$PhaseSuccess,
+      Print["\033[0;32mPASS: " <> phaseName <> "\033[0m"],
+      Print["\033[0;31mFAIL: " <> phaseName <> "\033[0m"]
+    ]
+  ];
+  $PhaseSuccess
+];
+
+QuietPrint[""];
+QuietPrint["========================================"];
+QuietPrint["  Generato Test Suite"];
+QuietPrint["========================================"];
+QuietPrint[""];
 
 (* Collect all verification tests *)
 $AllTests = {};
@@ -19,36 +40,39 @@ $AllTests = {};
 (* PHASE 1: Unit Tests *)
 (* ========================================= *)
 
-Print["--- Unit Tests ---"];
-Print[""];
+RunUnitTests[] := Module[{unitTestFiles, report},
+  QuietPrint["--- Unit Tests ---"];
+  QuietPrint[""];
 
-unitTestFiles = FileNames["*.wl", FileNameJoin[{$TestDir, "unit"}]];
+  unitTestFiles = FileNames["*.wl", FileNameJoin[{$TestDir, "unit"}]];
 
-If[Length[unitTestFiles] > 0,
-  Do[
-    Print["Running: ", FileNameTake[file]];
-    Get[file],
-    {file, unitTestFiles}
-  ],
-  Print["No unit test files found in test/unit/"]
-];
+  If[Length[unitTestFiles] > 0,
+    Do[
+      QuietPrint["Running: ", FileNameTake[file]];
+      QuietGet[file],
+      {file, unitTestFiles}
+    ],
+    QuietPrint["No unit test files found in test/unit/"]
+  ];
 
-Print[""];
+  QuietPrint[""];
 
-(* Generate test report if VerificationTests were run *)
-If[Length[$AllTests] > 0,
-  Print["Generating TestReport..."];
-  report = TestReport[$AllTests];
-  Print["Tests Passed: ", report["TestsSucceededCount"], "/", report["TestsSucceededCount"] + report["TestsFailedCount"]];
-  Print[""];
+  (* Generate test report if VerificationTests were run *)
+  If[Length[$AllTests] > 0,
+    QuietPrint["Generating TestReport..."];
+    report = TestReport[$AllTests];
+    QuietPrint["Tests Passed: ", report["TestsSucceededCount"], "/", report["TestsSucceededCount"] + report["TestsFailedCount"]];
+    QuietPrint[""];
+    (* Mark phase as failed if any tests failed *)
+    If[report["TestsFailedCount"] > 0,
+      $PhaseSuccess = False;
+    ];
+  ];
 ];
 
 (* ========================================= *)
 (* PHASE 2: Golden File Regression Tests *)
 (* ========================================= *)
-
-Print["--- Regression Tests (Golden Files) ---"];
-Print[""];
 
 (* Load test cases from config file *)
 $ConfigFile = FileNameJoin[{$TestDir, "test_cases.txt"}];
@@ -60,65 +84,83 @@ $TestCases = Select[
 (* Validate shell input to prevent injection *)
 ValidShellInput[str_String] := StringMatchQ[str, RegularExpression["^[a-zA-Z0-9_./\\-]+$"]];
 
-(* Generate outputs for each test case *)
-Print["Generating test outputs..."];
-Print[""];
+RunRegressionTests[] := Module[{backend, testName, ext, testFile, result, outputFile, quietPrefix},
+  QuietPrint["--- Regression Tests (Golden Files) ---"];
+  QuietPrint[""];
 
-$GenerationFailed = False;
-Do[
-  {backend, testName, ext} = testCase;
-  testFile = FileNameJoin[{$TestDir, backend, testName <> ".wl"}];
+  (* Generate outputs for each test case *)
+  QuietPrint["Generating test outputs..."];
+  QuietPrint[""];
 
-  If[FileExistsQ[testFile],
-    (* Validate inputs before shell execution *)
-    If[!ValidShellInput[backend] || !ValidShellInput[testName],
-      Print["  ERROR: Invalid characters in backend or testName"];
-      $GenerationFailed = True;
-      Continue[];
-    ];
+  (* Pass QUIET to subprocess if in quiet mode *)
+  quietPrefix = If[$QuietMode, "QUIET=1 ", ""];
 
-    Print["  Generating: ", backend, "/", testName, ".wl"];
-    (* Run Generato from the test directory *)
-    result = Run["cd " <> FileNameJoin[{$TestDir, backend}] <> " && \"$GENERATO/Generato\" " <> testName <> ".wl 2>&1"];
-    If[result != 0,
-      Print["    FAILED to generate ", testName, ext];
-      $GenerationFailed = True;
+  $GenerationFailed = False;
+  Do[
+    {backend, testName, ext} = testCase;
+    testFile = FileNameJoin[{$TestDir, backend, testName <> ".wl"}];
+
+    If[FileExistsQ[testFile],
+      (* Validate inputs before shell execution *)
+      If[!ValidShellInput[backend] || !ValidShellInput[testName],
+        QuietPrint["  ERROR: Invalid characters in backend or testName"];
+        $GenerationFailed = True;
+        Continue[];
+      ];
+
+      QuietPrint["  Generating: ", backend, "/", testName, ".wl"];
+      (* Run Generato from the test directory, passing QUIET mode *)
+      result = Run["cd " <> FileNameJoin[{$TestDir, backend}] <> " && " <> quietPrefix <> "\"$GENERATO/Generato\" " <> testName <> ".wl 2>&1"];
+      If[result != 0,
+        QuietPrint["    FAILED to generate ", testName, ext];
+        $GenerationFailed = True;
+      ],
+      QuietPrint["  SKIP: ", testFile, " not found"];
     ],
-    Print["  SKIP: ", testFile, " not found"];
-  ],
-  {testCase, $TestCases}
+    {testCase, $TestCases}
+  ];
+
+  QuietPrint[""];
+
+  If[$GenerationFailed,
+    QuietPrint["ERROR: Some outputs failed to generate"];
+    $PhaseSuccess = False;
+    Return[];
+  ];
+
+  (* Load golden file comparison module *)
+  QuietGet[FileNameJoin[{$TestDir, "regression", "compare_golden.wl"}]];
+
+  (* Run golden file comparisons *)
+  $RegressionResult = GoldenTest`RunGoldenTests[];
+
+  (* Cleanup generated output files *)
+  QuietPrint[""];
+  QuietPrint["Cleaning up generated files..."];
+  Do[
+    {backend, testName, ext} = testCase;
+    outputFile = FileNameJoin[{$TestDir, backend, testName <> ext}];
+    If[FileExistsQ[outputFile],
+      Check[
+        DeleteFile[outputFile],
+        QuietPrint["  Warning: Failed to delete ", outputFile]
+      ];
+    ],
+    {testCase, $TestCases}
+  ];
+
+  (* Mark phase as failed if regression detected *)
+  If[$RegressionResult === $Failed,
+    $PhaseSuccess = False;
+  ];
 ];
 
-Print[""];
-
-If[$GenerationFailed,
-  Print["ERROR: Some outputs failed to generate"];
-  Exit[1]
-];
-
-(* Load golden file comparison module *)
-Get[FileNameJoin[{$TestDir, "regression", "compare_golden.wl"}]];
-
-(* Run golden file comparisons *)
-$RegressionResult = GoldenTest`RunGoldenTests[];
-
-(* Cleanup generated output files *)
-Print[""];
-Print["Cleaning up generated files..."];
-Do[
-  {backend, testName, ext} = testCase;
-  outputFile = FileNameJoin[{$TestDir, backend, testName <> ext}];
-  If[FileExistsQ[outputFile],
-    Check[
-      DeleteFile[outputFile],
-      Print["  Warning: Failed to delete ", outputFile]
-    ];
-  ],
-  {testCase, $TestCases}
-];
+(* Run the test phases *)
+$UnitTestsSuccess = RunPhase["unit", RunUnitTests[]];
+$RegressionTestsSuccess = RunPhase["regression", RunRegressionTests[]];
 
 (* Exit with appropriate status *)
-If[$RegressionResult === $Failed,
+If[!$UnitTestsSuccess || !$RegressionTestsSuccess,
   Exit[1],
   Exit[0]
 ];

--- a/test/regression/compare_golden.wl
+++ b/test/regression/compare_golden.wl
@@ -11,6 +11,12 @@ RunGoldenTests::usage = "RunGoldenTests[] runs all golden file comparisons and r
 
 Begin["`Private`"];
 
+(* Use QuietPrint if available (from AllTests.wl), otherwise use Print *)
+GoldenPrint[args___] := If[ValueQ[Global`$QuietMode] && Global`$QuietMode === True,
+  Null,  (* Suppress output in quiet mode *)
+  Print[args]
+];
+
 $TestDir = DirectoryName[$InputFileName];
 $GoldenDir = FileNameJoin[{$TestDir, "..", "golden"}];
 
@@ -19,12 +25,12 @@ CompareGoldenFile[currentFile_String, goldenFile_String] := Module[
   {current, golden, result},
 
   If[!FileExistsQ[currentFile],
-    Print["FAIL: Current file not found: ", currentFile];
+    GoldenPrint["FAIL: Current file not found: ", currentFile];
     Return[$Failed]
   ];
 
   If[!FileExistsQ[goldenFile],
-    Print["FAIL: Golden file not found: ", goldenFile];
+    GoldenPrint["FAIL: Golden file not found: ", goldenFile];
     Return[$Failed]
   ];
 
@@ -32,11 +38,11 @@ CompareGoldenFile[currentFile_String, goldenFile_String] := Module[
   golden = Import[goldenFile, "Text"];
 
   If[current === golden,
-    Print["PASS: ", FileNameTake[currentFile]];
+    GoldenPrint["PASS: ", FileNameTake[currentFile]];
     True,
-    Print["FAIL: ", FileNameTake[currentFile], " differs from golden"];
-    Print["  Current: ", StringLength[current], " chars"];
-    Print["  Golden:  ", StringLength[golden], " chars"];
+    GoldenPrint["FAIL: ", FileNameTake[currentFile], " differs from golden"];
+    GoldenPrint["  Current: ", StringLength[current], " chars"];
+    GoldenPrint["  Golden:  ", StringLength[golden], " chars"];
     $Failed
   ]
 ];
@@ -52,8 +58,8 @@ $TestCases = Select[
 RunGoldenTests[] := Module[
   {results, passed, failed, backend, testName, ext, currentFile, goldenFile},
 
-  Print["=== Golden File Regression Tests ==="];
-  Print[""];
+  GoldenPrint["=== Golden File Regression Tests ==="];
+  GoldenPrint[""];
 
   results = Table[
     {backend, testName, ext} = testCase;
@@ -66,20 +72,20 @@ RunGoldenTests[] := Module[
   passed = Count[results, True];
   failed = Count[results, $Failed];
 
-  Print[""];
-  Print["=== Summary ==="];
-  Print["Passed: ", passed, "/", Length[results]];
-  Print["Failed: ", failed, "/", Length[results]];
+  GoldenPrint[""];
+  GoldenPrint["=== Summary ==="];
+  GoldenPrint["Passed: ", passed, "/", Length[results]];
+  GoldenPrint["Failed: ", failed, "/", Length[results]];
 
   If[failed > 0,
-    Print[""];
-    Print["REGRESSION DETECTED"];
+    GoldenPrint[""];
+    GoldenPrint["REGRESSION DETECTED"];
     If[Length[$ScriptCommandLine] > 0 && MemberQ[StringContainsQ[#, "compare_golden.wl"] & /@ $ScriptCommandLine, True],
       Exit[1],
       $Failed
     ],
-    Print[""];
-    Print["ALL TESTS PASSED"];
+    GoldenPrint[""];
+    GoldenPrint["ALL TESTS PASSED"];
     If[Length[$ScriptCommandLine] > 0 && MemberQ[StringContainsQ[#, "compare_golden.wl"] & /@ $ScriptCommandLine, True],
       Exit[0],
       True

--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -3,7 +3,7 @@
 (* BasicTests.wl *)
 (* Unit tests for Generato`Basic module *)
 
-Print["Loading BasicTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading BasicTests.wl..."]];
 
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
@@ -174,4 +174,4 @@ SetPVerbose[False];
 SetGridPointIndex[""];
 SetTilePointIndex[""];
 
-Print["BasicTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["BasicTests.wl completed."]];

--- a/test/unit/ComponentTests.wl
+++ b/test/unit/ComponentTests.wl
@@ -3,7 +3,7 @@
 (* ComponentTests.wl *)
 (* Unit tests for Generato`Component module *)
 
-Print["Loading ComponentTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading ComponentTests.wl..."]];
 
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
@@ -146,4 +146,4 @@ SetTempVariableType["double"];
 SetInterfaceWithNonCoordBasis[False];
 SetSuffixName[""];
 
-Print["ComponentTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["ComponentTests.wl completed."]];

--- a/test/unit/DerivationTests.wl
+++ b/test/unit/DerivationTests.wl
@@ -3,7 +3,7 @@
 (* DerivationTests.wl *)
 (* Unit tests for Generato`Derivation module *)
 
-Print["Loading DerivationTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading DerivationTests.wl..."]];
 
 (* Load the Derivation package *)
 Needs["Generato`Derivation`", FileNameJoin[{Environment["GENERATO"], "src/Derivation.wl"}]];
@@ -54,4 +54,4 @@ VerificationTest[
   TestID -> "TestEQN-RecoveryAfterAbort"
 ];
 
-Print["DerivationTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["DerivationTests.wl completed."]];

--- a/test/unit/FiniteDifferenceStencilsTests.wl
+++ b/test/unit/FiniteDifferenceStencilsTests.wl
@@ -3,7 +3,7 @@
 (* FiniteDifferenceStencilsTests.wl *)
 (* Unit tests for Generato`FiniteDifferenceStencils module *)
 
-Print["Loading FiniteDifferenceStencilsTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading FiniteDifferenceStencilsTests.wl..."]];
 
 (* Load the stencils package *)
 Needs["Generato`FiniteDifferenceStencils`", FileNameJoin[{Environment["GENERATO"], "src/stencils/FiniteDifferenceStencils.wl"}]];
@@ -124,4 +124,4 @@ VerificationTest[
   TestID -> "GetUpwindCoefficients-HasSymmetricAndAntisymmetric"
 ];
 
-Print["FiniteDifferenceStencilsTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["FiniteDifferenceStencilsTests.wl completed."]];

--- a/test/unit/InterfaceTests.wl
+++ b/test/unit/InterfaceTests.wl
@@ -4,7 +4,7 @@
 (* Unit tests for Generato`Interface module *)
 (* Tests: GridTensors, TileTensors, TempTensors *)
 
-Print["Loading InterfaceTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading InterfaceTests.wl..."]];
 
 (* Load Generato if not already loaded *)
 If[!MemberQ[$Packages, "Generato`Interface`"],
@@ -123,4 +123,4 @@ VerificationTest[
   TestID -> "SetComponents-UseTilePointIndex"
 ];
 
-Print["InterfaceTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["InterfaceTests.wl completed."]];

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -3,7 +3,7 @@
 (* ParseModeTests.wl *)
 (* Unit tests for Generato`ParseMode module *)
 
-Print["Loading ParseModeTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading ParseModeTests.wl..."]];
 
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
@@ -215,4 +215,4 @@ CleanParsePrintCompEQNMode[];
 CleanParsePrintCompInitTensorType[];
 CleanParsePrintCompInitStorageType[];
 
-Print["ParseModeTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["ParseModeTests.wl completed."]];

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -4,7 +4,7 @@
 (* Unit tests for Generato`Varlist module *)
 (* Tests: ParseVar, DefineTensor *)
 
-Print["Loading VarlistTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading VarlistTests.wl..."]];
 
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
@@ -158,4 +158,4 @@ VerificationTest[
   TestID -> "ParseVarlist-BasicSmoke"
 ];
 
-Print["VarlistTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["VarlistTests.wl completed."]];

--- a/test/unit/WritefileTests.wl
+++ b/test/unit/WritefileTests.wl
@@ -3,7 +3,7 @@
 (* WritefileTests.wl *)
 (* Unit tests for Generato`Writefile module *)
 
-Print["Loading WritefileTests.wl..."];
+If[Environment["QUIET"] =!= "1", Print["Loading WritefileTests.wl..."]];
 
 (* Load Generato which includes Writefile *)
 If[!MemberQ[$Packages, "Generato`Writefile`"],
@@ -100,4 +100,4 @@ VerificationTest[
   TestID -> "WriteToFile-NoHeaderMacro"
 ];
 
-Print["WritefileTests.wl completed."];
+If[Environment["QUIET"] =!= "1", Print["WritefileTests.wl completed."]];


### PR DESCRIPTION
## Summary

- Add `QUIET=1` environment variable support to suppress verbose output during test runs
- When enabled, tests show only `PASS: <phase>` or `FAIL: <phase>` status instead of full package loading banners and progress messages
- Suppresses xAct package loading banners, Generato package banners, file writing messages, and unit test loading messages

## Test plan

- [ ] Run `./test/run_tests.sh` and verify full verbose output appears
- [ ] Run `QUIET=1 ./test/run_tests.sh` and verify only `PASS: integration` and `PASS: golden` appear
- [ ] Run `QUIET=1 wolframscript -f test/AllTests.wl` and verify only `PASS: unit` and `PASS: regression` appear
- [ ] Introduce a test failure and verify full output is dumped before `FAIL: <phase>`