### PR TITLE
Refactor mode system from 7 globals to single nested structure

### DIFF
--- a/codes/AMReX.wl
+++ b/codes/AMReX.wl
@@ -87,10 +87,10 @@ PrintComponentInitialization[varinfo_, compname_] :=
 
     (* set subbuf *)
     Which[
-      GetParsePrintCompInitTensorType[Scal],
+      GetTensorType[] === "Scal",
         subbuf = If[len == 0, "", "[" <> ToString[varlistindex] <> "]"]
       ,
-      GetParsePrintCompInitTensorType[Vect],
+      GetTensorType[] === "Vect",
         Which[
           len == 1,
             subbuf = "[" <> ToString[varlistindex] <> "]"
@@ -107,7 +107,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
             Throw @ Message[PrintComponentInitialization::EVarLength]
         ]
       ,
-      GetParsePrintCompInitTensorType[Smat],
+      GetTensorType[] === "Smat",
         Which[
           len == 2,
             subbuf = "[" <> ToString[varlistindex] <> "]"
@@ -127,19 +127,19 @@ PrintComponentInitialization[varinfo_, compname_] :=
       True,
         Throw @ Message[PrintComponentInitialization::EMode]
     ];
-    fdorder = GetParsePrintCompInitMode[DerivsOrder];
-    fdaccuracy = GetParsePrintCompInitMode[DerivsAccuracy];
+    fdorder = GetDerivsOrder[];
+    fdaccuracy = GetDerivsAccuracy[];
 
     (* set buf *)
     buf =
       Which[
-        GetParsePrintCompInitMode[MainIn] || GetParsePrintCompInitMode[MainOut],
+        GetInitMode[] === "MainIn" || GetInitMode[] === "MainOut",
           "auto &" <> ToString[compToValue]
           <> " = " <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ";"
         ,
-        GetParsePrintCompInitMode[Derivs],
+        GetInitMode[] === "Derivs",
           offset = fdorder - 1;
-          If[GetParsePrintCompInitStorageType[Tile],
+          If[GetStorageType[] === "Tile",
             "const auto " <> StringTrim[ToString[compToValue], GetTilePointIndex[]]
             <> " = tl_" <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ".ptr;"
             ,
@@ -159,7 +159,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
             <> ", p.i, p.j, p.k);"
           ]
         ,
-        GetParsePrintCompInitMode[Temp],
+        GetInitMode[] === "Temp",
           "const auto &" <> ToString[compToValue]
           <> " = " <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ";"
         ,
@@ -199,7 +199,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetParsePrintCompEQNMode[NewVar],
+      GetEqnMode[] === "NewVar",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           Global`pr[StringTrim[ToString[compToValue], GetGridPointIndex[]]];
@@ -208,7 +208,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[Main],
+      GetEqnMode[] === "Main",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["="];
@@ -216,7 +216,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[AddToMain],
+      GetEqnMode[] === "AddToMain",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["+="];

--- a/codes/Carpet.wl
+++ b/codes/Carpet.wl
@@ -196,18 +196,18 @@ PrintComponentInitialization[varinfo_, compname_] :=
 
     (* set subbuf *)
     subbuf = If[len == 0, "", "[" <> ToString[varlistindex] <> "]"];
-    fdorder = GetParsePrintCompInitMode[DerivsOrder];
-    fdaccuracy = GetParsePrintCompInitMode[DerivsAccuracy];
+    fdorder = GetDerivsOrder[];
+    fdaccuracy = GetDerivsAccuracy[];
 
     (* set buf *)
     buf =
       Which[
-        GetParsePrintCompInitMode[MainIn] || GetParsePrintCompInitMode[MainOut],
+        GetInitMode[] === "MainIn" || GetInitMode[] === "MainOut",
           "const auto &"
           <> StringTrim[ToString[compToValue], GetGridPointIndex[]]
           <> " = gf_" <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ";"
         ,
-        GetParsePrintCompInitMode[Derivs],
+        GetInitMode[] === "Derivs",
           offset = fdorder - 1;
           "const auto " <> ToString[compToValue]
           <> " = calcderivs" <> ToString[fdorder] <> "_"
@@ -219,7 +219,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
           <> ", i, j, k);"
         ,
         (*
-        GetParsePrintCompInitMode[Derivs],
+        GetInitMode[] === "Derivs",
           offset = fdorder - 1;
           "const auto " <> ToString[compToValue]
           <> " = fd_" <> ToString[fdorder] <> "_o" <> ToString[fdaccuracy]
@@ -232,7 +232,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
           <> ", i, j, k, invDxyz);"
         ,
         *)
-        GetParsePrintCompInitMode[Temp],
+        GetInitMode[] === "Temp",
           buf = "auto " <> ToString[compToValue] <> ";"
         ,
         True,
@@ -271,7 +271,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetParsePrintCompEQNMode[NewVar],
+      GetEqnMode[] === "NewVar",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];
@@ -280,7 +280,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[Main],
+      GetEqnMode[] === "Main",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["="];
@@ -288,7 +288,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[AddToMain],
+      GetEqnMode[] === "AddToMain",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["+="];

--- a/codes/CarpetX.wl
+++ b/codes/CarpetX.wl
@@ -30,7 +30,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
     {varname, symmetry} = varinfo;
     (* set subbuf *)
     Which[
-      GetParsePrintCompInitTensorType[Scal],
+      GetTensorType[] === "Scal",
         Which[
           Length[varname] == 0,
             subbuf = ""
@@ -52,7 +52,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
             Throw @ Message[PrintComponentInitialization::EVarLength]
         ]
       ,
-      GetParsePrintCompInitTensorType[Vect],
+      GetTensorType[] === "Vect",
         Which[
           Length[varname] == 1,
             subbuf = "(" <> ToString[compname[[1]][[1]] - 1] <> ")"
@@ -74,7 +74,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
             Throw @ Message[PrintComponentInitialization::EVarLength]
         ]
       ,
-      GetParsePrintCompInitTensorType[Smat],
+      GetTensorType[] === "Smat",
         Which[
           Length[varname] == 2,
             subbuf = "(" <> ToString[compname[[1]][[1]] - 1] <> "," <> ToString[compname[[2]][[1]] - 1] <> ")"
@@ -93,20 +93,20 @@ PrintComponentInitialization[varinfo_, compname_] :=
         Throw @ Message[PrintComponentInitialization::EMode]
     ];
     (* combine buf *)
-    isGF3D2 = GetParsePrintCompInitStorageType[GF];
-    isGF3D5 = GetParsePrintCompInitStorageType[Tile];
+    isGF3D2 = GetStorageType[] === "GF";
+    isGF3D5 = GetStorageType[] === "Tile";
     buf =
       Which[
-        GetParsePrintCompInitMode[MainOut] && isGF3D2,
+        GetInitMode[] === "MainOut" && isGF3D2,
           "const GF3D2<CCTK_REAL> &local_" <> StringTrim[ToString[compToValue], GetGridPointIndex[]] <> " = gf_" <> StringTrim[ToString[varname[[0]]], GetSuffixUnprotected[]] <> subbuf <> ";"
         ,
-        GetParsePrintCompInitMode[MainIn] && isGF3D2,
+        GetInitMode[] === "MainIn" && isGF3D2,
           "const vreal " <> StringTrim[ToString[compToValue], GetGridPointIndex[]] <> " = tmp_" <> StringTrim[ToString[varname[[0]]], GetSuffixUnprotected[]] <> subbuf <> ";"
         ,
-        GetParsePrintCompInitMode[MainIn] && isGF3D5,
+        GetInitMode[] === "MainIn" && isGF3D5,
           "const vreal " <> StringTrim[ToString[compToValue], GetGridPointIndex[]] <> " = tmp_" <> StringTrim[ToString[varname[[0]]], GetSuffixUnprotected[]] <> subbuf <> ";"
         ,
-        GetParsePrintCompInitMode[Temp],
+        GetInitMode[] === "Temp",
           buf = "vreal " <> ToString[compToValue] <> ";"
         ,
         True,
@@ -143,7 +143,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetParsePrintCompEQNMode[NewVar],
+      GetEqnMode[] === "NewVar",
         Module[{},
           Global`pr[GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];
@@ -152,14 +152,14 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[Main],
+      GetEqnMode[] === "Main",
         Module[{},
           Global`pr["local_" <> ToString[CForm[compToValue]] <> ".store(mask, index2, "];
           PutAppend[CForm[rhssToValue], outputfile];
           Global`pr[");\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[AddToMain],
+      GetEqnMode[] === "AddToMain",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["+="];

--- a/codes/CarpetXGPU.wl
+++ b/codes/CarpetXGPU.wl
@@ -194,10 +194,10 @@ PrintComponentInitialization[varinfo_, compname_] :=
 
     (* set subbuf *)
     Which[
-      GetParsePrintCompInitTensorType[Scal],
+      GetTensorType[] === "Scal",
         subbuf = If[len == 0, "", "[" <> ToString[varlistindex] <> "]"]
       ,
-      GetParsePrintCompInitTensorType[Vect],
+      GetTensorType[] === "Vect",
         Which[
           len == 1,
             subbuf = "[" <> ToString[varlistindex] <> "]"
@@ -214,7 +214,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
             Throw @ Message[PrintComponentInitialization::EVarLength]
         ]
       ,
-      GetParsePrintCompInitTensorType[Smat],
+      GetTensorType[] === "Smat",
         Which[
           len == 2,
             subbuf = "[" <> ToString[varlistindex] <> "]"
@@ -234,14 +234,14 @@ PrintComponentInitialization[varinfo_, compname_] :=
       True,
         Throw @ Message[PrintComponentInitialization::EMode]
     ];
-    fdorder = GetParsePrintCompInitMode[DerivsOrder];
-    fdaccuracy = GetParsePrintCompInitMode[DerivsAccuracy];
+    fdorder = GetDerivsOrder[];
+    fdaccuracy = GetDerivsAccuracy[];
 
     (* set buf *)
     buf =
       Which[
-        GetParsePrintCompInitMode[MainIn] || GetParsePrintCompInitMode[MainOut],
-          If[GetParsePrintCompInitStorageType[Tile],
+        GetInitMode[] === "MainIn" || GetInitMode[] === "MainOut",
+          If[GetStorageType[] === "Tile",
             "const auto " <> StringTrim[ToString[compToValue], GetGridPointIndex[]]
             <> " = tl_" <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ".ptr;"
             ,
@@ -250,9 +250,9 @@ PrintComponentInitialization[varinfo_, compname_] :=
             <> " = gf_" <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ";"
           ]
         ,
-        GetParsePrintCompInitMode[Derivs],
+        GetInitMode[] === "Derivs",
           offset = fdorder - 1;
-          If[GetParsePrintCompInitStorageType[Tile],
+          If[GetStorageType[] === "Tile",
             "const auto " <> StringTrim[ToString[compToValue], GetTilePointIndex[]]
             <> " = tl_" <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ".ptr;"
             ,
@@ -273,7 +273,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
           ]
         ,
         (*
-        GetParsePrintCompInitMode[Derivs],
+        GetInitMode[] === "Derivs",
           offset = fdorder - 1;
           "const auto " <> ToString[compToValue]
           <> " = fd_" <> ToString[fdorder] <> "_o" <> ToString[fdaccuracy]
@@ -286,7 +286,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
           <> ", p.i, p.j, p.k, invDxyz);"
         ,
         *)
-        GetParsePrintCompInitMode[Temp],
+        GetInitMode[] === "Temp",
           "auto " <> ToString[compToValue] <> ";"
         ,
         True,
@@ -325,7 +325,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetParsePrintCompEQNMode[NewVar],
+      GetEqnMode[] === "NewVar",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           Global`pr[StringTrim[ToString[compToValue], GetGridPointIndex[]]];
@@ -334,7 +334,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[Main],
+      GetEqnMode[] === "Main",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["="];
@@ -342,7 +342,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[AddToMain],
+      GetEqnMode[] === "AddToMain",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["+="];

--- a/codes/CarpetXPointDesc.wl
+++ b/codes/CarpetXPointDesc.wl
@@ -137,25 +137,25 @@ PrintComponentInitialization[varinfo_, compname_] :=
     (* set buf *)
     buf =
       Which[
-        GetParsePrintCompInitMode[MainIn] || GetParsePrintCompInitMode[MainOut],
+        GetInitMode[] === "MainIn" || GetInitMode[] === "MainOut",
           "const auto &"
           <> StringTrim[ToString[compToValue], GetGridPointIndex[]]
           <> " = gf_" <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ";"
         ,
-        GetParsePrintCompInitMode[Derivs1st],
+        GetInitMode[] === "Derivs1st",
           "const auto " <> ToString[compToValue]
           <> " = fd_1st<" <> ToString[compname[[1]][[1]]] <> ">("
           <> StringDrop[StringDrop[ToString[compToValue], 1], {-len, -len + 0}]
           <> ", p);"
         ,
-        GetParsePrintCompInitMode[Derivs2nd],
+        GetInitMode[] === "Derivs2nd",
           "const auto " <> ToString[compToValue]
           <> " = fd_2nd<" <> ToString[compname[[1]][[1]]] <> ", "
           <> ToString[compname[[2]][[1]]] <> ">("
           <> StringDrop[StringDrop[ToString[compToValue], 2], {-len, -len + 1}]
           <> ", p);"
         ,
-        GetParsePrintCompInitMode[Temp],
+        GetInitMode[] === "Temp",
           buf = "auto " <> ToString[compToValue] <> ";"
         ,
         True,
@@ -194,7 +194,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetParsePrintCompEQNMode[NewVar],
+      GetEqnMode[] === "NewVar",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];
@@ -203,7 +203,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[Main],
+      GetEqnMode[] === "Main",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["="];
@@ -211,7 +211,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[AddToMain],
+      GetEqnMode[] === "AddToMain",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["+="];

--- a/codes/Nmesh.wl
+++ b/codes/Nmesh.wl
@@ -26,7 +26,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
   Module[{varlistindex = GetMapComponentToVarlist[][compname], compToValue = compname // ToValues, varname, buf},
     varname = varinfo[[1]];
     Which[
-      GetParsePrintCompInitMode[MainOut],
+      GetInitMode[] === "MainOut",
         buf =
           "double *" <> StringTrim[ToString[compToValue], GetGridPointIndex[]] <> " = Vard(node, Vind(vlr," <> ToString[GetProject[]] <> "->i_" <> StringTrim[ToString[varname[[0]]], (GetPrefixDt[] | GetSuffixUnprotected[])] <> GetInitialComp[varname] <>
             If[varlistindex == 0,
@@ -35,7 +35,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
               "+" <> ToString[varlistindex]
             ] <> "));"
       ,
-      GetParsePrintCompInitMode[MainIn],
+      GetInitMode[] === "MainIn",
         buf =
           "double *" <> StringTrim[ToString[compToValue], GetGridPointIndex[]] <> " = Vard(node, Vind(vlu," <> ToString[GetProject[]] <> "->i_" <> StringTrim[ToString[varname[[0]]], GetSuffixUnprotected[]] <> GetInitialComp[varname] <>
             If[varlistindex == 0,
@@ -44,7 +44,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
               "+" <> ToString[varlistindex]
             ] <> "));"
       ,
-      GetParsePrintCompInitMode[MoreInOut],
+      GetInitMode[] === "MoreInOut",
         buf =
           "double *" <> StringTrim[ToString[compToValue], GetGridPointIndex[]] <> " = Vard(node, i" <> StringTrim[ToString[varname[[0]]], GetSuffixUnprotected[]] <> GetInitialComp[varname] <>
             If[varlistindex == 0,
@@ -53,7 +53,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
               "+" <> ToString[varlistindex]
             ] <> ");"
       ,
-      GetParsePrintCompInitMode[Temp],
+      GetInitMode[] === "Temp",
         buf = "double " <> ToString[compToValue] <> ";"
       ,
       True,
@@ -88,7 +88,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetParsePrintCompEQNMode[NewVar],
+      GetEqnMode[] === "NewVar",
         Module[{},
           Global`pr[GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];
@@ -97,7 +97,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[Main],
+      GetEqnMode[] === "Main",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["="];
@@ -105,7 +105,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
           Global`pr[";\n"]
         ]
       ,
-      GetParsePrintCompEQNMode[AddToMain],
+      GetEqnMode[] === "AddToMain",
         Module[{},
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["+="];

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -170,10 +170,10 @@ ParseComponent[varinfo_, compindexlist_?ListQ, coordinate_, extrareplacerules_?L
       Continue[]
     ];
     Which[
-      GetParseMode[SetComp],
+      InSetCompPhase[],
         SetComponent[compname, SetExprName[varname, compindexlist, coordinate]]
       ,
-      GetParseMode[PrintComp],
+      InPrintCompPhase[],
         PrintComponent[coordinate, varinfo, compname, extrareplacerules]
       ,
       True,
@@ -188,11 +188,11 @@ Protect[ParseComponent];
 PrintComponent[coordinate_, varinfo_, compname_, extrareplacerules_] :=
   Module[{},
     Which[
-      GetParsePrintCompMode[Initializations],
+      InInitMode[],
         PrintVerbose["    PrintComponentInitialization ", compname, "..."];
         Global`PrintComponentInitialization[varinfo, compname]
       ,
-      GetParsePrintCompMode[Equations],
+      InEqnMode[],
         PrintVerbose["    PrintComponentEquation ", compname, "..."];
         Global`PrintComponentEquation[coordinate, compname, extrareplacerules]
       ,
@@ -217,7 +217,7 @@ PrintComponent::EMode = "PrintMode unrecognized!";
 SetComponent[compname_, exprname_] :=
   Module[{varlistindex, mapCtoV = GetMapComponentToVarlist[]},
     PrintVerbose["    SetComponent ", compname, "..."];
-    If[Length[mapCtoV] == 0 || GetProcessNewVarlist[] || (GetParseSetCompMode[IndependentVarlistIndex] && (compname[[0]] =!= Last[Keys[mapCtoV]][[0]])),
+    If[Length[mapCtoV] == 0 || GetProcessNewVarlist[] || (GetIndependentVarlistIndex[] && (compname[[0]] =!= Last[Keys[mapCtoV]][[0]])),
       varlistindex = 0(*C convention*)
       ,
       varlistindex = Last[mapCtoV] + 1
@@ -283,10 +283,10 @@ SetExprName[varname_, compindexlist_, coordinate_] :=
       ]
     ];
     exprname =
-      If[GetParseSetCompMode[WithoutGridPointIndex] || (GetInterfaceWithNonCoordBasis[] && coordinate === GetDefaultChart[]),
+      If[GetWithoutGridPointIndex[] || (GetInterfaceWithNonCoordBasis[] && coordinate === GetDefaultChart[]),
         ToExpression[exprname]
         ,
-        If[GetParseSetCompMode[UseTilePointIndex],
+        If[GetUseTilePointIndex[],
           ToExpression[exprname <> GetTilePointIndex[]]
           ,
           ToExpression[exprname <> GetGridPointIndex[]]

--- a/src/Varlist.wl
+++ b/src/Varlist.wl
@@ -52,7 +52,7 @@ ParseVarlist[OptionsPattern[], varlist_?ListQ, chartname_] :=
         symindex = symmetry[[1]]
       ];
       If[!xTensorQ[varname[[0]]],
-        If[GetParseMode[SetComp],
+        If[InSetCompPhase[],
           DefineTensor[varname, symmetry, printname]
           ,
           Throw @ Message[ParseVarlist::ETensorNonExist, ivar, varname]

--- a/test/regression/Nmesh/GHG_set_profile_ADM.wl
+++ b/test/regression/Nmesh/GHG_set_profile_ADM.wl
@@ -342,9 +342,11 @@ $MainPrint[] :=
       (* set d_k g_{ab} *)
       printdg[cc_, aa_, bb_] :=
         Module[{},
-          SetParsePrintCompEQNMode[Main -> True];
+          SetMode["Phase" -> "PrintComp"];
+          SetMode["PrintComp", "Type" -> "Equations"];
+          SetMode["PrintComp", "Eqn", "Mode" -> "Main"];
           PrintComponentEquation[GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}];
-          CleanParsePrintCompEQNMode[];
+          ResetMode["PrintComp", "Eqn"];
         ];
       Do[printdg[cc, aa, bb], {cc, 3, 1, -1}, {aa, 3, 0, -1}, {bb, 3, aa, -1}];
       (* set d_t g_{ab} *)
@@ -354,9 +356,11 @@ $MainPrint[] :=
         printdtgEin[cc_, aa_, bb_] :=
           Module[{},
             SetSuffixName["Ein"];
-            SetParsePrintCompEQNMode[Main -> True];
+            SetMode["Phase" -> "PrintComp"];
+            SetMode["PrintComp", "Type" -> "Equations"];
+            SetMode["PrintComp", "Eqn", "Mode" -> "Main"];
             PrintComponentEquation[GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}];
-            CleanParsePrintCompEQNMode[];
+            ResetMode["PrintComp", "Eqn"];
             SetSuffixName[""];
           ];
         Do[printdtgEin[0, aa, bb], {aa, 3, 0, -1}, {bb, 3, aa, -1}];

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -1,7 +1,7 @@
 (* ::Package:: *)
 
 (* ParseModeTests.wl *)
-(* Unit tests for Generato`ParseMode module *)
+(* Unit tests for Generato`ParseMode module - New Nested Mode System *)
 
 If[Environment["QUIET"] =!= "1", Print["Loading ParseModeTests.wl..."]];
 
@@ -12,236 +12,242 @@ SetPVerbose[False];
 SetPrintDate[False];
 
 (* ========================================= *)
-(* Test: ParseMode (Level 1) *)
+(* Test: GetMode / SetMode / ResetMode *)
 (* ========================================= *)
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParseMode[];
-    SetParseMode[<|SetComp -> True|>];
-    GetParseMode[SetComp],
+    ResetMode[];
+    SetMode["Phase" -> "SetComp"];
+    GetMode["Phase"],
+    "SetComp",
+    TestID -> "Mode-Phase-SetComp"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["Phase" -> "PrintComp"];
+    GetMode["Phase"],
+    "PrintComp",
+    TestID -> "Mode-Phase-PrintComp"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    GetMode["Phase"],
+    None,
+    TestID -> "Mode-Phase-Default-None"
+  ]
+];
+
+(* ========================================= *)
+(* Test: SetComp Options *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["SetComp", "IndependentVarlistIndex" -> True];
+    GetMode["SetComp", "IndependentVarlistIndex"],
     True,
-    TestID -> "ParseMode-SetComp-True"
+    TestID -> "Mode-SetComp-IndependentVarlistIndex"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParseMode[];
-    SetParseMode[<|PrintComp -> True|>];
-    GetParseMode[PrintComp],
+    ResetMode[];
+    SetMode["SetComp", "WithoutGridPointIndex" -> True];
+    GetMode["SetComp", "WithoutGridPointIndex"],
     True,
-    TestID -> "ParseMode-PrintComp-True"
+    TestID -> "Mode-SetComp-WithoutGridPointIndex"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParseMode[];
-    GetParseMode[NonExistentKey],
-    False,
-    TestID -> "ParseMode-NonExistentKey-ReturnsFalse"
-  ]
-];
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParseMode[];
-    SetParseMode[<|SetComp -> True, PrintComp -> True|>];
-    SetParseModeAllToFalse[];
-    {GetParseMode[SetComp], GetParseMode[PrintComp]},
-    {False, False},
-    TestID -> "ParseMode-SetAllToFalse"
-  ]
-];
-
-(* ========================================= *)
-(* Test: ParseSetCompMode (Level 2) *)
-(* ========================================= *)
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParseSetCompMode[];
-    SetParseSetCompMode[<|IndependentVarlistIndex -> True|>];
-    GetParseSetCompMode[IndependentVarlistIndex],
+    ResetMode[];
+    SetMode["SetComp", "UseTilePointIndex" -> True];
+    GetMode["SetComp", "UseTilePointIndex"],
     True,
-    TestID -> "ParseSetCompMode-IndependentVarlistIndex-True"
+    TestID -> "Mode-SetComp-UseTilePointIndex"
+  ]
+];
+
+(* ========================================= *)
+(* Test: PrintComp Init Modes *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["PrintComp", "Type" -> "Initializations"];
+    SetMode["PrintComp", "Init", "Mode" -> "MainIn"];
+    GetMode["PrintComp", "Init", "Mode"],
+    "MainIn",
+    TestID -> "Mode-PrintComp-Init-MainIn"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParseSetCompMode[];
-    SetParseSetCompMode[<|WithoutGridPointIndex -> True|>];
-    GetParseSetCompMode[WithoutGridPointIndex],
+    ResetMode[];
+    SetMode["PrintComp", "Init", "TensorType" -> "Vect"];
+    GetMode["PrintComp", "Init", "TensorType"],
+    "Vect",
+    TestID -> "Mode-PrintComp-Init-TensorType-Vect"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["PrintComp", "Init", "StorageType" -> "Tile"];
+    GetMode["PrintComp", "Init", "StorageType"],
+    "Tile",
+    TestID -> "Mode-PrintComp-Init-StorageType-Tile"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["PrintComp", "Init", "DerivsOrder" -> 2];
+    SetMode["PrintComp", "Init", "DerivsAccuracy" -> 6];
+    {GetMode["PrintComp", "Init", "DerivsOrder"], GetMode["PrintComp", "Init", "DerivsAccuracy"]},
+    {2, 6},
+    TestID -> "Mode-PrintComp-Init-Derivs"
+  ]
+];
+
+(* ========================================= *)
+(* Test: PrintComp Eqn Modes *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["PrintComp", "Eqn", "Mode" -> "NewVar"];
+    GetMode["PrintComp", "Eqn", "Mode"],
+    "NewVar",
+    TestID -> "Mode-PrintComp-Eqn-NewVar"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["PrintComp", "Eqn", "Mode" -> "Main"];
+    GetMode["PrintComp", "Eqn", "Mode"],
+    "Main",
+    TestID -> "Mode-PrintComp-Eqn-Main"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["PrintComp", "Eqn", "Mode" -> "AddToMain"];
+    GetMode["PrintComp", "Eqn", "Mode"],
+    "AddToMain",
+    TestID -> "Mode-PrintComp-Eqn-AddToMain"
+  ]
+];
+
+(* ========================================= *)
+(* Test: Convenience Helpers *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetMode[];
+    SetMode["Phase" -> "SetComp"];
+    InSetCompPhase[],
     True,
-    TestID -> "ParseSetCompMode-WithoutGridPointIndex-True"
+    TestID -> "Mode-Helper-InSetCompPhase"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParseSetCompMode[];
-    SetParseSetCompMode[<|UseTilePointIndex -> True|>];
-    GetParseSetCompMode[UseTilePointIndex],
+    ResetMode[];
+    SetMode["Phase" -> "PrintComp"];
+    InPrintCompPhase[],
     True,
-    TestID -> "ParseSetCompMode-UseTilePointIndex-True"
+    TestID -> "Mode-Helper-InPrintCompPhase"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParseSetCompMode[];
-    GetParseSetCompMode[NonExistentKey],
-    False,
-    TestID -> "ParseSetCompMode-NonExistentKey-ReturnsFalse"
-  ]
-];
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParseSetCompMode[];
-    SetParseSetCompMode[<|IndependentVarlistIndex -> True, WithoutGridPointIndex -> True, UseTilePointIndex -> True|>];
-    SetParseSetCompModeAllToFalse[];
-    {GetParseSetCompMode[IndependentVarlistIndex], GetParseSetCompMode[WithoutGridPointIndex], GetParseSetCompMode[UseTilePointIndex]},
-    {False, False, False},
-    TestID -> "ParseSetCompMode-SetAllToFalse"
-  ]
-];
-
-(* ========================================= *)
-(* Test: ParsePrintCompMode (Level 3) *)
-(* ========================================= *)
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParsePrintCompMode[];
-    SetParsePrintCompMode[<|Initializations -> True|>];
-    GetParsePrintCompMode[Initializations],
+    ResetMode[];
+    SetMode["PrintComp", "Type" -> "Initializations"];
+    InInitMode[],
     True,
-    TestID -> "ParsePrintCompMode-Initializations-True"
+    TestID -> "Mode-Helper-InInitMode"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParsePrintCompMode[];
-    SetParsePrintCompMode[<|Equations -> True|>];
-    GetParsePrintCompMode[Equations],
+    ResetMode[];
+    SetMode["PrintComp", "Type" -> "Equations"];
+    InEqnMode[],
     True,
-    TestID -> "ParsePrintCompMode-Equations-True"
+    TestID -> "Mode-Helper-InEqnMode"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParsePrintCompMode[];
-    GetParsePrintCompMode[NonExistentKey],
-    False,
-    TestID -> "ParsePrintCompMode-NonExistentKey-ReturnsFalse"
+    ResetMode[];
+    SetMode["PrintComp", "Init", "Mode" -> "MainOut"];
+    GetInitMode[],
+    "MainOut",
+    TestID -> "Mode-Helper-GetInitMode"
   ]
 ];
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParsePrintCompMode[];
-    SetParsePrintCompMode[<|Initializations -> True, Equations -> True|>];
-    SetParsePrintCompModeAllToFalse[];
-    {GetParsePrintCompMode[Initializations], GetParsePrintCompMode[Equations]},
-    {False, False},
-    TestID -> "ParsePrintCompMode-SetAllToFalse"
-  ]
-];
-
-(* ========================================= *)
-(* Test: ParsePrintCompInitMode (Level 4) *)
-(* ========================================= *)
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParsePrintCompInitMode[];
-    SetParsePrintCompInitMode[<|"TestKey" -> "TestValue"|>];
-    GetParsePrintCompInitMode["TestKey"],
-    "TestValue",
-    TestID -> "ParsePrintCompInitMode-SetGet"
-  ]
-];
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParsePrintCompInitMode[];
-    GetParsePrintCompInitMode["NonExistentKey"],
-    False,
-    TestID -> "ParsePrintCompInitMode-NonExistentKey-ReturnsFalse"
+    ResetMode[];
+    SetMode["PrintComp", "Eqn", "Mode" -> "Main"];
+    GetEqnMode[],
+    "Main",
+    TestID -> "Mode-Helper-GetEqnMode"
   ]
 ];
 
 (* ========================================= *)
-(* Test: ParsePrintCompEQNMode (Level 5) *)
+(* Test: ResetMode Subtree *)
 (* ========================================= *)
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParsePrintCompEQNMode[];
-    SetParsePrintCompEQNMode[<|"TestKey" -> "TestValue"|>];
-    GetParsePrintCompEQNMode["TestKey"],
-    "TestValue",
-    TestID -> "ParsePrintCompEQNMode-SetGet"
-  ]
-];
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParsePrintCompEQNMode[];
-    GetParsePrintCompEQNMode["NonExistentKey"],
-    False,
-    TestID -> "ParsePrintCompEQNMode-NonExistentKey-ReturnsFalse"
+    ResetMode[];
+    SetMode["PrintComp", "Init", "Mode" -> "MainIn"];
+    SetMode["PrintComp", "Init", "TensorType" -> "Vect"];
+    ResetMode["PrintComp", "Init"];
+    {GetMode["PrintComp", "Init", "Mode"], GetMode["PrintComp", "Init", "TensorType"]},
+    {None, None},
+    TestID -> "Mode-ResetMode-Subtree"
   ]
 ];
 
 (* ========================================= *)
-(* Test: ParsePrintCompInitTensorType (Level 6) *)
+(* Test: Validation *)
 (* ========================================= *)
 
 AppendTo[$AllTests,
   VerificationTest[
-    CleanParsePrintCompInitTensorType[];
-    SetParsePrintCompInitTensorType[<|"TestKey" -> "TestValue"|>];
-    GetParsePrintCompInitTensorType["TestKey"],
-    "TestValue",
-    TestID -> "ParsePrintCompInitTensorType-SetGet"
-  ]
-];
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParsePrintCompInitTensorType[];
-    GetParsePrintCompInitTensorType["NonExistentKey"],
-    False,
-    TestID -> "ParsePrintCompInitTensorType-NonExistentKey-ReturnsFalse"
-  ]
-];
-
-(* ========================================= *)
-(* Test: ParsePrintCompInitStorageType (Level 7) *)
-(* ========================================= *)
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParsePrintCompInitStorageType[];
-    SetParsePrintCompInitStorageType[<|"TestKey" -> "TestValue"|>];
-    GetParsePrintCompInitStorageType["TestKey"],
-    "TestValue",
-    TestID -> "ParsePrintCompInitStorageType-SetGet"
-  ]
-];
-
-AppendTo[$AllTests,
-  VerificationTest[
-    CleanParsePrintCompInitStorageType[];
-    GetParsePrintCompInitStorageType["NonExistentKey"],
-    False,
-    TestID -> "ParsePrintCompInitStorageType-NonExistentKey-ReturnsFalse"
+    ResetMode[];
+    Quiet[Catch[SetMode["Phase" -> "InvalidPhase"]], SetMode::EInvalidValue],
+    Null,
+    TestID -> "Mode-Validation-InvalidPhase"
   ]
 ];
 
@@ -249,12 +255,6 @@ AppendTo[$AllTests,
 (* Cleanup *)
 (* ========================================= *)
 
-CleanParseMode[];
-CleanParseSetCompMode[];
-CleanParsePrintCompMode[];
-CleanParsePrintCompInitMode[];
-CleanParsePrintCompEQNMode[];
-CleanParsePrintCompInitTensorType[];
-CleanParsePrintCompInitStorageType[];
+ResetMode[];
 
 If[Environment["QUIET"] =!= "1", Print["ParseModeTests.wl completed."]];

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -176,7 +176,7 @@ AppendTo[$AllTests,
     (* ParseVarlist should process a list of variable definitions *)
     (* This is a basic smoke test - full functionality tested via GridTensors *)
     varlist = {{parseVarlistTest[i], PrintAs -> "pvt"}};
-    SetParseMode[{SetComp -> True, PrintComp -> False}];
+    SetMode["Phase" -> "SetComp"];
     ParseVarlist[varlist, testCart];
     True,
     True,


### PR DESCRIPTION
## Summary
- Replace 7 separate global associations with a single `$Mode` nested structure
- Reduce 21+ functions to 3 core functions (`GetMode`, `SetMode`, `ResetMode`) plus convenience helpers
- Add value validation for all mode settings
- Update all consumers: Interface.wl, Component.wl, Varlist.wl, and all 6 backends

## Test plan
- [x] All unit tests pass: `wolframscript -script test/AllTests.wl`
- [x] All regression tests produce identical output to baseline
- [x] Manual end-to-end code generation verification