### PR TITLE
Protect parse mode cleanup helpers

### DIFF
--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -136,6 +136,8 @@ CleanParseMode[] :=
     $ParseModeAssociation = <||>
   ];
 
+Protect[CleanParseMode];
+
 GetParseSetCompMode[key_] :=
   Return[
     If[KeyExistsQ[$ParseSetCompModeAssociation, key],
@@ -165,6 +167,8 @@ CleanParseSetCompMode[] :=
   Module[{},
     $ParseSetCompModeAssociation = <||>
   ];
+
+Protect[CleanParseSetCompMode];
 
 GetParsePrintCompMode[key_] :=
   Return[
@@ -196,6 +200,8 @@ CleanParsePrintCompMode[] :=
     $ParsePrintCompModeAssociation = <||>
   ];
 
+Protect[CleanParsePrintCompMode];
+
 GetParsePrintCompInitMode[key_] :=
   Return[
     If[KeyExistsQ[$ParsePrintCompInitModeAssociation, key],
@@ -218,6 +224,8 @@ CleanParsePrintCompInitMode[] :=
   Module[{},
     $ParsePrintCompInitModeAssociation = <||>
   ];
+
+Protect[CleanParsePrintCompInitMode];
 
 GetParsePrintCompEQNMode[key_] :=
   Return[
@@ -242,6 +250,8 @@ CleanParsePrintCompEQNMode[] :=
     $ParsePrintCompEQNModeAssociation = <||>
   ];
 
+Protect[CleanParsePrintCompEQNMode];
+
 GetParsePrintCompInitTensorType[key_] :=
   Return[
     If[KeyExistsQ[$ParsePrintCompInitTensorTypeAssociation, key],
@@ -265,6 +275,8 @@ CleanParsePrintCompInitTensorType[] :=
     $ParsePrintCompInitTensorTypeAssociation = <||>
   ];
 
+Protect[CleanParsePrintCompInitTensorType];
+
 GetParsePrintCompInitStorageType[key_] :=
   Return[
     If[KeyExistsQ[$ParsePrintCompInitStorageTypeAssociation, key],
@@ -287,6 +299,8 @@ CleanParsePrintCompInitStorageType[] :=
   Module[{},
     $ParsePrintCompInitStorageTypeAssociation = <||>
   ];
+
+Protect[CleanParsePrintCompInitStorageType];
 
 End[];
 


### PR DESCRIPTION
### Motivation

- The parse-mode cleanup functions were not protected, making them susceptible to accidental redefinition at runtime. 
- Other public API functions in the package are `Protect`ed for safety, so these cleanup helpers should follow the same pattern.  
- Protecting these symbols improves API stability when loading/reloading packages in interactive sessions.  

### Description

- Updated `src/ParseMode.wl` to add `Protect[...]` calls for the cleanup helpers after each definition.  
- The following functions are now protected: `CleanParseMode`, `CleanParseSetCompMode`, `CleanParsePrintCompMode`, `CleanParsePrintCompInitMode`, `CleanParsePrintCompEQNMode`, `CleanParsePrintCompInitTensorType`, and `CleanParsePrintCompInitStorageType`.  
- No other behavioral changes were made; these are symbol protection additions only.  

### Testing

- No automated tests were run for this change.  
- The change is a non-functional hardening (adding `Protect`), so no test changes were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962549a9f7c832592804b582e8da865)