### PR TITLE
Fix parse mode reset helpers

### DIFF
--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -126,7 +126,7 @@ Protect[SetParseMode];
 
 SetParseModeAllToFalse[] :=
   Module[{},
-    AppendTo[$ParseModeAssociation, <|SetComp -> False, PrintComp -> False|>]
+    $ParseModeAssociation = <|SetComp -> False, PrintComp -> False|>
   ];
 
 Protect[SetParseModeAllToFalse];
@@ -158,7 +158,7 @@ Protect[SetParseSetCompMode];
 
 SetParseSetCompModeAllToFalse[] :=
   Module[{},
-    AppendTo[$ParseSetCompModeAssociation, <|IndependentVarlistIndex -> False, WithoutGridPointIndex -> False, UseTilePointIndex -> False|>]
+    $ParseSetCompModeAssociation = <|IndependentVarlistIndex -> False, WithoutGridPointIndex -> False, UseTilePointIndex -> False|>
   ];
 
 Protect[SetParseSetCompModeAllToFalse];
@@ -190,7 +190,7 @@ Protect[SetParsePrintCompMode];
 
 SetParsePrintCompModeAllToFalse[] :=
   Module[{},
-    AppendTo[$ParsePrintCompModeAssociation, <|Initializations -> False, Equations -> False|>]
+    $ParsePrintCompModeAssociation = <|Initializations -> False, Equations -> False|>
   ];
 
 Protect[SetParsePrintCompModeAllToFalse];


### PR DESCRIPTION
### Motivation

- The `*AllToFalse` helpers in `src/ParseMode.wl` used `AppendTo` which appended associations instead of resetting them, allowing stale keys to persist and making mode-reset behavior unpredictable.  
- This could lead to incorrect results from `GetParse*` functions when callers expect a clean "all false" state.  

### Description

- Replace `AppendTo[...]` with direct assignment for the reset helpers in `src/ParseMode.wl` so the associations are replaced rather than appended.  
- The following functions were updated: `SetParseModeAllToFalse`, `SetParseSetCompModeAllToFalse`, and `SetParsePrintCompModeAllToFalse`.  

### Testing

- No automated tests were run as part of this change.  
- The repository changes were committed with the message `Fix parse mode reset helpers`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625b6f12cc8325930289f0c98c6335)