### PR TITLE
refactor: extract test config parsing into shared TestConfig module

### DIFF
--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -16,6 +16,9 @@ QuietPrint[args___] := If[!$QuietMode, Print[args]];
 (* Suppress all Print output during package loading in quiet mode *)
 QuietGet[file_] := Block[{Print}, Get[file]];
 
+(* Load shared test configuration *)
+Get[FileNameJoin[{$TestDir, "TestConfig.wl"}]];
+
 (* Phase tracking for quiet mode *)
 $PhaseSuccess = True;
 
@@ -104,12 +107,8 @@ RunUnitTests[] := Module[{unitTestFiles, report},
 (* PHASE 2: Golden File Regression Tests *)
 (* ========================================= *)
 
-(* Load test cases from config file *)
-$ConfigFile = FileNameJoin[{$TestDir, "test_cases.txt"}];
-$TestCases = Select[
-  StringSplit[#, ":"] & /@ Import[$ConfigFile, "Lines"],
-  Length[#] == 3 && !StringStartsQ[#[[1]], "#"] &
-];
+(* Load test cases from shared config *)
+$TestCases = TestConfig`LoadTestCases[];
 
 (* Validate shell input to prevent injection *)
 ValidShellInput[str_String] := StringMatchQ[str, RegularExpression["^[a-zA-Z0-9_./\\-]+$"]];

--- a/test/TestConfig.wl
+++ b/test/TestConfig.wl
@@ -1,0 +1,26 @@
+(* ::Package:: *)
+
+(* TestConfig.wl *)
+(* Shared test configuration for Generato test suite *)
+
+BeginPackage["TestConfig`"];
+
+GetTestDir::usage = "GetTestDir[] returns the base test directory path.";
+LoadTestCases::usage = "LoadTestCases[] returns the list of test cases from test_cases.txt.";
+
+Begin["`Private`"];
+
+$TestDir = DirectoryName[$InputFileName];
+
+GetTestDir[] := $TestDir;
+
+LoadTestCases[] := Module[{configFile},
+  configFile = FileNameJoin[{$TestDir, "test_cases.txt"}];
+  Select[
+    StringSplit[#, ":"] & /@ Import[configFile, "Lines"],
+    Length[#] == 3 && !StringStartsQ[#[[1]], "#"] &
+  ]
+];
+
+End[];
+EndPackage[];


### PR DESCRIPTION
## Summary
- Extract duplicated test case configuration parsing into a new shared module (`test/TestConfig.wl`)
- Update `AllTests.wl` and `compare_golden.wl` to use the shared module
- Remove unused `ValidateExtension` function and standalone execution logic from `compare_golden.wl`

## Test plan
- [x] All tests pass: `wolframscript -script test/AllTests.wl`
- [x] Verbose mode works: `wolframscript -script test/AllTests.wl --verbose`
- [x] Unit-only mode works: `wolframscript -script test/AllTests.wl --unit-only`
- [x] Generate mode works: `wolframscript -script test/AllTests.wl --generate`