### PR TITLE
feat: add GetDefaultManifold helper and protect manifold utilities

### DIFF
--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -52,6 +52,8 @@ GetProject::usage = "GetProject[] returns the project name used in code generati
 
 SetProject::usage = "SetProject[name] sets the project name used in code generation.";
 
+GetDefaultManifold::usage = "GetDefaultManifold[] returns the first defined manifold.";
+
 GetDefaultChart::usage = "GetDefaultChart[] returns the default coordinate chart of the first defined manifold.";
 
 GetDim::usage = "GetDim[] returns the dimension of the first defined manifold.";
@@ -205,11 +207,20 @@ SetProject[name_] :=
 
 Protect[SetProject];
 
+GetDefaultManifold[] :=
+  Return[$Manifolds[[1]]];
+
+Protect[GetDefaultManifold];
+
 GetDefaultChart[] :=
-  Return[ChartsOfManifold[$Manifolds[[1]]][[1]]];
+  Return[ChartsOfManifold[GetDefaultManifold[]][[1]]];
+
+Protect[GetDefaultChart];
 
 GetDim[] :=
-  Return[DimOfManifold[$Manifolds[[1]]]];
+  Return[DimOfManifold[GetDefaultManifold[]]];
+
+Protect[GetDim];
 
 IsDefined[term_] :=
   Module[{head = Head[term]},

--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -52,7 +52,7 @@ GetProject::usage = "GetProject[] returns the project name used in code generati
 
 SetProject::usage = "SetProject[name] sets the project name used in code generation.";
 
-GetDefaultManifold::usage = "GetDefaultManifold[] returns the first defined manifold.";
+GetDefaultManifold::usage = "GetDefaultManifold[] returns the first defined manifold. Returns $Failed if no manifolds have been defined.";
 
 GetDefaultChart::usage = "GetDefaultChart[] returns the default coordinate chart of the first defined manifold.";
 
@@ -208,7 +208,16 @@ SetProject[name_] :=
 Protect[SetProject];
 
 GetDefaultManifold[] :=
-  Return[$Manifolds[[1]]];
+  Module[{},
+    If[Length[$Manifolds] === 0,
+      Message[GetDefaultManifold::NoManifolds];
+      Return[$Failed]
+      ,
+      Return[$Manifolds[[1]]]
+    ]
+  ];
+
+GetDefaultManifold::NoManifolds = "No manifolds have been defined. Use DefManifold to define a manifold.";
 
 Protect[GetDefaultManifold];
 

--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -222,12 +222,22 @@ GetDefaultManifold::NoManifolds = "No manifolds have been defined. Use DefManifo
 Protect[GetDefaultManifold];
 
 GetDefaultChart[] :=
-  Return[ChartsOfManifold[GetDefaultManifold[]][[1]]];
+  Module[{manifold = GetDefaultManifold[]},
+    If[manifold === $Failed,
+      Return[$Failed],
+      Return[ChartsOfManifold[manifold][[1]]]
+    ]
+  ];
 
 Protect[GetDefaultChart];
 
 GetDim[] :=
-  Return[DimOfManifold[GetDefaultManifold[]]];
+  Module[{manifold = GetDefaultManifold[]},
+    If[manifold === $Failed,
+      Return[$Failed],
+      Return[DimOfManifold[manifold]]
+    ]
+  ];
 
 Protect[GetDim];
 

--- a/src/Varlist.wl
+++ b/src/Varlist.wl
@@ -210,7 +210,7 @@ ParseVarlist::ESymmetryType = "Symmetry type of the `1`-th var, `2`, in varlist 
 Protect[ParseVarlist];
 
 DefineTensor[varname_, symmetry_, printname_] :=
-  Module[{manifold = $Manifolds[[1]]},
+  Module[{manifold = GetDefaultManifold[]},
     If[symmetry =!= Null && StringLength[printname] > 0,
       DefTensor[varname, manifold, symmetry, PrintAs -> printname]
       ,

--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -176,6 +176,44 @@ AppendTo[$AllTests,
 ];
 
 (* ========================================= *)
+(* Test: GetDefaultManifold *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* GetDefaultManifold should return a symbol when manifolds exist *)
+    Module[{result = GetDefaultManifold[]},
+      Head[result] === Symbol && MemberQ[$Manifolds, result]
+    ],
+    True,
+    TestID -> "GetDefaultManifold-ReturnsFirstManifold"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* GetDefaultManifold should return the first manifold in $Manifolds *)
+    GetDefaultManifold[] === $Manifolds[[1]],
+    True,
+    TestID -> "GetDefaultManifold-ReturnsFirstInList"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* GetDefaultManifold should return $Failed when no manifolds exist *)
+    Module[{savedManifolds = $Manifolds, result},
+      Block[{$Manifolds = {}},
+        result = Quiet[GetDefaultManifold[]];
+        result === $Failed
+      ]
+    ],
+    True,
+    TestID -> "GetDefaultManifold-EmptyManifolds-ReturnsFailed"
+  ]
+];
+
+(* ========================================= *)
 (* Test: GetDefaultChart *)
 (* ========================================= *)
 

--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -226,6 +226,20 @@ AppendTo[$AllTests,
   ]
 ];
 
+AppendTo[$AllTests,
+  VerificationTest[
+    (* GetDefaultChart should return $Failed when no manifolds exist *)
+    Module[{savedManifolds = $Manifolds, result},
+      Block[{$Manifolds = {}},
+        result = Quiet[GetDefaultChart[]];
+        result === $Failed
+      ]
+    ],
+    True,
+    TestID -> "GetDefaultChart-EmptyManifolds-ReturnsFailed"
+  ]
+];
+
 (* ========================================= *)
 (* Test: GetDim *)
 (* ========================================= *)
@@ -238,6 +252,20 @@ AppendTo[$AllTests,
     ],
     True,
     TestID -> "GetDim-ReturnsValidDimension"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* GetDim should return $Failed when no manifolds exist *)
+    Module[{savedManifolds = $Manifolds, result},
+      Block[{$Manifolds = {}},
+        result = Quiet[GetDim[]];
+        result === $Failed
+      ]
+    ],
+    True,
+    TestID -> "GetDim-EmptyManifolds-ReturnsFailed"
   ]
 ];
 


### PR DESCRIPTION
## Summary
- Add `GetDefaultManifold[]` function to centralize access to the first defined manifold
- Refactor `GetDefaultChart[]` and `GetDim[]` to use the new helper for consistency
- Add `Protect` calls to `GetDefaultManifold`, `GetDefaultChart`, and `GetDim` to prevent accidental redefinition

## Test plan
- [ ] Run `wolframscript -script test/AllTests.wl` to verify no regressions
- [ ] Verify `GetDefaultManifold[]` returns the first manifold correctly
- [ ] Verify `GetDefaultChart[]` and `GetDim[]` continue to work as expected