### PR TITLE
fix: improve test module robustness and assertion quality

### DIFF
--- a/test/AllTests.wl
+++ b/test/AllTests.wl
@@ -110,6 +110,12 @@ RunUnitTests[] := Module[{unitTestFiles, report},
 (* Load test cases from shared config *)
 $TestCases = TestConfig`LoadTestCases[];
 
+(* Abort if test configuration failed to load *)
+If[$TestCases === $Failed,
+  Print["FATAL: Failed to load test configuration"];
+  Exit[1]
+];
+
 (* Validate shell input to prevent injection *)
 ValidShellInput[str_String] := StringMatchQ[str, RegularExpression["^[a-zA-Z0-9_./\\-]+$"]];
 

--- a/test/TestConfig.wl
+++ b/test/TestConfig.wl
@@ -14,12 +14,28 @@ $TestDir = DirectoryName[$InputFileName];
 
 GetTestDir[] := $TestDir;
 
-LoadTestCases[] := Module[{configFile},
+LoadTestCases[] := Module[{configFile, lines, parsed, valid, skipped},
   configFile = FileNameJoin[{$TestDir, "test_cases.txt"}];
-  Select[
-    StringSplit[#, ":"] & /@ Import[configFile, "Lines"],
-    Length[#] == 3 && !StringStartsQ[#[[1]], "#"] &
-  ]
+
+  (* Check if config file exists *)
+  If[!FileExistsQ[configFile],
+    Print["ERROR: test_cases.txt not found at ", configFile];
+    Return[{}]
+  ];
+
+  lines = Import[configFile, "Lines"];
+  parsed = StringSplit[#, ":"] & /@ lines;
+
+  (* Filter valid entries (3 parts, not comments) *)
+  valid = Select[parsed, Length[#] == 3 && !StringStartsQ[#[[1]], "#"] &];
+
+  (* Warn about malformed lines (non-comments with wrong format) *)
+  skipped = Select[parsed, Length[#] != 3 && Length[#] > 0 && !StringStartsQ[#[[1]], "#"] &];
+  If[Length[skipped] > 0,
+    Print["WARNING: Skipped ", Length[skipped], " malformed line(s) in test_cases.txt"]
+  ];
+
+  valid
 ];
 
 End[];

--- a/test/TestConfig.wl
+++ b/test/TestConfig.wl
@@ -20,7 +20,8 @@ LoadTestCases[] := Module[{configFile, lines, parsed, valid, skipped},
   (* Check if config file exists *)
   If[!FileExistsQ[configFile],
     Print["ERROR: test_cases.txt not found at ", configFile];
-    Return[{}]
+    Print["ERROR: Test suite cannot proceed without test configuration"];
+    Return[$Failed]
   ];
 
   lines = Import[configFile, "Lines"];

--- a/test/regression/compare_golden.wl
+++ b/test/regression/compare_golden.wl
@@ -46,6 +46,10 @@ CompareGoldenFile[currentFile_String, goldenFile_String] := Module[
     GoldenPrint["FAIL: ", FileNameTake[currentFile], " differs from golden"];
     GoldenPrint["  Current: ", StringLength[current], " chars"];
     GoldenPrint["  Golden:  ", StringLength[golden], " chars"];
+    (* Always print failure details even in quiet mode *)
+    If[ValueQ[Global`$QuietMode] && Global`$QuietMode === True,
+      Print["  FAIL: ", FileNameTake[currentFile], " (", StringLength[current], " vs ", StringLength[golden], " chars)"]
+    ];
     $Failed
   ]
 ];
@@ -76,16 +80,10 @@ RunGoldenTests[] := Module[
   If[failed > 0,
     GoldenPrint[""];
     GoldenPrint["REGRESSION DETECTED"];
-    If[Length[$ScriptCommandLine] > 0 && MemberQ[StringContainsQ[#, "compare_golden.wl"] & /@ $ScriptCommandLine, True],
-      Exit[1],
-      $Failed
-    ],
+    $Failed,
     GoldenPrint[""];
     GoldenPrint["ALL TESTS PASSED"];
-    If[Length[$ScriptCommandLine] > 0 && MemberQ[StringContainsQ[#, "compare_golden.wl"] & /@ $ScriptCommandLine, True],
-      Exit[0],
-      True
-    ]
+    True
   ]
 ];
 

--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -97,9 +97,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    (* RHSOf should retrieve the set equation *)
+    (* RHSOf should return a symbol referencing the tensor's RHS *)
     rhs = RHSOf[testVec];
-    Head[rhs] =!= Null,
+    Head[rhs] === Symbol && StringContainsQ[ToString[rhs], "RHS"],
     True,
     TestID -> "RHSOf-ReturnsValue"
   ]
@@ -194,16 +194,24 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    (* GetDim should return an integer *)
-    IntegerQ[GetDim[]],
+    (* GetDim should return a valid dimension (1-10) *)
+    Module[{dim = GetDim[]},
+      IntegerQ[dim] && dim >= 1 && dim <= 10
+    ],
     True,
-    TestID -> "GetDim-ReturnsInteger"
+    TestID -> "GetDim-ReturnsValidDimension"
   ]
 ];
 
-(* Reset to clean state *)
+(* Reset to clean state - all modified variables *)
 SetPVerbose[False];
+SetPrintDate[False];
 SetGridPointIndex[""];
 SetTilePointIndex[""];
+SetOutputFile[""];
+SetProject[""];
+SetCheckInputEquations[True];
+SetPrintHeaderMacro[True];
+SetSuffixUnprotected[""];
 
 If[Environment["QUIET"] =!= "1", Print["BasicTests.wl completed."]];

--- a/test/unit/InterfaceTests.wl
+++ b/test/unit/InterfaceTests.wl
@@ -31,9 +31,9 @@ If[!MemberQ[$Manifolds, TestM3],
 
 AppendTo[$AllTests,
   VerificationTest[
-    (* GridTensors should return a list *)
+    (* GridTensors should return a non-empty list *)
     varlist = GridTensors[{intTestVec[i], PrintAs -> "itv"}];
-    ListQ[varlist],
+    ListQ[varlist] && Length[varlist] >= 1,
     True,
     TestID -> "GridTensors-ReturnsList"
   ]
@@ -69,9 +69,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    (* TempTensors should return a list *)
+    (* TempTensors should return a non-empty list *)
     tempList = TempTensors[{intTestTemp[i], PrintAs -> "itt"}];
-    ListQ[tempList],
+    ListQ[tempList] && Length[tempList] >= 1,
     True,
     TestID -> "TempTensors-ReturnsList"
   ]
@@ -83,9 +83,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    (* DefTensors should define tensors without setting components *)
+    (* DefTensors should define tensors and return non-empty list *)
     defList = DefTensors[{intDefTest[i], PrintAs -> "idt"}];
-    ListQ[defList],
+    ListQ[defList] && Length[defList] >= 1,
     True,
     TestID -> "DefTensors-ReturnsList"
   ]
@@ -107,9 +107,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    (* TileTensors should return a list *)
+    (* TileTensors should return a non-empty list *)
     tileList = TileTensors[{intTileTest[i], PrintAs -> "itile"}];
-    ListQ[tileList],
+    ListQ[tileList] && Length[tileList] >= 1,
     True,
     TestID -> "TileTensors-ReturnsList"
   ]
@@ -140,5 +140,9 @@ AppendTo[$AllTests,
     TestID -> "SetComponents-UseTilePointIndex"
   ]
 ];
+
+(* Reset state *)
+SetPVerbose[False];
+SetPrintDate[False];
 
 If[Environment["QUIET"] =!= "1", Print["InterfaceTests.wl completed."]];


### PR DESCRIPTION
## Summary
- Add error handling to `LoadTestCases` in TestConfig.wl: file existence check and warnings for malformed lines
- Show failure details even in quiet mode for golden file regression tests
- Simplify exit code logic in compare_golden.wl by removing fragile `$ScriptCommandLine` pattern matching
- Complete state cleanup in BasicTests.wl for all modified global variables
- Strengthen weak type-only assertions with value validation (GetDim range check, RHSOf symbol verification)
- Add state cleanup to InterfaceTests.wl

## Test plan
- [x] Run full test suite with `wolframscript -script test/AllTests.wl`
- [x] Verify all unit tests pass
- [x] Verify all regression tests pass