### PR TITLE
fix: correct typo in Interface.wl comment

### DIFF
--- a/src/Interface.wl
+++ b/src/Interface.wl
@@ -148,7 +148,7 @@ TempTensors[vars__] :=
 Protect[TempTensors];
 
 (*
-    Baisc functions
+    Basic functions
 *)
 
 Options[SetComponents] :=


### PR DESCRIPTION
Changed "Baisc functions" to "Basic functions" in comment at line 151.