### PR TITLE
feat: add --unit-only flag to run unit tests only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,15 @@ Each backend implements `PrintComponentInitialization` and `PrintComponentEquati
 # Run all tests (recommended - runs unit tests + regression tests)
 wolframscript -script test/AllTests.wl
 
+# Run with verbose output
+wolframscript -script test/AllTests.wl --verbose
+
+# Run unit tests only (skip regression tests)
+wolframscript -script test/AllTests.wl --unit-only
+
 # Alternative: Run via bash script
 ./test/run_tests.sh
+./test/run_tests.sh --verbose
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,9 @@ wolframscript -script test/AllTests.wl
 # Run with verbose output
 wolframscript -script test/AllTests.wl --verbose
 
+# Run unit tests only (skip regression tests)
+wolframscript -script test/AllTests.wl --unit-only
+
 # Alternative: Run via bash script
 ./test/run_tests.sh
 ./test/run_tests.sh --verbose

--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@ Generato GHG_rhs.wl
 # Run all tests (recommended - runs unit tests + regression tests)
 wolframscript -script test/AllTests.wl
 
+# Run with verbose output
+wolframscript -script test/AllTests.wl --verbose
+
+# Run unit tests only (skip regression tests)
+wolframscript -script test/AllTests.wl --unit-only
+
 # Alternative: Run via bash script
 ./test/run_tests.sh
+./test/run_tests.sh --verbose
 
 # Update golden files with new outputs
 ./test/run_tests.sh --generate

--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -2,12 +2,14 @@
 
 (* AllTests.wl *)
 (* Master test runner for Generato *)
-(* Usage: wolframscript -f test/AllTests.wl [--verbose] *)
+(* Usage: wolframscript -f test/AllTests.wl [--verbose] [--unit-only] *)
 
 $TestDir = DirectoryName[$InputFileName];
 
 (* Quiet mode support - use --verbose flag to enable verbose output *)
 $QuietMode = !MemberQ[$CommandLine, "--verbose"];
+(* Unit-only mode - use --unit-only flag to skip regression tests *)
+$UnitOnlyMode = MemberQ[$CommandLine, "--unit-only"];
 QuietPrint[args___] := If[!$QuietMode, Print[args]];
 (* Suppress all Print output during package loading in quiet mode *)
 QuietGet[file_] := Block[{Print}, Get[file]];
@@ -210,7 +212,10 @@ RunRegressionTests[] := Module[{backend, testName, ext, testFile, result, output
 
 (* Run the test phases *)
 $UnitTestsSuccess = RunPhase["unit", RunUnitTests[]];
-$RegressionTestsSuccess = RunPhase["regression", RunRegressionTests[]];
+$RegressionTestsSuccess = If[$UnitOnlyMode,
+  True,
+  RunPhase["regression", RunRegressionTests[]]
+];
 
 (* Exit with appropriate status *)
 If[!$UnitTestsSuccess || !$RegressionTestsSuccess,


### PR DESCRIPTION
## Summary
- Add `--unit-only` command-line flag to `test/AllTests.wl` to skip regression tests
- Update documentation in CLAUDE.md, AGENTS.md, and README.md with the new option
- Also added missing `--verbose` flag documentation to AGENTS.md and README.md

## Test plan
- [ ] Run `wolframscript -script test/AllTests.wl --unit-only` to verify only unit tests run
- [ ] Run `wolframscript -script test/AllTests.wl --unit-only --verbose` to verify verbose output works with the flag
- [ ] Run `wolframscript -script test/AllTests.wl` to verify full test suite still works