### PR TITLE
Streamline CLAUDE.md and add Architecture section to README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,81 +1,46 @@
 # Repository Guidelines
 
-## Project Overview
+Generato is a Wolfram Language code generator that produces C/C++ from symbolic tensor expressions using xAct.
 
-Generato is a Wolfram Language-based code generator that produces C/C++ implementations from symbolic tensor expressions. It uses the xAct tensor algebra framework and targets numerical relativity simulations and tensor-based PDEs.
-
-## Running Generato
+## Running
 
 ```bash
-# Prerequisites: Wolfram Engine with wolframscript, xAct tensor package installed
 export GENERATO="/path/to/repo"
-
-# Execute code generation
 Generato test.wl                    # Single file
-Generato file1.wl file2.wl file3.wl # Multiple files
+Generato file1.wl file2.wl          # Multiple files
 ```
-
-Output files (`.hxx` or `.c`) are generated alongside the input `.wl` files.
 
 ## Architecture
 
-### Core Modules (src/)
+### Core (src/)
+- **Generato.wl** - Package loader
+- **Basic.wl** - Config state, tensor utilities, SetEQN/SetEQNDelayed
+- **ParseMode.wl** - Mode management (SetComp/PrintComp phases)
+- **Component.wl** - Tensor component to varlist index mapping
+- **Varlist.wl** - Tensor definitions via ParseVarlist
+- **Interface.wl** - Public API: DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations
+- **BackendCommon.wl** - Shared backend utilities
+- **Derivation.wl** - Testing utilities (TestEQN)
+- **Writefile.wl** - Output buffering (SetMainPrint/GetMainPrint)
+- **stencils/FiniteDifferenceStencils.wl** - FD stencils for orders 2-12
 
-- **Generato.wl** - Package loader, imports modules in dependency order
-- **Basic.wl** - Global config state (`$CheckInputEquations`, `$OutputFile`, etc.), tensor utilities, equation setting (`SetEQN`, `SetEQNDelayed`)
-- **ParseMode.wl** - Multi-level mode management system tracking execution state (SetComp/PrintComp phases, initialization modes, storage types)
-- **Component.wl** - Maps tensor components to varlist indices, handles symmetries
-- **Varlist.wl** - Processes tensor definitions via `ParseVarlist`, creates xAct tensor definitions
-- **Interface.wl** - Public API: `DefTensors`, `GridTensors`, `TileTensors`, `TempTensors`, `SetComponents`, `PrintEquations`, `PrintInitializations`
-- **Writefile.wl** - Output buffering (`SetMainPrint`/`GetMainPrint`) and file writing
-- **stencils/FiniteDifferenceStencils.wl** - Finite difference stencil generation for orders 2-12
-
-### Framework Backends (codes/)
-
-Each backend implements `PrintComponentInitialization` and `PrintComponentEquation` for its target framework:
-
-- **CarpetX.wl** - CarpetX AMR with GF3D2 storage
-- **CarpetXGPU.wl** - GPU-enabled CarpetX
-- **CarpetXPointDesc.wl** - Point description variant
+### Backends (codes/)
+Each implements PrintComponentInitialization and PrintComponentEquation:
+- **CarpetX.wl**, **CarpetXGPU.wl**, **CarpetXPointDesc.wl** - CarpetX variants
 - **Carpet.wl** - Original Carpet framework
-- **AMReX.wl** - AMReX AMR library
-- **Nmesh.wl** - Structured mesh framework (C output)
+- **AMReX.wl** - AMReX library
+- **Nmesh.wl** - Structured mesh (C output)
 
-## Code Generation Workflow
-
-1. User creates `.wl` file with xAct manifold setup and tensor definitions
-2. Define variables using `GridTensors`/`TileTensors`/`TempTensors`
-3. Set equations with `SetEQN` or `SetEQNDelayed`
-4. Call `SetMainPrint` with `PrintEquations` and `PrintInitializations`
-5. Import framework-specific backend
-6. Run `Generato script.wl`
-
-## Key Concepts
-
-- **ParseMode System**: Tracks execution phases (SetComp vs PrintComp) and sub-modes for initialization types
-- **SuffixName**: Controls conditional equation generation
-- **Component Mapping**: Logical tensor indices map to varlist positions
-- **Symmetry Handling**: Symmetric vs Antisymmetric (AB) notations for 2-index tensors
-
-## Running Tests
+## Tests
 
 ```bash
-wolframscript -script test/AllTests.wl
+wolframscript -script test/AllTests.wl              # All tests
+wolframscript -script test/AllTests.wl --unit-only  # Unit tests only
 ```
-
-See [README.md](README.md) for more details on test options, directory structure, and adding new tests.
 
 ## Wolframscript Tips
 
-When running wolframscript with `-e` and backticks in the code, shell escaping issues can cause misleading "license error" messages. Use a pipe instead:
-
+Shell escaping with backticks causes misleading errors. Use pipe instead:
 ```bash
-# Don't use -e with backticks (causes shell escaping issues)
-# wolframscript -e 'Needs["Generato`ParseMode`"]'  # May fail with "license error"
-
-# Use pipe instead
 echo 'Needs["Generato`ParseMode`"]; Print["success"]' | wolframscript
-
-# Or load files directly with Get
-echo 'Get["/path/to/file.wl"]; Print["success"]' | QUIET=1 wolframscript
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,29 @@ cd test/Nmesh
 Generato GHG_rhs.wl
 ```
 
+## Architecture
+
+### Core Modules (src/)
+- **Generato.wl** - Package loader, imports modules in dependency order
+- **Basic.wl** - Global config state, tensor utilities, equation setting (SetEQN/SetEQNDelayed)
+- **ParseMode.wl** - Mode management system tracking execution state (SetComp/PrintComp phases)
+- **Component.wl** - Maps tensor components to varlist indices, handles symmetries
+- **Varlist.wl** - Processes tensor definitions via ParseVarlist
+- **Interface.wl** - Public API: DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations
+- **BackendCommon.wl** - Shared backend utilities
+- **Derivation.wl** - Testing utilities
+- **Writefile.wl** - Output buffering (SetMainPrint/GetMainPrint)
+- **stencils/FiniteDifferenceStencils.wl** - Finite difference stencil generation
+
+### Backends (codes/)
+Each backend implements `PrintComponentInitialization` and `PrintComponentEquation`:
+- **CarpetX.wl** - CarpetX AMR with GF3D2 storage
+- **CarpetXGPU.wl** - GPU-enabled CarpetX
+- **CarpetXPointDesc.wl** - Point description variant
+- **Carpet.wl** - Original Carpet framework
+- **AMReX.wl** - AMReX AMR library
+- **Nmesh.wl** - Structured mesh framework (C output)
+
 ## Recommendations
 
 * Use lower case to name variables (to avoid conflict with say `Pi`)


### PR DESCRIPTION
## Summary
- Shorten CLAUDE.md from 86 to 47 lines by removing redundant sections
- Add missing modules (BackendCommon.wl, Derivation.wl) to documentation
- Move Architecture documentation to README.md for user visibility

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm all modules are accurately documented