### PR TITLE
feat: add --verbose flag to test runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Each backend implements `PrintComponentInitialization` and `PrintComponentEquati
 
 ```bash
 # Run all tests (recommended - runs unit tests + regression tests)
-wolframscript -f test/AllTests.wl
+wolframscript -script test/AllTests.wl
 
 # Alternative: Run via bash script
 ./test/run_tests.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,14 @@ Each backend implements `PrintComponentInitialization` and `PrintComponentEquati
 
 ```bash
 # Run all tests (recommended - runs unit tests + regression tests)
-wolframscript -f test/AllTests.wl
+wolframscript -script test/AllTests.wl
+
+# Run with verbose output
+wolframscript -script test/AllTests.wl --verbose
 
 # Alternative: Run via bash script
 ./test/run_tests.sh
+./test/run_tests.sh --verbose
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Generato GHG_rhs.wl
 
 ```bash
 # Run all tests (recommended - runs unit tests + regression tests)
-wolframscript -f test/AllTests.wl
+wolframscript -script test/AllTests.wl
 
 # Alternative: Run via bash script
 ./test/run_tests.sh

--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -2,12 +2,12 @@
 
 (* AllTests.wl *)
 (* Master test runner for Generato *)
-(* Usage: wolframscript -f test/AllTests.wl *)
+(* Usage: wolframscript -f test/AllTests.wl [--verbose] *)
 
 $TestDir = DirectoryName[$InputFileName];
 
-(* Quiet mode support *)
-$QuietMode = (Environment["QUIET"] === "1");
+(* Quiet mode support - use --verbose flag to enable verbose output *)
+$QuietMode = !MemberQ[$CommandLine, "--verbose"];
 QuietPrint[args___] := If[!$QuietMode, Print[args]];
 (* Suppress all Print output during package loading in quiet mode *)
 QuietGet[file_] := Block[{Print}, Get[file]];

--- a/test/CarpetX/test.hxx
+++ b/test/CarpetX/test.hxx
@@ -1,0 +1,73 @@
+/* test.hxx */
+/* Produced with Generato */
+
+#ifndef TEST_HXX
+#define TEST_HXX
+
+
+const GF3D2<CCTK_REAL> &local_rU1 = gf_rU(0);
+const GF3D2<CCTK_REAL> &local_rU2 = gf_rU(1);
+const GF3D2<CCTK_REAL> &local_rU3 = gf_rU(2);
+const vreal uU1 = tmp_uU(0);
+const vreal uU2 = tmp_uU(1);
+const vreal uU3 = tmp_uU(2);
+const vreal MDD11 = tmp_MDD(0,0);
+const vreal MDD12 = tmp_MDD(0,1);
+const vreal MDD13 = tmp_MDD(0,2);
+const vreal MDD22 = tmp_MDD(1,1);
+const vreal MDD23 = tmp_MDD(1,2);
+const vreal MDD33 = tmp_MDD(2,2);
+
+vreal
+vU1
+=
+MDD11*uU1 + MDD12*uU2 + MDD13*uU3
+;
+
+vreal
+vU2
+=
+MDD12*uU1 + MDD22*uU2 + MDD23*uU3
+;
+
+vreal
+vU3
+=
+MDD13*uU1 + MDD23*uU2 + MDD33*uU3
+;
+
+
+if(Msqr)
+{
+local_rU1.store(mask, index2,
+MDD11*vU1 + MDD12*vU2 + MDD13*vU3
+);
+
+local_rU2.store(mask, index2,
+MDD12*vU1 + MDD22*vU2 + MDD23*vU3
+);
+
+local_rU3.store(mask, index2,
+MDD13*vU1 + MDD23*vU2 + MDD33*vU3
+);
+
+}
+else
+{
+local_rU1.store(mask, index2,
+vU1
+);
+
+local_rU2.store(mask, index2,
+vU2
+);
+
+local_rU3.store(mask, index2,
+vU3
+);
+
+}
+
+#endif // #ifndef TEST_HXX
+
+/* test.hxx */

--- a/test/CarpetXGPU/testGPU.hxx
+++ b/test/CarpetXGPU/testGPU.hxx
@@ -1,0 +1,79 @@
+/* testGPU.hxx */
+/* Produced with Generato */
+
+#ifndef TESTGPU_HXX
+#define TESTGPU_HXX
+
+
+const auto rU1 = gf_rU[0];
+const auto rU2 = gf_rU[1];
+const auto rU3 = gf_rU[2];
+const auto uU1 = gf_uU[0];
+const auto uU2 = gf_uU[1];
+const auto uU3 = gf_uU[2];
+const auto MDD11 = gf_MDD[0];
+const auto MDD12 = gf_MDD[1];
+const auto MDD13 = gf_MDD[2];
+const auto MDD22 = gf_MDD[3];
+const auto MDD23 = gf_MDD[4];
+const auto MDD33 = gf_MDD[5];
+
+const vreal
+vU1
+=
+MDD11*uU1 + MDD12*uU2 + MDD13*uU3
+;
+
+const vreal
+vU2
+=
+MDD12*uU1 + MDD22*uU2 + MDD23*uU3
+;
+
+const vreal
+vU3
+=
+MDD13*uU1 + MDD23*uU2 + MDD33*uU3
+;
+
+
+if(Msqr)
+{
+rU1
+=
+MDD11*vU1 + MDD12*vU2 + MDD13*vU3
+;
+
+rU2
+=
+MDD12*vU1 + MDD22*vU2 + MDD23*vU3
+;
+
+rU3
+=
+MDD13*vU1 + MDD23*vU2 + MDD33*vU3
+;
+
+}
+else
+{
+rU1
+=
+vU1
+;
+
+rU2
+=
+vU2
+;
+
+rU3
+=
+vU3
+;
+
+}
+
+#endif // #ifndef TESTGPU_HXX
+
+/* testGPU.hxx */

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,8 +3,8 @@
 # run_tests.sh - Run all Generato tests
 #
 # Usage: ./test/run_tests.sh [options]
+#   --verbose     Show detailed output (default: quiet mode)
 #   --generate    Regenerate all test outputs
-#   --compare     Compare outputs against golden files only
 #   --help        Show this help message
 
 set -e
@@ -53,15 +53,21 @@ run_phase() {
 
 # Parse arguments
 GENERATE=false
+QUIET="${QUIET:-1}"  # Default to quiet mode
 
 for arg in "$@"; do
   case $arg in
+    --verbose)
+      QUIET=0
+      shift
+      ;;
     --generate)
       GENERATE=true
       shift
       ;;
     --help)
       echo "Usage: $0 [options]"
+      echo "  --verbose     Show detailed output (default: quiet mode)"
       echo "  --generate    Update golden files with new outputs"
       echo "  --help        Show this help message"
       exit 0


### PR DESCRIPTION
## Summary
- Replace `QUIET=0` environment variable with `--verbose` command-line flag for controlling test verbosity
- Tests now default to quiet mode and show detailed output only when `--verbose` is specified
- Update documentation to use `wolframscript -script` instead of `-f`

## Test plan
- [x] Run `./test/run_tests.sh` (quiet mode by default)
- [x] Run `./test/run_tests.sh --verbose` (detailed output)
- [x] Verify `--help` shows new `--verbose` option