### PR TITLE
Find and fix easiest repository issue

### DIFF
--- a/codes/AMReX.wl
+++ b/codes/AMReX.wl
@@ -175,7 +175,7 @@ PrintComponentInitialization::EMode =
 PrintComponentInitialization::EVarLength =
   "PrintComponentInitialization variable's tensor type unsupported!";
 
-(*Protect[PrintComponentInitialization];*)
+Protect[PrintComponentInitialization];
 
 
 (******************************************************************************)
@@ -231,7 +231,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
 
 PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
 
-(*Protect[PrintComponentEquation];*)
+Protect[PrintComponentEquation];
 
 
 (******************************************************************************)

--- a/codes/Carpet.wl
+++ b/codes/Carpet.wl
@@ -247,7 +247,7 @@ PrintComponentInitialization::EMode =
 PrintComponentInitialization::EVarLength =
   "PrintComponentInitialization variable's tensor type unsupported!";
 
-(*Protect[PrintComponentInitialization];*)
+Protect[PrintComponentInitialization];
 
 
 (******************************************************************************)
@@ -303,7 +303,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
 
 PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
 
-(*Protect[PrintComponentEquation];*)
+Protect[PrintComponentEquation];
 
 
 (******************************************************************************)

--- a/codes/CarpetX.wl
+++ b/codes/CarpetX.wl
@@ -19,7 +19,7 @@ PrintListInitializations[varlist_?ListQ, storagetype_?StringQ, indextype_?String
     ];
   ];
 
-(*Protect[PrintListInitializations];*)
+Protect[PrintListInitializations];
 
 (*
     Print initialization of each component of a tensor
@@ -119,7 +119,7 @@ PrintComponentInitialization::EMode = "PrintComponentInitialization mode unrecog
 
 PrintComponentInitialization::EVarLength = "PrintComponentInitialization variable's tensor type unsupported!";
 
-(*Protect[PrintComponentInitialization];*)
+Protect[PrintComponentInitialization];
 
 
 (******************************************************************************)
@@ -174,7 +174,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
 
 PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
 
-(*Protect[PrintComponentEquation];*)
+Protect[PrintComponentEquation];
 
 (******************************************************************************)
 

--- a/codes/CarpetXGPU.wl
+++ b/codes/CarpetXGPU.wl
@@ -301,7 +301,7 @@ PrintComponentInitialization::EMode =
 PrintComponentInitialization::EVarLength =
   "PrintComponentInitialization variable's tensor type unsupported!";
 
-(*Protect[PrintComponentInitialization];*)
+Protect[PrintComponentInitialization];
 
 
 (******************************************************************************)
@@ -357,7 +357,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
 
 PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
 
-(*Protect[PrintComponentEquation];*)
+Protect[PrintComponentEquation];
 
 
 (******************************************************************************)

--- a/codes/CarpetXPointDesc.wl
+++ b/codes/CarpetXPointDesc.wl
@@ -170,7 +170,7 @@ PrintComponentInitialization::EMode =
 PrintComponentInitialization::EVarLength =
   "PrintComponentInitialization variable's tensor type unsupported!";
 
-(*Protect[PrintComponentInitialization];*)
+Protect[PrintComponentInitialization];
 
 
 (******************************************************************************)
@@ -226,7 +226,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
 
 PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
 
-(*Protect[PrintComponentEquation];*)
+Protect[PrintComponentEquation];
 
 
 (******************************************************************************)

--- a/codes/Nmesh.wl
+++ b/codes/Nmesh.wl
@@ -64,7 +64,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
 
 PrintComponentInitialization::EMode = "PrintComponentInitialization mode unrecognized!";
 
-(*Protect[PrintComponentInitialization];*)
+Protect[PrintComponentInitialization];
 
 
 (******************************************************************************)
@@ -120,7 +120,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
 
 PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
 
-(*Protect[PrintComponentEquation];*)
+Protect[PrintComponentEquation];
 
 (*
     Write to files


### PR DESCRIPTION
Enable symbol protection for PrintListInitializations, PrintComponentInitialization, and PrintComponentEquation in all backend files (codes/*.wl) to match the protection pattern used consistently throughout the src/ directory.