### PR TITLE
feat: allow Format.wl to format a single file

### DIFF
--- a/tool/Format.wl
+++ b/tool/Format.wl
@@ -1,15 +1,35 @@
 Needs["CodeFormatter`"]
 
-Module[{dirs = {"src", "test/Nmesh", "test/CarpetX"}},
-  Do[
-    System`Print["Formatting '.wl' files in "<>dir<>" ..."];
-    files = FileNames["*.wl", dir];
-    Do[
-      file = File[fname];
-      formattedContent = CodeFormat[file, "IndentationString" -> "  ", LineWidth -> 4096];
-      Export[file, formattedContent, "String"],
-    {fname, files}],
-  {dir, dirs}]
+(* Format a single file with standard settings *)
+FormatFile[fname_String] := Module[{file, formattedContent},
+  file = File[fname];
+  formattedContent = CodeFormat[file, "IndentationString" -> "  ", LineWidth -> 4096];
+  Export[file, formattedContent, "String"]
 ];
 
-System`Print["Done"];
+(* Check if a file argument was provided *)
+If[Length[$ScriptCommandLine] >= 1,
+  (* Single file mode *)
+  Module[{fname = First[$ScriptCommandLine]},
+    If[!FileExistsQ[fname],
+      System`Print["Error: File '" <> fname <> "' does not exist."];
+      Exit[1]
+    ];
+    If[!StringMatchQ[fname, "*.wl"],
+      System`Print["Error: File '" <> fname <> "' is not a .wl file."];
+      Exit[1]
+    ];
+    System`Print["Formatting '" <> fname <> "' ..."];
+    FormatFile[fname];
+    System`Print["Done"];
+  ],
+  (* Batch mode: format all .wl files in predefined directories *)
+  Module[{dirs = {"src", "test/Nmesh", "test/CarpetX"}, files},
+    Do[
+      System`Print["Formatting '.wl' files in " <> dir <> " ..."];
+      files = FileNames["*.wl", dir];
+      Do[FormatFile[fname], {fname, files}],
+    {dir, dirs}];
+    System`Print["Done"];
+  ]
+];


### PR DESCRIPTION
Add support for passing a filename as a command-line argument to Format.wl. When a file argument is provided, only that file is formatted. Without arguments, the original batch mode behavior (formatting all .wl files in src/, test/Nmesh/, test/CarpetX/) is preserved.

Usage: wolframscript -script tool/Format.wl [file.wl]

Closes #3