### PR TITLE
fix: always suppress package loading messages during tests

### DIFF
--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -10,7 +10,7 @@ $TestDir = DirectoryName[$InputFileName];
 $QuietMode = (Environment["QUIET"] === "1");
 QuietPrint[args___] := If[!$QuietMode, Print[args]];
 (* Suppress all Print output during package loading in quiet mode *)
-QuietGet[file_] := If[$QuietMode, Block[{Print}, Get[file]], Get[file]];
+QuietGet[file_] := Block[{Print}, Get[file]];
 
 (* Phase tracking for quiet mode *)
 $PhaseSuccess = True;
@@ -118,8 +118,8 @@ RunRegressionTests[] := Module[{backend, testName, ext, testFile, result, output
   QuietPrint["Generating test outputs..."];
   QuietPrint[""];
 
-  (* Pass QUIET to subprocess if in quiet mode *)
-  quietPrefix = If[$QuietMode, "QUIET=1 ", ""];
+  (* Always suppress package loading messages in subprocess *)
+  quietPrefix = "QUIET=1 ";
 
   $GenerationFailed = False;
   Do[

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -84,7 +84,7 @@ run_test() {
 
   cd "$SCRIPT_DIR/$backend"
 
-  if "$GENERATO_DIR/Generato" "${test_name}.wl" 2>&1; then
+  if QUIET=1 "$GENERATO_DIR/Generato" "${test_name}.wl" 2>&1; then
     echo -e "${GREEN}  OK${NC}"
     return 0
   else


### PR DESCRIPTION
## Summary
- Always suppress package loading banners during test execution regardless of QUIET mode
- Keeps other test output (progress, results, errors) visible when QUIET=0
- Cleaner test output without xAct and Generato module loading messages

## Test plan
- [x] Run `./test/run_tests.sh` - all tests pass, no package banners shown
- [x] Run `wolframscript -f test/AllTests.wl` - all tests pass, no package banners shown