### PR TITLE
Rename PrintComp-Eqn-Mode "NewVar" to "Temp"

### DIFF
--- a/codes/AMReX.wl
+++ b/codes/AMReX.wl
@@ -199,7 +199,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetEqnMode[] === "NewVar",
+      GetEqnMode[] === "Temp",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           Global`pr[StringTrim[ToString[compToValue], GetGridPointIndex[]]];

--- a/codes/Carpet.wl
+++ b/codes/Carpet.wl
@@ -271,7 +271,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetEqnMode[] === "NewVar",
+      GetEqnMode[] === "Temp",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];

--- a/codes/CarpetX.wl
+++ b/codes/CarpetX.wl
@@ -143,7 +143,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetEqnMode[] === "NewVar",
+      GetEqnMode[] === "Temp",
         Module[{},
           Global`pr[GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];

--- a/codes/CarpetXGPU.wl
+++ b/codes/CarpetXGPU.wl
@@ -325,7 +325,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetEqnMode[] === "NewVar",
+      GetEqnMode[] === "Temp",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           Global`pr[StringTrim[ToString[compToValue], GetGridPointIndex[]]];

--- a/codes/CarpetXPointDesc.wl
+++ b/codes/CarpetXPointDesc.wl
@@ -194,7 +194,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetEqnMode[] === "NewVar",
+      GetEqnMode[] === "Temp",
         Module[{},
           Global`pr["const " <> GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];

--- a/codes/Nmesh.wl
+++ b/codes/Nmesh.wl
@@ -88,7 +88,7 @@ PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
       rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
     ];
     Which[
-      GetEqnMode[] === "NewVar",
+      GetEqnMode[] === "Temp",
         Module[{},
           Global`pr[GetTempVariableType[] <> " "];
           PutAppend[CForm[compToValue], outputfile];

--- a/src/Interface.wl
+++ b/src/Interface.wl
@@ -119,29 +119,20 @@ Options[PrintEquations] :=
   {ChartName -> GetDefaultChart[], SuffixName -> Null, Mode -> "Main", ExtraReplaceRules -> {}};
 
 PrintEquations[OptionsPattern[], varlist_?ListQ] :=
-  Module[{chartname, suffixname, mode, extrareplacerules, eqnMode},
+  Module[{chartname, suffixname, mode, extrareplacerules},
     {chartname, suffixname, mode, extrareplacerules} = OptionValue[{ChartName, SuffixName, Mode, ExtraReplaceRules}];
     If[suffixname =!= Null,
       SetSuffixName[suffixname]
     ];
-    (* Map string mode to internal mode *)
-    eqnMode = Which[
-      StringMatchQ[mode, "Temp"], "NewVar",
-      StringMatchQ[mode, "Main"], "Main",
-      StringMatchQ[mode, "AddToMain"], "AddToMain",
-      True, Throw @ Message[PrintEquations::EMode, mode]
-    ];
     WithMode[{
       {"Phase"} -> "PrintComp",
       {"PrintComp", "Type"} -> "Equations",
-      {"PrintComp", "Eqn", "Mode"} -> eqnMode
+      {"PrintComp", "Eqn", "Mode"} -> mode
     },
       ParseVarlist[{ExtraReplaceRules -> extrareplacerules}, varlist, chartname]
     ];
     SetSuffixName[""];
   ];
-
-PrintEquations::EMode = "PrintEquations mode '`1`' unsupported yet!";
 
 Protect[PrintEquations];
 

--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -54,7 +54,7 @@ $ModeValidValues = <|
   {"PrintComp", "Init", "StorageType"} -> {None, "GF", "Tile"},
   {"PrintComp", "Init", "DerivsOrder"} -> _Integer,
   {"PrintComp", "Init", "DerivsAccuracy"} -> _Integer,
-  {"PrintComp", "Eqn", "Mode"} -> {None, "NewVar", "Main", "AddToMain"}
+  {"PrintComp", "Eqn", "Mode"} -> {None, "Temp", "Main", "AddToMain"}
 |>;
 
 (* Default mode structure *)

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -131,10 +131,10 @@ AppendTo[$AllTests,
 AppendTo[$AllTests,
   VerificationTest[
     ResetMode[];
-    SetMode["PrintComp", "Eqn", "Mode" -> "NewVar"];
+    SetMode["PrintComp", "Eqn", "Mode" -> "Temp"];
     GetMode["PrintComp", "Eqn", "Mode"],
-    "NewVar",
-    TestID -> "Mode-PrintComp-Eqn-NewVar"
+    "Temp",
+    TestID -> "Mode-PrintComp-Eqn-Temp"
   ]
 ];
 


### PR DESCRIPTION
## Summary
- Rename internal mode value `"NewVar"` to `"Temp"` in `PrintComp.Eqn.Mode` path
- Simplify `PrintEquations` by removing the `Which` mapping block since modes now match directly
- Update all 6 backend framework files to use the new mode name

## Test plan
- [x] All unit tests pass
- [x] All regression tests pass