### PR TITLE
Find and fix easiest repository issue

### DIFF
--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -121,6 +121,8 @@ Protect[SetCheckInputEquations];
 GetPVerbose[] :=
   Return[$PVerbose];
 
+Protect[GetPVerbose];
+
 SetPVerbose[verbose_] :=
   Module[{},
     $PVerbose = verbose


### PR DESCRIPTION
Add missing Protect[GetPVerbose] statement to match the pattern used for all other getter functions in the module. This was the only getter function without protection in Basic.wl.