### PR TITLE
refactor: rename CarpetXGPU/testGPU.wl to test.wl for consistency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           cd test/CarpetX
           $GENERATO/Generato test.wl
-          $GENERATO/Generato testGPU.wl
 
       - name: Run Integration Tests (CarpetXPointDesc)
         if: ${{ false }}  # Disabled until Wolfram Engine is configured

--- a/test/regression/CarpetXGPU/test.wl
+++ b/test/regression/CarpetXGPU/test.wl
@@ -1,6 +1,6 @@
 (* ::Package:: *)
 
-(* testGPU.wl *)
+(* test.wl *)
 
 (* (c) Liwei Ji, 01/2024 *)
 
@@ -45,7 +45,7 @@ SetEQN[{SuffixName -> "Msqr"}, rU[i_], euclid[i, k] MDD[-k, -j] vU[j]];
 
 SetEQN[{SuffixName -> "otherwise"}, rU[i_], vU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "testGPU.hxx"}]];
+SetOutputFile[FileNameJoin[{Directory[], "test.hxx"}]];
 
 (* SetProject["CarpetX"]; *)
 

--- a/test/regression/golden/CarpetXGPU/test.hxx.golden
+++ b/test/regression/golden/CarpetXGPU/test.hxx.golden
@@ -1,8 +1,8 @@
-/* testGPU.hxx */
+/* test.hxx */
 /* Produced with Generato */
 
-#ifndef TESTGPU_HXX
-#define TESTGPU_HXX
+#ifndef TEST_HXX
+#define TEST_HXX
 
 
 const auto rU1 = gf_rU[0];
@@ -74,6 +74,6 @@ vU3
 
 }
 
-#endif // #ifndef TESTGPU_HXX
+#endif // #ifndef TEST_HXX
 
-/* testGPU.hxx */
+/* test.hxx */

--- a/test/test_cases.txt
+++ b/test/test_cases.txt
@@ -2,7 +2,7 @@
 # Format: backend:test_name:extension
 # Lines starting with # are comments
 CarpetX:test:.hxx
-CarpetXGPU:testGPU:.hxx
+CarpetXGPU:test:.hxx
 CarpetXGPU:testTile:.hxx
 CarpetXGPU:testDerivs:.hxx
 CarpetXPointDesc:test:.hxx


### PR DESCRIPTION
## Summary
- Rename `CarpetXGPU/testGPU.wl` to `test.wl` to follow the naming convention used by other backend tests
- Update internal file references and regenerate the golden file
- Remove obsolete reference from CI workflow

## Test plan
- [x] Run `wolframscript -script test/AllTests.wl` - all tests pass