### PR TITLE
Add context-based state management for functional purity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Generato file1.wl file2.wl          # Multiple files
 
 ### Core (src/)
 - **Generato.wl** - Package loader
+- **Context.wl** - Context-based state management (CreateContext, GetCtx, SetCtx, UpdateCtx, WithContext)
 - **Basic.wl** - Config state, tensor utilities, SetEQN/SetEQNDelayed
 - **ParseMode.wl** - Mode management (SetComp/PrintComp phases)
 - **Component.wl** - Tensor component to varlist index mapping
@@ -25,11 +26,41 @@ Generato file1.wl file2.wl          # Multiple files
 - **stencils/FiniteDifferenceStencils.wl** - FD stencils for orders 2-12
 
 ### Backends (codes/)
-Each implements PrintComponentInitialization and PrintComponentEquation:
+Each implements `PrintComponentInitialization[ctx, varinfo, compname]` and `PrintComponentEquation[ctx, coordinate, compname, extrareplacerules]`:
 - **CarpetX.wl**, **CarpetXGPU.wl**, **CarpetXPointDesc.wl** - CarpetX variants
 - **Carpet.wl** - Original Carpet framework
 - **AMReX.wl** - AMReX library
 - **Nmesh.wl** - Structured mesh (C output)
+
+Common backend code is in `BackendCommon.wl`.
+
+### Context-Based State Management
+
+All state is encapsulated in a `GeneratoContext` association. Functions take context as first parameter.
+
+```wolfram
+ctx = CreateContext[];
+ctx = SetGridPointIndex[ctx, "[[ijk]]"];
+```
+
+### Two-Phase Processing
+
+Code generation uses explicit phases:
+
+1. **SetComp Phase**: Maps tensor components to varlist indices
+```wolfram
+ctx = WithSetCompPhase[ctx,
+  SetComponents[ctx, {}, varlist]
+];
+```
+
+2. **PrintComp Phase**: Generates C/C++ code
+```wolfram
+ctx = WithPrintCompPhase[ctx,
+  PrintInitializations[ctx, {Mode -> "MainOut"}, varlist];
+  PrintEquations[ctx, {Mode -> "Temp"}, varlist];
+];
+```
 
 ## Tests
 

--- a/codes/Carpet.wl
+++ b/codes/Carpet.wl
@@ -9,14 +9,7 @@
 (*                    Finite difference stencil function                      *)
 (******************************************************************************)
 
-(* Function to get GF index name - GetGFIndexName is now in BackendCommon.wl *)
-
-GetGFIndexNameMix2nd[index1_?IntegerQ, index2_?IntegerQ] :=
-  Module[{gfindex},
-    gfindex = ToString[GetGFIndexName[index1]]
-           <> ToString[GetGFIndexName[index2]];
-    ToExpression[gfindex]
-  ];
+(* GetGFIndexName and GetGFIndexNameMix2nd are now in BackendCommon.wl *)
 
 (* Function to print 3D indexes *)
 
@@ -152,51 +145,35 @@ PrintFDExpressionMix2nd[accuracyOrd_?IntegerQ, strIdx_?StringQ] :=
   ];
 
 
-(******************************************************************************)
-(*                               Misc functions                               *)
-(******************************************************************************)
-
-(* Function to get variable name in interface.ccl *)
-
-GetInterfaceName[compname_] :=
-  Module[{intfname = ToString[compname[[0]]], colist = {"t", "x", "y", "z"}},
-    Do[
-      coindex = compname[[icomp]][[1]];
-      intfname = intfname <> colist[[coindex + 1]]
-      ,
-      {icomp, 1, Length[compname]}
-    ];
-    intfname = ToString[CForm[ToExpression[intfname <> GetGridPointIndex[]]]];
-    Return[intfname];
-  ];
+(* GetInterfaceName is now in BackendCommon.wl *)
 
 
 (******************************************************************************)
 (*            Print initialization of each component of a tensor              *)
 (******************************************************************************)
 
-PrintComponentInitialization[varinfo_, compname_] :=
+PrintComponentInitialization[ctx_Association, varinfo_, compname_] :=
   Module[{varlistindex, compToValue, varname, symmetry, buf, subbuf, len,
           fdorder, fdaccuracy},
-    varlistindex = GetMapComponentToVarlist[][compname];
+    varlistindex = GetMapComponentToVarlist[ctx][compname];
     compToValue = compname // ToValues;
     {varname, symmetry} = varinfo;
     len = Length[varname];
 
     (* set subbuf *)
     subbuf = If[len == 0, "", "[" <> ToString[varlistindex] <> "]"];
-    fdorder = GetDerivsOrder[];
-    fdaccuracy = GetDerivsAccuracy[];
+    fdorder = GetDerivsOrder[ctx];
+    fdaccuracy = GetDerivsAccuracy[ctx];
 
     (* set buf *)
     buf =
       Which[
-        GetInitializationsMode[] === "MainIn" || GetInitializationsMode[] === "MainOut",
+        GetInitializationsMode[ctx] === "MainIn" || GetInitializationsMode[ctx] === "MainOut",
           "const auto &"
-          <> StringTrim[ToString[compToValue], GetGridPointIndex[]]
+          <> StringTrim[ToString[compToValue], GetGridPointIndex[ctx]]
           <> " = gf_" <> StringTrim[ToString[varname[[0]]]] <> subbuf <> ";"
         ,
-        GetInitializationsMode[] === "Derivs",
+        GetInitializationsMode[ctx] === "Derivs",
           offset = fdorder - 1;
           "const auto " <> ToString[compToValue]
           <> " = calcderivs" <> ToString[fdorder] <> "_"
@@ -208,7 +185,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
           <> ", i, j, k);"
         ,
         (*
-        GetInitializationsMode[] === "Derivs",
+        GetInitializationsMode[ctx] === "Derivs",
           offset = fdorder - 1;
           "const auto " <> ToString[compToValue]
           <> " = fd_" <> ToString[fdorder] <> "_o" <> ToString[fdaccuracy]
@@ -221,7 +198,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
           <> ", i, j, k, invDxyz);"
         ,
         *)
-        GetInitializationsMode[] === "Temp",
+        GetInitializationsMode[ctx] === "Temp",
           buf = "auto " <> ToString[compToValue] <> ";"
         ,
         True,
@@ -230,11 +207,7 @@ PrintComponentInitialization[varinfo_, compname_] :=
     pr[buf];
   ];
 
-PrintComponentInitialization::EMode =
-  "PrintComponentInitialization mode unrecognized!";
-
-PrintComponentInitialization::EVarLength =
-  "PrintComponentInitialization variable's tensor type unsupported!";
+(* Error messages PrintComponentInitialization::EMode and ::EVarLength are in BackendCommon.wl *)
 
 Protect[PrintComponentInitialization];
 
@@ -247,50 +220,35 @@ Protect[PrintComponentInitialization];
  *        introduced to replace say coordinates representation of metric.
  *)
 
-PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
-  Module[{outputfile = GetOutputFile[], compToValue, rhssToValue},
+PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
+  Module[{outputfile = GetOutputFile[ctx], compToValue, rhssToValue},
     compToValue = compname // ToValues;
-    rhssToValue =
-      (compname /. {compname[[0]] -> RHSOf[compname[[0]], GetSuffixName[]]}) //
-      DummyToBasis[coordinate] // TraceBasisDummy // ToValues;
-    If[GetSimplifyEquation[],
-      rhssToValue = rhssToValue // Simplify
-    ];
-    If[Length[extrareplacerules] > 0,
-      rhssToValue = (rhssToValue // ToValues) /. extrareplacerules
-    ];
-    Which[
-      GetEquationsMode[] === "Temp",
-        Module[{},
-          Global`pr["const " <> GetTempVariableType[] <> " "];
-          PutAppend[CForm[compToValue], outputfile];
-          Global`pr["="];
-          PutAppend[CForm[rhssToValue], outputfile];
-          Global`pr[";\n"]
-        ]
-      ,
-      GetEquationsMode[] === "MainOut",
-        Module[{},
-          PutAppend[CForm[compToValue], outputfile];
-          Global`pr["="];
-          PutAppend[CForm[rhssToValue], outputfile];
-          Global`pr[";\n"]
-        ]
-      ,
-      GetEquationsMode[] === "AddToMainOut",
-        Module[{},
-          PutAppend[CForm[compToValue], outputfile];
-          Global`pr["+="];
-          PutAppend[CForm[rhssToValue], outputfile];
-          Global`pr[";\n"]
-        ]
-      ,
-      True,
-        Throw @ Message[PrintComponentEquation::EMode]
+    rhssToValue = ComputeRHSValue[ctx, coordinate, compname, extrareplacerules];
+    PrintEquationByMode[ctx, compToValue, rhssToValue,
+      (* MainOut formatter - standard assignment *)
+      Function[{comp, rhs},
+        PutAppend[CForm[comp], outputfile];
+        Global`pr["="];
+        PutAppend[CForm[rhs], outputfile];
+        Global`pr[";\n"]
+      ],
+      (* Temp formatter - Carpet specific: const prefix *)
+      Function[{comp, rhs},
+        Global`pr["const " <> GetTempVariableType[ctx] <> " "];
+        PutAppend[CForm[comp], outputfile];
+        Global`pr["="];
+        PutAppend[CForm[rhs], outputfile];
+        Global`pr[";\n"]
+      ]
     ]
   ];
 
-PrintComponentEquation::EMode = "PrintEquationMode unrecognized!";
+(* Backwards compat: old 3-argument signature *)
+PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
+  Module[{},
+    SyncModeToContext[];
+    PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
+  ];
 
 Protect[PrintComponentEquation];
 

--- a/src/BackendCommon.wl
+++ b/src/BackendCommon.wl
@@ -4,6 +4,7 @@
 
 BeginPackage["Generato`BackendCommon`"];
 
+Needs["Generato`Context`"];
 Needs["Generato`Basic`"];
 Needs["Generato`ParseMode`"];
 Needs["Generato`Component`"];
@@ -15,8 +16,11 @@ If[Environment["QUIET"] =!= "1",
 ];
 
 GetGFIndexName::usage = "GetGFIndexName[index] converts integer index to GF index name (p1, m1, c0, etc.).";
+GetGFIndexNameMix2nd::usage = "GetGFIndexNameMix2nd[index1, index2] creates mixed 2nd derivative GF index name.";
+GetInterfaceName::usage = "GetInterfaceName[compname] returns the interface name for a component.";
 ComputeRHSValue::usage = "ComputeRHSValue[coordinate, compname, extrareplacerules] computes the RHS value for an equation.";
-PrintEquationByMode::usage = "PrintEquationByMode[compToValue, rhssToValue, mainFormatter] prints equation based on current EquationsMode.";
+PrintEquationByMode::usage = "PrintEquationByMode[compToValue, rhssToValue, mainFormatter, tempFormatter] prints equation based on current EquationsMode. tempFormatter is optional (defaults to Automatic for standard Temp output).";
+GetTensorIndexSubbuf::usage = "GetTensorIndexSubbuf[len, varlistindex] computes subbuf string for tensor component indexing.";
 
 Begin["`Private`"];
 
@@ -38,15 +42,49 @@ GetGFIndexName[index_?IntegerQ] :=
 Protect[GetGFIndexName];
 
 (*
+  GetGFIndexNameMix2nd - Creates mixed 2nd derivative GF index name
+  Previously duplicated in: Carpet.wl, CarpetXGPU.wl, CarpetXPointDesc.wl
+*)
+GetGFIndexNameMix2nd[index1_?IntegerQ, index2_?IntegerQ] :=
+  Module[{gfindex},
+    gfindex = ToString[GetGFIndexName[index1]]
+           <> ToString[GetGFIndexName[index2]];
+    ToExpression[gfindex]
+  ];
+
+Protect[GetGFIndexNameMix2nd];
+
+(*
+  GetInterfaceName - Returns the interface name for a component
+  Previously duplicated in: Carpet.wl, CarpetXGPU.wl, CarpetXPointDesc.wl
+*)
+GetInterfaceName[ctx_Association, compname_] :=
+  Module[{intfname = ToString[compname[[0]]], colist = {"t", "x", "y", "z"}},
+    Do[
+      coindex = compname[[icomp]][[1]];
+      intfname = intfname <> colist[[coindex + 1]]
+      ,
+      {icomp, 1, Length[compname]}
+    ];
+    intfname = ToString[CForm[ToExpression[intfname <> GetGridPointIndex[ctx]]]];
+    Return[intfname];
+  ];
+
+(* Backwards compat *)
+GetInterfaceName[compname_] := GetInterfaceName[$CurrentContext, compname];
+
+Protect[GetInterfaceName];
+
+(*
   ComputeRHSValue - Computes the RHS value for an equation
   Previously duplicated in all 6 backends
 *)
-ComputeRHSValue[coordinate_, compname_, extrareplacerules_] :=
+ComputeRHSValue[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
   Module[{rhssToValue},
     rhssToValue =
-      (compname /. {compname[[0]] -> RHSOf[compname[[0]], GetSuffixName[]]}) //
+      (compname /. {compname[[0]] -> RHSOf[compname[[0]], GetSuffixName[ctx]]}) //
       DummyToBasis[coordinate] // TraceBasisDummy // ToValues;
-    If[GetSimplifyEquation[],
+    If[GetSimplifyEquation[ctx],
       rhssToValue = rhssToValue // Simplify
     ];
     If[Length[extrareplacerules] > 0,
@@ -55,44 +93,128 @@ ComputeRHSValue[coordinate_, compname_, extrareplacerules_] :=
     rhssToValue
   ];
 
+(* Backwards compat *)
+ComputeRHSValue[coordinate_, compname_, extrareplacerules_] :=
+  ComputeRHSValue[$CurrentContext, coordinate, compname, extrareplacerules];
+
 Protect[ComputeRHSValue];
 
 (*
   PrintEquationByMode - Prints equation based on current EquationsMode
-  mainFormatter is a function that takes (compToValue, rhssToValue) and prints the Main mode output
-  This handles the common Temp and AddToMainOut cases; backends provide custom Main formatting
+
+  Calling conventions:
+  1. PrintEquationByMode[ctx, compToValue, rhssToValue, mainFormatter] - callback for MainOut,
+     default Temp (no const, CForm[compToValue]), shared AddToMainOut
+  2. PrintEquationByMode[ctx, compToValue, rhssToValue, mainFormatter, tempFormatter] - callbacks
+     for both MainOut and Temp, shared AddToMainOut
+
+  The tempFormatter function takes (compToValue, rhssToValue) and prints the Temp mode output.
+  If tempFormatter is Automatic (default), uses standard: GetTempVariableType[ctx] + CForm[compToValue]
 *)
-PrintEquationByMode[compToValue_, rhssToValue_, mainFormatter_] :=
-  Module[{outputfile = GetOutputFile[]},
+PrintEquationByMode[ctx_Association, compToValue_, rhssToValue_, mainFormatter_] :=
+  PrintEquationByMode[ctx, compToValue, rhssToValue, mainFormatter, Automatic];
+
+PrintEquationByMode[ctx_Association, compToValue_, rhssToValue_, mainFormatter_, tempFormatter_] :=
+  Module[{outputfile = GetOutputFile[ctx]},
     Which[
-      GetEquationsMode[] === "Temp",
-        Module[{},
-          Global`pr[GetTempVariableType[] <> " "];
+      GetEquationsMode[ctx] === "Temp",
+        If[tempFormatter === Automatic,
+          (* Default Temp handling: no const prefix, CForm[compToValue] *)
+          Global`pr[GetTempVariableType[ctx] <> " "];
           PutAppend[CForm[compToValue], outputfile];
           Global`pr["="];
           PutAppend[CForm[rhssToValue], outputfile];
           Global`pr[";\n"]
+          ,
+          (* Custom Temp handling via callback *)
+          tempFormatter[compToValue, rhssToValue]
         ]
       ,
-      GetEquationsMode[] === "MainOut",
+      GetEquationsMode[ctx] === "MainOut",
         mainFormatter[compToValue, rhssToValue]
       ,
-      GetEquationsMode[] === "AddToMainOut",
-        Module[{},
-          PutAppend[CForm[compToValue], outputfile];
-          Global`pr["+="];
-          PutAppend[CForm[rhssToValue], outputfile];
-          Global`pr[";\n"]
-        ]
+      GetEquationsMode[ctx] === "AddToMainOut",
+        (* Shared AddToMainOut - identical across all backends *)
+        PutAppend[CForm[compToValue], outputfile];
+        Global`pr["+="];
+        PutAppend[CForm[rhssToValue], outputfile];
+        Global`pr[";\n"]
       ,
       True,
         Throw @ Message[PrintEquationByMode::EMode]
     ]
   ];
 
+(* Backwards compat *)
+PrintEquationByMode[compToValue_, rhssToValue_, mainFormatter_] :=
+  PrintEquationByMode[$CurrentContext, compToValue, rhssToValue, mainFormatter, Automatic];
+
+PrintEquationByMode[compToValue_, rhssToValue_, mainFormatter_, tempFormatter_] :=
+  PrintEquationByMode[$CurrentContext, compToValue, rhssToValue, mainFormatter, tempFormatter];
+
 PrintEquationByMode::EMode = "PrintEquationByMode: EquationsMode unrecognized!";
 
 Protect[PrintEquationByMode];
+
+(*
+  GetTensorIndexSubbuf - Computes subbuf string for tensor component indexing
+  This handles the common Scal/Vect/Smat pattern using varlistindex with
+  bracket notation. Used by backends like CarpetXGPU and AMReX.
+  Note: Some backends (CarpetX, Nmesh) have different indexing schemes
+  and do not use this function.
+
+  For "Scal" TensorType, any tensor length is handled with simple [varlistindex]
+  because TensorType=Scal means each component is treated as independent scalar.
+*)
+GetTensorIndexSubbuf[ctx_Association, len_Integer, varlistindex_Integer] :=
+  Module[{tensorType = GetTensorType[ctx]},
+    Which[
+      tensorType === "Scal",
+        (* Scal treats all components as independent scalars *)
+        If[len == 0, "", "[" <> ToString[varlistindex] <> "]"],
+      tensorType === "Vect",
+        Which[
+          len == 1, "[" <> ToString[varlistindex] <> "]",
+          len == 2,
+            "[" <> ToString[Quotient[varlistindex, 3]] <> "]["
+                <> ToString[Mod[varlistindex, 3]] <> "]",
+          len == 3,
+            "[" <> ToString[Quotient[varlistindex, 3]] <> "]["
+                <> ToString[Mod[varlistindex, 3]] <> "]",
+          True, Message[GetTensorIndexSubbuf::ELength]; ""
+        ],
+      tensorType === "Smat",
+        Which[
+          len == 2, "[" <> ToString[varlistindex] <> "]",
+          len == 3,
+            "[" <> ToString[Quotient[varlistindex, 6]] <> "]["
+                <> ToString[Mod[varlistindex, 6]] <> "]",
+          len == 4,
+            "[" <> ToString[Quotient[varlistindex, 6]] <> "]["
+                <> ToString[Mod[varlistindex, 6]] <> "]",
+          True, Message[GetTensorIndexSubbuf::ELength]; ""
+        ],
+      True,
+        Message[GetTensorIndexSubbuf::ETensorType]; ""
+    ]
+  ];
+
+(* Backwards compat *)
+GetTensorIndexSubbuf[len_Integer, varlistindex_Integer] :=
+  GetTensorIndexSubbuf[$CurrentContext, len, varlistindex];
+
+GetTensorIndexSubbuf::ELength = "GetTensorIndexSubbuf: Unsupported tensor rank for tensor type.";
+GetTensorIndexSubbuf::ETensorType = "GetTensorIndexSubbuf: Unknown tensor type.";
+
+Protect[GetTensorIndexSubbuf];
+
+(*
+  Standard backend error messages - shared by all backends
+  Previously duplicated in: CarpetX.wl, CarpetXGPU.wl, CarpetXPointDesc.wl,
+  Carpet.wl, AMReX.wl, Nmesh.wl
+*)
+PrintComponentInitialization::EMode = "PrintComponentInitialization mode unrecognized!";
+PrintComponentInitialization::EVarLength = "PrintComponentInitialization variable's tensor type unsupported!";
 
 End[];
 

--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -8,10 +8,10 @@
 
 If[Environment["QUIET"] === "1",
   Block[{Print},
-    BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`"}]
+    BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`", "Generato`Context`"}]
   ]
   ,
-  BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`"}]
+  BeginPackage["Generato`Basic`", {"xAct`xTensor`", "xAct`xCoba`", "Generato`Context`"}]
 ];
 
 If[Environment["QUIET"] =!= "1",
@@ -106,11 +106,19 @@ $Project = "TEST";
 
 (* Function *)
 
-GetCheckInputEquations[] :=
-  Return[$CheckInputEquations];
+(* Context-aware getter *)
+GetCheckInputEquations[ctx_Association] := GetCtx[ctx, "CheckInputEquations"];
+
+(* Global getter - uses current context *)
+GetCheckInputEquations[] := $CheckInputEquations;
 
 Protect[GetCheckInputEquations];
 
+(* Context-aware setter - returns new context *)
+SetCheckInputEquations[ctx_Association, checkinput_] :=
+  SetCtx[ctx, "CheckInputEquations", checkinput];
+
+(* Global setter - mutates global variable *)
 SetCheckInputEquations[checkinput_] :=
   Module[{},
     $CheckInputEquations = checkinput
@@ -118,11 +126,19 @@ SetCheckInputEquations[checkinput_] :=
 
 Protect[SetCheckInputEquations];
 
-GetPVerbose[] :=
-  Return[$PVerbose];
+(* Context-aware getter *)
+GetPVerbose[ctx_Association] := GetCtx[ctx, "PVerbose"];
+
+(* Global getter - uses current context *)
+GetPVerbose[] := $PVerbose;
 
 Protect[GetPVerbose];
 
+(* Context-aware setter - returns new context *)
+SetPVerbose[ctx_Association, verbose_] :=
+  SetCtx[ctx, "PVerbose", verbose];
+
+(* Global setter - mutates global variable *)
 SetPVerbose[verbose_] :=
   Module[{},
     $PVerbose = verbose
@@ -130,11 +146,19 @@ SetPVerbose[verbose_] :=
 
 Protect[SetPVerbose];
 
-GetPrintDate[] :=
-  Return[$PrintDate];
+(* Context-aware getter *)
+GetPrintDate[ctx_Association] := GetCtx[ctx, "PrintDate"];
+
+(* Global getter - uses current context *)
+GetPrintDate[] := $PrintDate;
 
 Protect[GetPrintDate];
 
+(* Context-aware setter - returns new context *)
+SetPrintDate[ctx_Association, print_] :=
+  SetCtx[ctx, "PrintDate", print];
+
+(* Global setter - mutates global variable *)
 SetPrintDate[print_] :=
   Module[{},
     $PrintDate = print
@@ -142,11 +166,19 @@ SetPrintDate[print_] :=
 
 Protect[SetPrintDate];
 
-GetPrintHeaderMacro[] :=
-  Return[$PrintHeaderMacro];
+(* Context-aware getter *)
+GetPrintHeaderMacro[ctx_Association] := GetCtx[ctx, "PrintHeaderMacro"];
+
+(* Global getter - uses current context *)
+GetPrintHeaderMacro[] := $PrintHeaderMacro;
 
 Protect[GetPrintHeaderMacro];
 
+(* Context-aware setter - returns new context *)
+SetPrintHeaderMacro[ctx_Association, print_] :=
+  SetCtx[ctx, "PrintHeaderMacro", print];
+
+(* Global setter - mutates global variable *)
 SetPrintHeaderMacro[print_] :=
   Module[{},
     $PrintHeaderMacro = print
@@ -154,11 +186,19 @@ SetPrintHeaderMacro[print_] :=
 
 Protect[SetPrintHeaderMacro];
 
-GetGridPointIndex[] :=
-  Return[$GridPointIndex];
+(* Context-aware getter *)
+GetGridPointIndex[ctx_Association] := GetCtx[ctx, "GridPointIndex"];
+
+(* Global getter - uses current context *)
+GetGridPointIndex[] := $GridPointIndex;
 
 Protect[GetGridPointIndex];
 
+(* Context-aware setter - returns new context *)
+SetGridPointIndex[ctx_Association, gridindex_] :=
+  SetCtx[ctx, "GridPointIndex", gridindex];
+
+(* Global setter - mutates global variable *)
 SetGridPointIndex[gridindex_] :=
   Module[{},
     $GridPointIndex = gridindex
@@ -166,11 +206,19 @@ SetGridPointIndex[gridindex_] :=
 
 Protect[SetGridPointIndex];
 
-GetTilePointIndex[] :=
-  Return[$TilePointIndex];
+(* Context-aware getter *)
+GetTilePointIndex[ctx_Association] := GetCtx[ctx, "TilePointIndex"];
+
+(* Global getter - uses current context *)
+GetTilePointIndex[] := $TilePointIndex;
 
 Protect[GetTilePointIndex];
 
+(* Context-aware setter - returns new context *)
+SetTilePointIndex[ctx_Association, tileindex_] :=
+  SetCtx[ctx, "TilePointIndex", tileindex];
+
+(* Global setter - mutates global variable *)
 SetTilePointIndex[tileindex_] :=
   Module[{},
     $TilePointIndex = tileindex
@@ -178,11 +226,19 @@ SetTilePointIndex[tileindex_] :=
 
 Protect[SetTilePointIndex];
 
-GetSuffixUnprotected[] :=
-  Return[$SuffixUnprotected];
+(* Context-aware getter *)
+GetSuffixUnprotected[ctx_Association] := GetCtx[ctx, "SuffixUnprotected"];
+
+(* Global getter - uses current context *)
+GetSuffixUnprotected[] := $SuffixUnprotected;
 
 Protect[GetSuffixUnprotected];
 
+(* Context-aware setter - returns new context *)
+SetSuffixUnprotected[ctx_Association, suffix_] :=
+  SetCtx[ctx, "SuffixUnprotected", suffix];
+
+(* Global setter - mutates global variable *)
 SetSuffixUnprotected[suffix_] :=
   Module[{},
     $SuffixUnprotected = suffix
@@ -190,11 +246,19 @@ SetSuffixUnprotected[suffix_] :=
 
 Protect[SetSuffixUnprotected];
 
-GetOutputFile[] :=
-  Return[$OutputFile];
+(* Context-aware getter *)
+GetOutputFile[ctx_Association] := GetCtx[ctx, "OutputFile"];
+
+(* Global getter - uses current context *)
+GetOutputFile[] := $OutputFile;
 
 Protect[GetOutputFile];
 
+(* Context-aware setter - returns new context *)
+SetOutputFile[ctx_Association, filename_] :=
+  SetCtx[ctx, "OutputFile", filename];
+
+(* Global setter - mutates global variable *)
 SetOutputFile[filename_] :=
   Module[{},
     $OutputFile = filename
@@ -202,11 +266,19 @@ SetOutputFile[filename_] :=
 
 Protect[SetOutputFile];
 
-GetProject[] :=
-  Return[$Project];
+(* Context-aware getter *)
+GetProject[ctx_Association] := GetCtx[ctx, "Project"];
+
+(* Global getter - uses current context *)
+GetProject[] := $Project;
 
 Protect[GetProject];
 
+(* Context-aware setter - returns new context *)
+SetProject[ctx_Association, name_] :=
+  SetCtx[ctx, "Project", name];
+
+(* Global setter - mutates global variable *)
 SetProject[name_] :=
   Module[{},
     $Project = name

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -2,7 +2,7 @@
 
 (* (c) Liwei Ji, 01/2024 *)
 
-BeginPackage["Generato`Component`"];
+BeginPackage["Generato`Component`", {"Generato`Context`"}];
 
 Needs["Generato`Basic`"];
 
@@ -14,31 +14,37 @@ If[Environment["QUIET"] =!= "1",
   System`Print["------------------------------------------------------------"];
 ];
 
-GetMapComponentToVarlist::usage = "GetMapComponentToVarlist[] returns the Association mapping tensor components to varlist indices.";
+GetMapComponentToVarlist::usage = "GetMapComponentToVarlist[ctx] returns the Association mapping tensor components to varlist indices from context.\nGetMapComponentToVarlist[] returns the mapping from global state.";
 
-SetProcessNewVarlist::usage = "SetProcessNewVarlist[bool] sets whether the next varlist is treated as a new varlist for index numbering.";
+SetMapComponentToVarlist::usage = "SetMapComponentToVarlist[ctx, map] returns new context with updated mapping.\nSetMapComponentToVarlist[map] sets the mapping in global state.";
 
-GetSimplifyEquation::usage = "GetSimplifyEquation[] returns True if equations are simplified before output.";
+GetProcessNewVarlist::usage = "GetProcessNewVarlist[ctx] returns ProcessNewVarlist flag from context.\nGetProcessNewVarlist[] returns the flag from global state.";
 
-SetSimplifyEquation::usage = "SetSimplifyEquation[bool] enables or disables simplification of equations before output.";
+SetProcessNewVarlist::usage = "SetProcessNewVarlist[ctx, bool] returns new context with updated flag.\nSetProcessNewVarlist[bool] sets whether the next varlist is treated as a new varlist for index numbering.";
 
-GetUseLetterForTensorComponent::usage = "GetUseLetterForTensorComponent[] returns True if letters are used for tensor component indices instead of numbers.";
+GetSimplifyEquation::usage = "GetSimplifyEquation[ctx] returns SimplifyEquation flag from context.\nGetSimplifyEquation[] returns True if equations are simplified before output.";
 
-SetUseLetterForTensorComponent::usage = "SetUseLetterForTensorComponent[bool] sets whether to use letters for tensor component indices instead of numbers.";
+SetSimplifyEquation::usage = "SetSimplifyEquation[ctx, bool] returns new context with updated flag.\nSetSimplifyEquation[bool] enables or disables simplification of equations before output.";
 
-GetTempVariableType::usage = "GetTempVariableType[] returns the C type string used for temporary variables.";
+GetUseLetterForTensorComponent::usage = "GetUseLetterForTensorComponent[ctx] returns UseLetterForTensorComponent flag from context.\nGetUseLetterForTensorComponent[] returns True if letters are used for tensor component indices instead of numbers.";
 
-SetTempVariableType::usage = "SetTempVariableType[type] sets the C type string used for temporary variables.";
+SetUseLetterForTensorComponent::usage = "SetUseLetterForTensorComponent[ctx, bool] returns new context with updated flag.\nSetUseLetterForTensorComponent[bool] sets whether to use letters for tensor component indices instead of numbers.";
 
-GetInterfaceWithNonCoordBasis::usage = "GetInterfaceWithNonCoordBasis[] returns True if interfacing with non-coordinate basis tensors.";
+GetTempVariableType::usage = "GetTempVariableType[ctx] returns TempVariableType from context.\nGetTempVariableType[] returns the C type string used for temporary variables.";
 
-SetInterfaceWithNonCoordBasis::usage = "SetInterfaceWithNonCoordBasis[bool] enables or disables interfacing with non-coordinate basis tensors.";
+SetTempVariableType::usage = "SetTempVariableType[ctx, type] returns new context with updated type.\nSetTempVariableType[type] sets the C type string used for temporary variables.";
 
-GetSuffixName::usage = "GetSuffixName[] returns the suffix appended to variable names in the current varlist.";
+GetInterfaceWithNonCoordBasis::usage = "GetInterfaceWithNonCoordBasis[ctx] returns InterfaceWithNonCoordBasis flag from context.\nGetInterfaceWithNonCoordBasis[] returns True if interfacing with non-coordinate basis tensors.";
 
-SetSuffixName::usage = "SetSuffixName[suffix] sets the suffix appended to variable names in the current varlist.";
+SetInterfaceWithNonCoordBasis::usage = "SetInterfaceWithNonCoordBasis[ctx, bool] returns new context with updated flag.\nSetInterfaceWithNonCoordBasis[bool] enables or disables interfacing with non-coordinate basis tensors.";
 
-GetPrefixDt::usage = "GetPrefixDt[] returns the prefix used for time derivatives of variables.";
+GetSuffixName::usage = "GetSuffixName[ctx] returns SuffixName from context.\nGetSuffixName[] returns the suffix appended to variable names in the current varlist.";
+
+SetSuffixName::usage = "SetSuffixName[ctx, suffix] returns new context with updated suffix.\nSetSuffixName[suffix] sets the suffix appended to variable names in the current varlist.";
+
+GetPrefixDt::usage = "GetPrefixDt[ctx] returns PrefixDt from context.\nGetPrefixDt[] returns the prefix used for time derivatives of variables.";
+
+SetPrefixDt::usage = "SetPrefixDt[ctx, prefix] returns new context with updated prefix.\nSetPrefixDt[prefix] sets the prefix used for time derivatives of variables.";
 
 ParseComponent::usage = "ParseComponent[varinfo, compindexlist, coordinate, extrareplacerules] processes a single tensor component for setting or printing.";
 
@@ -66,19 +72,39 @@ $PrefixDt = "dt";
 
 (* Function *)
 
-GetMapComponentToVarlist[] :=
-  Return[$MapComponentToVarlist];
+(* Context-aware getter *)
+GetMapComponentToVarlist[ctx_Association] := GetCtx[ctx, "MapComponentToVarlist"];
+
+(* Global getter - uses global variable *)
+GetMapComponentToVarlist[] := $MapComponentToVarlist;
 
 Protect[GetMapComponentToVarlist];
 
+(* Context-aware setter - returns new context *)
+SetMapComponentToVarlist[ctx_Association, map_] :=
+  SetCtx[ctx, "MapComponentToVarlist", map];
+
+(* Global setter - mutates global variable *)
 SetMapComponentToVarlist[map_] :=
   Module[{},
     $MapComponentToVarlist = map
   ];
 
-GetProcessNewVarlist[] :=
-  Return[$ProcessNewVarlist];
+Protect[SetMapComponentToVarlist];
 
+(* Context-aware getter *)
+GetProcessNewVarlist[ctx_Association] := GetCtx[ctx, "ProcessNewVarlist"];
+
+(* Global getter - uses global variable *)
+GetProcessNewVarlist[] := $ProcessNewVarlist;
+
+Protect[GetProcessNewVarlist];
+
+(* Context-aware setter - returns new context *)
+SetProcessNewVarlist[ctx_Association, isnew_] :=
+  SetCtx[ctx, "ProcessNewVarlist", isnew];
+
+(* Global setter - mutates global variable *)
 SetProcessNewVarlist[isnew_] :=
   Module[{},
     $ProcessNewVarlist = isnew
@@ -86,11 +112,19 @@ SetProcessNewVarlist[isnew_] :=
 
 Protect[SetProcessNewVarlist];
 
-GetSimplifyEquation[] :=
-  Return[$SimplifyEquation];
+(* Context-aware getter *)
+GetSimplifyEquation[ctx_Association] := GetCtx[ctx, "SimplifyEquation"];
+
+(* Global getter - uses global variable *)
+GetSimplifyEquation[] := $SimplifyEquation;
 
 Protect[GetSimplifyEquation];
 
+(* Context-aware setter - returns new context *)
+SetSimplifyEquation[ctx_Association, simplify_] :=
+  SetCtx[ctx, "SimplifyEquation", simplify];
+
+(* Global setter - mutates global variable *)
 SetSimplifyEquation[simplify_] :=
   Module[{},
     $SimplifyEquation = simplify
@@ -98,11 +132,19 @@ SetSimplifyEquation[simplify_] :=
 
 Protect[SetSimplifyEquation];
 
-GetUseLetterForTensorComponent[] :=
-  Return[$UseLetterForTensorComponent];
+(* Context-aware getter *)
+GetUseLetterForTensorComponent[ctx_Association] := GetCtx[ctx, "UseLetterForTensorComponent"];
+
+(* Global getter - uses global variable *)
+GetUseLetterForTensorComponent[] := $UseLetterForTensorComponent;
 
 Protect[GetUseLetterForTensorComponent];
 
+(* Context-aware setter - returns new context *)
+SetUseLetterForTensorComponent[ctx_Association, useletter_] :=
+  SetCtx[ctx, "UseLetterForTensorComponent", useletter];
+
+(* Global setter - mutates global variable *)
 SetUseLetterForTensorComponent[useletter_] :=
   Module[{},
     $UseLetterForTensorComponent = useletter
@@ -110,11 +152,19 @@ SetUseLetterForTensorComponent[useletter_] :=
 
 Protect[SetUseLetterForTensorComponent];
 
-GetTempVariableType[] :=
-  Return[$TempVariableType];
+(* Context-aware getter *)
+GetTempVariableType[ctx_Association] := GetCtx[ctx, "TempVariableType"];
+
+(* Global getter - uses global variable *)
+GetTempVariableType[] := $TempVariableType;
 
 Protect[GetTempVariableType];
 
+(* Context-aware setter - returns new context *)
+SetTempVariableType[ctx_Association, type_] :=
+  SetCtx[ctx, "TempVariableType", type];
+
+(* Global setter - mutates global variable *)
 SetTempVariableType[type_] :=
   Module[{},
     $TempVariableType = type
@@ -122,11 +172,19 @@ SetTempVariableType[type_] :=
 
 Protect[SetTempVariableType];
 
-GetInterfaceWithNonCoordBasis[] :=
-  Return[$InterfaceWithNonCoordBasis];
+(* Context-aware getter *)
+GetInterfaceWithNonCoordBasis[ctx_Association] := GetCtx[ctx, "InterfaceWithNonCoordBasis"];
+
+(* Global getter - uses global variable *)
+GetInterfaceWithNonCoordBasis[] := $InterfaceWithNonCoordBasis;
 
 Protect[GetInterfaceWithNonCoordBasis];
 
+(* Context-aware setter - returns new context *)
+SetInterfaceWithNonCoordBasis[ctx_Association, noncoordbasis_] :=
+  SetCtx[ctx, "InterfaceWithNonCoordBasis", noncoordbasis];
+
+(* Global setter - mutates global variable *)
 SetInterfaceWithNonCoordBasis[noncoordbasis_] :=
   Module[{},
     $InterfaceWithNonCoordBasis = noncoordbasis
@@ -134,11 +192,19 @@ SetInterfaceWithNonCoordBasis[noncoordbasis_] :=
 
 Protect[SetInterfaceWithNonCoordBasis];
 
-GetSuffixName[] :=
-  Return[$SuffixName];
+(* Context-aware getter *)
+GetSuffixName[ctx_Association] := GetCtx[ctx, "SuffixName"];
+
+(* Global getter - uses global variable *)
+GetSuffixName[] := $SuffixName;
 
 Protect[GetSuffixName];
 
+(* Context-aware setter - returns new context *)
+SetSuffixName[ctx_Association, suffix_] :=
+  SetCtx[ctx, "SuffixName", suffix];
+
+(* Global setter - mutates global variable *)
 SetSuffixName[suffix_] :=
   Module[{},
     $SuffixName = suffix
@@ -146,11 +212,19 @@ SetSuffixName[suffix_] :=
 
 Protect[SetSuffixName];
 
-GetPrefixDt[] :=
-  Return[$PrefixDt];
+(* Context-aware getter *)
+GetPrefixDt[ctx_Association] := GetCtx[ctx, "PrefixDt"];
+
+(* Global getter - uses global variable *)
+GetPrefixDt[] := $PrefixDt;
 
 Protect[GetPrefixDt];
 
+(* Context-aware setter - returns new context *)
+SetPrefixDt[ctx_Association, prefix_] :=
+  SetCtx[ctx, "PrefixDt", prefix];
+
+(* Global setter - mutates global variable *)
 SetPrefixDt[prefix_] :=
   Module[{},
     $PrefixDt = prefix
@@ -187,14 +261,16 @@ Protect[ParseComponent];
 
 PrintComponent[coordinate_, varinfo_, compname_, extrareplacerules_] :=
   Module[{},
+    (* Sync global state to $CurrentContext before calling backend *)
+    SyncModeToContext[];
     Which[
       InInitializationsMode[],
         PrintVerbose["    PrintComponentInitialization ", compname, "..."];
-        Global`PrintComponentInitialization[varinfo, compname]
+        Global`PrintComponentInitialization[$CurrentContext, varinfo, compname]
       ,
       InEquationsMode[],
         PrintVerbose["    PrintComponentEquation ", compname, "..."];
-        Global`PrintComponentEquation[coordinate, compname, extrareplacerules]
+        Global`PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
       ,
       True,
         Throw @ Message[PrintComponent::EMode]

--- a/src/Context.wl
+++ b/src/Context.wl
@@ -1,0 +1,89 @@
+(* ::Package:: *)
+
+(* Generato`Context`, context-based state management for Generato *)
+
+(* (c) Liwei Ji, 01/2026 *)
+
+BeginPackage["Generato`Context`"];
+
+CreateContext::usage = "CreateContext[] creates a new GeneratoContext with default values.\nCreateContext[overrides] creates a context with specified overrides.";
+
+GetCtx::usage = "GetCtx[ctx, key] gets a value from context.";
+
+SetCtx::usage = "SetCtx[ctx, key, value] returns new context with updated value.";
+
+UpdateCtx::usage = "UpdateCtx[ctx, updates] returns new context with multiple updates.\nUpdates can be an Association or a list of {key, value} pairs.";
+
+WithContext::usage = "WithContext[ctx, body] evaluates body with ctx as current context.";
+
+$CurrentContext::usage = "$CurrentContext is the global context for backwards compatibility during transition.";
+
+(* Default context values - mirrors current global defaults *)
+$ContextDefaults = <|
+  (* Basic.wl state *)
+  "CheckInputEquations" -> False,
+  "PVerbose" -> False,
+  "QuietMode" -> If[Environment["QUIET"] === "1", True, False],
+  "PrintDate" -> True,
+  "PrintHeaderMacro" -> True,
+  "GridPointIndex" -> "",
+  "TilePointIndex" -> "",
+  "SuffixUnprotected" -> "$Upt",
+  "OutputFile" -> "output.c",
+  "Project" -> "TEST",
+
+  (* ParseMode.wl state - flattened *)
+  "Phase" -> None,
+  "IndependentVarlistIndex" -> True,
+  "WithoutGridPointIndex" -> False,
+  "UseTilePointIndex" -> False,
+  "PrintCompType" -> None,
+  "InitializationsMode" -> None,
+  "TensorType" -> None,
+  "StorageType" -> None,
+  "DerivsOrder" -> 1,
+  "DerivsAccuracy" -> 4,
+  "EquationsMode" -> None,
+
+  (* Component.wl state *)
+  "MapComponentToVarlist" -> <||>,
+  "ProcessNewVarlist" -> True,
+  "SimplifyEquation" -> True,
+  "UseLetterForTensorComponent" -> False,
+  "TempVariableType" -> "double",
+  "InterfaceWithNonCoordBasis" -> False,
+  "SuffixName" -> "",
+  "PrefixDt" -> "dt",
+
+  (* Writefile.wl state *)
+  "MainPrint" -> Null
+|>;
+
+CreateContext[] := $ContextDefaults;
+
+CreateContext[overrides_Association] := Join[$ContextDefaults, overrides];
+
+GetCtx[ctx_Association, key_String] := ctx[key];
+
+SetCtx[ctx_Association, key_String, value_] := Append[ctx, key -> value];
+
+UpdateCtx[ctx_Association, updates_Association] := Join[ctx, updates];
+
+UpdateCtx[ctx_Association, updates_List] :=
+  Fold[SetCtx[#1, #2[[1]], #2[[2]]] &, ctx, updates];
+
+(* Global context for backwards compatibility during transition *)
+$CurrentContext = CreateContext[];
+
+SetAttributes[WithContext, HoldRest];
+
+WithContext[ctx_Association, body_] :=
+  Block[{$CurrentContext = ctx}, body];
+
+Begin["`Private`"];
+
+(* Private helper functions can go here if needed *)
+
+End[];
+
+EndPackage[];

--- a/src/Generato.wl
+++ b/src/Generato.wl
@@ -10,6 +10,8 @@
 
 (*****************)
 
+<<Context.wl
+
 <<Basic.wl
 
 <<ParseMode.wl

--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -2,7 +2,7 @@
 
 (* (c) Liwei Ji, 07/2024 *)
 
-BeginPackage["Generato`ParseMode`"];
+BeginPackage["Generato`ParseMode`", {"Generato`Context`"}];
 
 If[Environment["QUIET"] =!= "1",
   System`Print["------------------------------------------------------------"];
@@ -18,31 +18,47 @@ SetModes::usage = "SetModes[{path1 -> val1, path2 -> val2, ...}] sets multiple m
 WithMode::usage = "WithMode[settings, body] sets modes, evaluates body, then restores previous mode state.";
 
 (* Phase Helpers *)
-InSetCompPhase::usage = "InSetCompPhase[] returns True if in SetComp phase.";
-InPrintCompPhase::usage = "InPrintCompPhase[] returns True if in PrintComp phase.";
+GetPhase::usage = "GetPhase[ctx] returns phase from context.\nGetPhase[] returns current phase from global mode.";
+SetPhase::usage = "SetPhase[ctx, phase] returns new context with updated phase.";
+InSetCompPhase::usage = "InSetCompPhase[ctx] returns True if context is in SetComp phase.\nInSetCompPhase[] returns True if in SetComp phase.";
+InPrintCompPhase::usage = "InPrintCompPhase[ctx] returns True if context is in PrintComp phase.\nInPrintCompPhase[] returns True if in PrintComp phase.";
 
 (* PrintComp Type Helpers *)
-InInitializationsMode::usage = "InInitializationsMode[] returns True if in Initializations mode.";
-InEquationsMode::usage = "InEquationsMode[] returns True if in Equations mode.";
+GetPrintCompType::usage = "GetPrintCompType[ctx] returns print comp type from context.\nGetPrintCompType[] returns current print comp type.";
+SetPrintCompType::usage = "SetPrintCompType[ctx, type] returns new context with updated print comp type.";
+InInitializationsMode::usage = "InInitializationsMode[ctx] returns True if context is in Initializations mode.\nInInitializationsMode[] returns True if in Initializations mode.";
+InEquationsMode::usage = "InEquationsMode[ctx] returns True if context is in Equations mode.\nInEquationsMode[] returns True if in Equations mode.";
 
 (* Initializations Mode Helpers *)
-GetInitializationsMode::usage = "GetInitializationsMode[] returns current initialization mode.";
-GetTensorType::usage = "GetTensorType[] returns current tensor type.";
-GetStorageType::usage = "GetStorageType[] returns current storage type.";
-GetDerivsOrder::usage = "GetDerivsOrder[] returns derivative order.";
-GetDerivsAccuracy::usage = "GetDerivsAccuracy[] returns derivative accuracy.";
+GetInitializationsMode::usage = "GetInitializationsMode[ctx] returns initialization mode from context.\nGetInitializationsMode[] returns current initialization mode.";
+SetInitializationsMode::usage = "SetInitializationsMode[ctx, mode] returns new context with updated initialization mode.";
+GetTensorType::usage = "GetTensorType[ctx] returns tensor type from context.\nGetTensorType[] returns current tensor type.";
+SetTensorType::usage = "SetTensorType[ctx, type] returns new context with updated tensor type.";
+GetStorageType::usage = "GetStorageType[ctx] returns storage type from context.\nGetStorageType[] returns current storage type.";
+SetStorageType::usage = "SetStorageType[ctx, type] returns new context with updated storage type.";
+GetDerivsOrder::usage = "GetDerivsOrder[ctx] returns derivative order from context.\nGetDerivsOrder[] returns derivative order.";
+SetDerivsOrder::usage = "SetDerivsOrder[ctx, order] returns new context with updated derivative order.";
+GetDerivsAccuracy::usage = "GetDerivsAccuracy[ctx] returns derivative accuracy from context.\nGetDerivsAccuracy[] returns derivative accuracy.";
+SetDerivsAccuracy::usage = "SetDerivsAccuracy[ctx, accuracy] returns new context with updated derivative accuracy.";
 
 (* Equations Mode Helper *)
-GetEquationsMode::usage = "GetEquationsMode[] returns current equation mode.";
+GetEquationsMode::usage = "GetEquationsMode[ctx] returns equation mode from context.\nGetEquationsMode[] returns current equation mode.";
+SetEquationsMode::usage = "SetEquationsMode[ctx, mode] returns new context with updated equation mode.";
+
+(* Context Sync *)
+SyncModeToContext::usage = "SyncModeToContext[] synchronizes global mode and state to $CurrentContext.";
 
 (* IndexOptions Helpers *)
-GetIndependentVarlistIndex::usage = "GetIndependentVarlistIndex[] returns IndependentVarlistIndex setting.";
-GetWithoutGridPointIndex::usage = "GetWithoutGridPointIndex[] returns WithoutGridPointIndex setting.";
-GetUseTilePointIndex::usage = "GetUseTilePointIndex[] returns UseTilePointIndex setting.";
+GetIndependentVarlistIndex::usage = "GetIndependentVarlistIndex[ctx] returns IndependentVarlistIndex from context.\nGetIndependentVarlistIndex[] returns IndependentVarlistIndex setting.";
+SetIndependentVarlistIndex::usage = "SetIndependentVarlistIndex[ctx, val] returns new context with updated IndependentVarlistIndex.";
+GetWithoutGridPointIndex::usage = "GetWithoutGridPointIndex[ctx] returns WithoutGridPointIndex from context.\nGetWithoutGridPointIndex[] returns WithoutGridPointIndex setting.";
+SetWithoutGridPointIndex::usage = "SetWithoutGridPointIndex[ctx, val] returns new context with updated WithoutGridPointIndex.";
+GetUseTilePointIndex::usage = "GetUseTilePointIndex[ctx] returns UseTilePointIndex from context.\nGetUseTilePointIndex[] returns UseTilePointIndex setting.";
+SetUseTilePointIndex::usage = "SetUseTilePointIndex[ctx, val] returns new context with updated UseTilePointIndex.";
 
 Begin["`Private`"];
 
-(* Valid values for each path *)
+(* Valid values for each path - nested structure *)
 $ModeValidValues = <|
   {"Phase"} -> {None, "SetComp", "PrintComp"},
   {"IndexOptions", "IndependentVarlistIndex"} -> {True, False},
@@ -55,6 +71,21 @@ $ModeValidValues = <|
   {"PrintComp", "Initializations", "DerivsOrder"} -> _Integer,
   {"PrintComp", "Initializations", "DerivsAccuracy"} -> _Integer,
   {"PrintComp", "Equations", "Mode"} -> {None, "Temp", "MainOut", "AddToMainOut"}
+|>;
+
+(* Valid values for flat context keys *)
+$ContextModeValidValues = <|
+  "Phase" -> {None, "SetComp", "PrintComp"},
+  "IndependentVarlistIndex" -> {True, False},
+  "WithoutGridPointIndex" -> {True, False},
+  "UseTilePointIndex" -> {True, False},
+  "PrintCompType" -> {None, "Initializations", "Equations"},
+  "InitializationsMode" -> {None, "MainOut", "MainIn", "Derivs", "Derivs1st", "Derivs2nd", "MoreInOut", "Temp"},
+  "TensorType" -> {None, "Scal", "Vect", "Smat"},
+  "StorageType" -> {None, "GF", "Tile"},
+  "DerivsOrder" -> _Integer,
+  "DerivsAccuracy" -> _Integer,
+  "EquationsMode" -> {None, "Temp", "MainOut", "AddToMainOut"}
 |>;
 
 (* Default mode structure *)
@@ -109,7 +140,7 @@ GetMode[keys__String] :=
 
 Protect[GetMode];
 
-(* Validate value for path *)
+(* Validate value for path - nested mode structure *)
 ValidateModeValue[path_List, value_] :=
   Module[{validValues},
     If[!KeyExistsQ[$ModeValidValues, path],
@@ -117,6 +148,23 @@ ValidateModeValue[path_List, value_] :=
       True
       ,
       validValues = $ModeValidValues[path];
+      If[ListQ[validValues],
+        MemberQ[validValues, value]
+        ,
+        (* It's a pattern (e.g., _Integer) - use pattern matching *)
+        MatchQ[value, validValues]
+      ]
+    ]
+  ];
+
+(* Validate value for flat context key *)
+ValidateContextModeValue[key_String, value_] :=
+  Module[{validValues},
+    If[!KeyExistsQ[$ContextModeValidValues, key],
+      (* No validation for this key - allow any value *)
+      True
+      ,
+      validValues = $ContextModeValidValues[key];
       If[ListQ[validValues],
         MemberQ[validValues, value]
         ,
@@ -184,16 +232,71 @@ SetModes[rules_List] :=
 
 Protect[SetModes];
 
-(* Scoped mode context with automatic restore *)
+(* Helper to sync $Mode to $CurrentContext *)
+(* Maps nested $Mode paths to flat context keys *)
+(* Also syncs Component.wl state: $MapComponentToVarlist, etc. *)
+SyncModeToContext[] :=
+  Module[{},
+    $CurrentContext = UpdateCtx[$CurrentContext, <|
+      (* Mode state *)
+      "Phase" -> GetMode["Phase"],
+      "IndependentVarlistIndex" -> GetMode["IndexOptions", "IndependentVarlistIndex"],
+      "WithoutGridPointIndex" -> GetMode["IndexOptions", "WithoutGridPointIndex"],
+      "UseTilePointIndex" -> GetMode["IndexOptions", "UseTilePointIndex"],
+      "PrintCompType" -> GetMode["PrintComp", "Type"],
+      "InitializationsMode" -> GetMode["PrintComp", "Initializations", "Mode"],
+      "TensorType" -> GetMode["PrintComp", "Initializations", "TensorType"],
+      "StorageType" -> GetMode["PrintComp", "Initializations", "StorageType"],
+      "DerivsOrder" -> GetMode["PrintComp", "Initializations", "DerivsOrder"],
+      "DerivsAccuracy" -> GetMode["PrintComp", "Initializations", "DerivsAccuracy"],
+      "EquationsMode" -> GetMode["PrintComp", "Equations", "Mode"],
+      (* Component state - sync from global variables *)
+      "MapComponentToVarlist" -> Generato`Component`Private`$MapComponentToVarlist,
+      "ProcessNewVarlist" -> Generato`Component`Private`$ProcessNewVarlist,
+      "SimplifyEquation" -> Generato`Component`Private`$SimplifyEquation,
+      "UseLetterForTensorComponent" -> Generato`Component`Private`$UseLetterForTensorComponent,
+      "TempVariableType" -> Generato`Component`Private`$TempVariableType,
+      "InterfaceWithNonCoordBasis" -> Generato`Component`Private`$InterfaceWithNonCoordBasis,
+      "SuffixName" -> Generato`Component`Private`$SuffixName,
+      "PrefixDt" -> Generato`Component`Private`$PrefixDt,
+      (* Basic state *)
+      "GridPointIndex" -> Generato`Basic`Private`$GridPointIndex,
+      "TilePointIndex" -> Generato`Basic`Private`$TilePointIndex,
+      "SuffixUnprotected" -> Generato`Basic`Private`$SuffixUnprotected,
+      "OutputFile" -> Generato`Basic`Private`$OutputFile,
+      "Project" -> Generato`Basic`Private`$Project
+    |>];
+  ];
+
+Protect[SyncModeToContext];
+
+(* Scoped mode context with automatic restore - global mode version *)
 SetAttributes[WithMode, HoldRest];
 
 WithMode[settings_List, body_] :=
-  Module[{savedMode = $Mode},
+  Module[{savedMode = $Mode, savedContext = $CurrentContext},
     SetModes[settings];
+    SyncModeToContext[];
     WithCleanup[
       body,
-      $Mode = savedMode
+      $Mode = savedMode;
+      $CurrentContext = savedContext
     ]
+  ];
+
+(* Context-aware WithMode - applies flat key-value settings to context *)
+(* settings is a list of {key, value} pairs or key -> value rules *)
+WithMode[ctx_Association, settings_List, body_] :=
+  Module[{newCtx},
+    newCtx = Fold[
+      If[Head[#2] === Rule,
+        SetCtx[#1, First[#2], Last[#2]],
+        SetCtx[#1, #2[[1]], #2[[2]]]
+      ] &,
+      ctx,
+      settings
+    ];
+    WithContext[newCtx, body]
   ];
 
 Protect[WithMode];
@@ -202,46 +305,200 @@ Protect[WithMode];
 (* Convenience Helpers *)
 (* ========================================= *)
 
-(* Phase helpers *)
+(* Phase helpers - context-aware versions *)
+GetPhase[ctx_Association] := GetCtx[ctx, "Phase"];
+GetPhase[] := GetMode["Phase"];
+
+InSetCompPhase[ctx_Association] := GetPhase[ctx] === "SetComp";
 InSetCompPhase[] := GetMode["Phase"] === "SetComp";
+
+InPrintCompPhase[ctx_Association] := GetPhase[ctx] === "PrintComp";
 InPrintCompPhase[] := GetMode["Phase"] === "PrintComp";
 
+(* Phase setters - context-aware versions return new context *)
+SetPhase[ctx_Association, phase_] :=
+  Module[{},
+    If[!ValidateContextModeValue["Phase", phase],
+      Throw @ Message[SetPhase::EInvalidValue, phase]
+    ];
+    SetCtx[ctx, "Phase", phase]
+  ];
+
+SetPhase::EInvalidValue = "Invalid phase value: `1`";
+
+Protect[GetPhase];
 Protect[InSetCompPhase];
 Protect[InPrintCompPhase];
+Protect[SetPhase];
 
-(* PrintComp type helpers *)
+(* PrintComp type helpers - context-aware versions *)
+GetPrintCompType[ctx_Association] := GetCtx[ctx, "PrintCompType"];
+GetPrintCompType[] := GetMode["PrintComp", "Type"];
+
+InInitializationsMode[ctx_Association] := GetPrintCompType[ctx] === "Initializations";
 InInitializationsMode[] := GetMode["PrintComp", "Type"] === "Initializations";
+
+InEquationsMode[ctx_Association] := GetPrintCompType[ctx] === "Equations";
 InEquationsMode[] := GetMode["PrintComp", "Type"] === "Equations";
 
+(* PrintCompType setter - context-aware version *)
+SetPrintCompType[ctx_Association, ptype_] :=
+  Module[{},
+    If[!ValidateContextModeValue["PrintCompType", ptype],
+      Throw @ Message[SetPrintCompType::EInvalidValue, ptype]
+    ];
+    SetCtx[ctx, "PrintCompType", ptype]
+  ];
+
+SetPrintCompType::EInvalidValue = "Invalid PrintCompType value: `1`";
+
+Protect[GetPrintCompType];
 Protect[InInitializationsMode];
 Protect[InEquationsMode];
+Protect[SetPrintCompType];
 
-(* Initializations mode helpers *)
+(* Initializations mode helpers - context-aware versions *)
+GetInitializationsMode[ctx_Association] := GetCtx[ctx, "InitializationsMode"];
 GetInitializationsMode[] := GetMode["PrintComp", "Initializations", "Mode"];
+
+GetTensorType[ctx_Association] := GetCtx[ctx, "TensorType"];
 GetTensorType[] := GetMode["PrintComp", "Initializations", "TensorType"];
+
+GetStorageType[ctx_Association] := GetCtx[ctx, "StorageType"];
 GetStorageType[] := GetMode["PrintComp", "Initializations", "StorageType"];
+
+GetDerivsOrder[ctx_Association] := GetCtx[ctx, "DerivsOrder"];
 GetDerivsOrder[] := GetMode["PrintComp", "Initializations", "DerivsOrder"];
+
+GetDerivsAccuracy[ctx_Association] := GetCtx[ctx, "DerivsAccuracy"];
 GetDerivsAccuracy[] := GetMode["PrintComp", "Initializations", "DerivsAccuracy"];
+
+(* Initializations mode setters - context-aware versions *)
+SetInitializationsMode[ctx_Association, mode_] :=
+  Module[{},
+    If[!ValidateContextModeValue["InitializationsMode", mode],
+      Throw @ Message[SetInitializationsMode::EInvalidValue, mode]
+    ];
+    SetCtx[ctx, "InitializationsMode", mode]
+  ];
+
+SetInitializationsMode::EInvalidValue = "Invalid InitializationsMode value: `1`";
+
+SetTensorType[ctx_Association, ttype_] :=
+  Module[{},
+    If[!ValidateContextModeValue["TensorType", ttype],
+      Throw @ Message[SetTensorType::EInvalidValue, ttype]
+    ];
+    SetCtx[ctx, "TensorType", ttype]
+  ];
+
+SetTensorType::EInvalidValue = "Invalid TensorType value: `1`";
+
+SetStorageType[ctx_Association, stype_] :=
+  Module[{},
+    If[!ValidateContextModeValue["StorageType", stype],
+      Throw @ Message[SetStorageType::EInvalidValue, stype]
+    ];
+    SetCtx[ctx, "StorageType", stype]
+  ];
+
+SetStorageType::EInvalidValue = "Invalid StorageType value: `1`";
+
+SetDerivsOrder[ctx_Association, order_] :=
+  Module[{},
+    If[!ValidateContextModeValue["DerivsOrder", order],
+      Throw @ Message[SetDerivsOrder::EInvalidValue, order]
+    ];
+    SetCtx[ctx, "DerivsOrder", order]
+  ];
+
+SetDerivsOrder::EInvalidValue = "Invalid DerivsOrder value: `1`";
+
+SetDerivsAccuracy[ctx_Association, accuracy_] :=
+  Module[{},
+    If[!ValidateContextModeValue["DerivsAccuracy", accuracy],
+      Throw @ Message[SetDerivsAccuracy::EInvalidValue, accuracy]
+    ];
+    SetCtx[ctx, "DerivsAccuracy", accuracy]
+  ];
+
+SetDerivsAccuracy::EInvalidValue = "Invalid DerivsAccuracy value: `1`";
 
 Protect[GetInitializationsMode];
 Protect[GetTensorType];
 Protect[GetStorageType];
 Protect[GetDerivsOrder];
 Protect[GetDerivsAccuracy];
+Protect[SetInitializationsMode];
+Protect[SetTensorType];
+Protect[SetStorageType];
+Protect[SetDerivsOrder];
+Protect[SetDerivsAccuracy];
 
-(* Equations mode helper *)
+(* Equations mode helper - context-aware versions *)
+GetEquationsMode[ctx_Association] := GetCtx[ctx, "EquationsMode"];
 GetEquationsMode[] := GetMode["PrintComp", "Equations", "Mode"];
 
-Protect[GetEquationsMode];
+SetEquationsMode[ctx_Association, mode_] :=
+  Module[{},
+    If[!ValidateContextModeValue["EquationsMode", mode],
+      Throw @ Message[SetEquationsMode::EInvalidValue, mode]
+    ];
+    SetCtx[ctx, "EquationsMode", mode]
+  ];
 
-(* IndexOptions helpers *)
+SetEquationsMode::EInvalidValue = "Invalid EquationsMode value: `1`";
+
+Protect[GetEquationsMode];
+Protect[SetEquationsMode];
+
+(* IndexOptions helpers - context-aware versions *)
+GetIndependentVarlistIndex[ctx_Association] := GetCtx[ctx, "IndependentVarlistIndex"];
 GetIndependentVarlistIndex[] := GetMode["IndexOptions", "IndependentVarlistIndex"];
+
+GetWithoutGridPointIndex[ctx_Association] := GetCtx[ctx, "WithoutGridPointIndex"];
 GetWithoutGridPointIndex[] := GetMode["IndexOptions", "WithoutGridPointIndex"];
+
+GetUseTilePointIndex[ctx_Association] := GetCtx[ctx, "UseTilePointIndex"];
 GetUseTilePointIndex[] := GetMode["IndexOptions", "UseTilePointIndex"];
+
+(* IndexOptions setters - context-aware versions *)
+SetIndependentVarlistIndex[ctx_Association, val_] :=
+  Module[{},
+    If[!ValidateContextModeValue["IndependentVarlistIndex", val],
+      Throw @ Message[SetIndependentVarlistIndex::EInvalidValue, val]
+    ];
+    SetCtx[ctx, "IndependentVarlistIndex", val]
+  ];
+
+SetIndependentVarlistIndex::EInvalidValue = "Invalid IndependentVarlistIndex value: `1`";
+
+SetWithoutGridPointIndex[ctx_Association, val_] :=
+  Module[{},
+    If[!ValidateContextModeValue["WithoutGridPointIndex", val],
+      Throw @ Message[SetWithoutGridPointIndex::EInvalidValue, val]
+    ];
+    SetCtx[ctx, "WithoutGridPointIndex", val]
+  ];
+
+SetWithoutGridPointIndex::EInvalidValue = "Invalid WithoutGridPointIndex value: `1`";
+
+SetUseTilePointIndex[ctx_Association, val_] :=
+  Module[{},
+    If[!ValidateContextModeValue["UseTilePointIndex", val],
+      Throw @ Message[SetUseTilePointIndex::EInvalidValue, val]
+    ];
+    SetCtx[ctx, "UseTilePointIndex", val]
+  ];
+
+SetUseTilePointIndex::EInvalidValue = "Invalid UseTilePointIndex value: `1`";
 
 Protect[GetIndependentVarlistIndex];
 Protect[GetWithoutGridPointIndex];
 Protect[GetUseTilePointIndex];
+Protect[SetIndependentVarlistIndex];
+Protect[SetWithoutGridPointIndex];
+Protect[SetUseTilePointIndex];
 
 End[];
 

--- a/src/Writefile.wl
+++ b/src/Writefile.wl
@@ -6,6 +6,8 @@
 
 BeginPackage["Generato`Writefile`"];
 
+Needs["Generato`Context`"];
+
 Needs["Generato`Basic`"];
 
 Needs["Generato`Component`"];
@@ -16,11 +18,11 @@ If[Environment["QUIET"] =!= "1",
   System`Print["------------------------------------------------------------"];
 ];
 
-SetMainPrint::usage = "SetMainPrint[content] sets the content to be written as the main body of the output file.";
+SetMainPrint::usage = "SetMainPrint[content] sets the content to be written as the main body of the output file.\nSetMainPrint[ctx, content] returns new context with content stored.";
 
-GetMainPrint::usage = "GetMainPrint[] returns and evaluates the content set by SetMainPrint.";
+GetMainPrint::usage = "GetMainPrint[] returns and evaluates the content set by SetMainPrint.\nGetMainPrint[ctx] returns the content from context.";
 
-WriteToFile::usage = "WriteToFile[filename] writes the main content to the specified file with header and footer.";
+WriteToFile::usage = "WriteToFile[filename] writes the main content to the specified file with header and footer.\nWriteToFile[ctx, filename] writes using settings from context.";
 
 ReplaceGFIndexName::usage = "ReplaceGFIndexName[filename, rule] applies string replacement rule to the contents of filename.";
 
@@ -32,11 +34,29 @@ $MainPrint = Null;
 
 (* Function *)
 
-GetMainPrint[] :=
-  Return[$MainPrint];
+(* Context-aware getter *)
+GetMainPrint[ctx_Association] := GetCtx[ctx, "MainPrint"];
+
+(* Global getter - uses global variable *)
+GetMainPrint[] := $MainPrint;
+
+Protect[GetMainPrint];
+
+(* SetMainPrint needs special handling:
+   - Context version (2 args): evaluate ctx, hold content
+   - Global version (1 arg): hold content for deferred evaluation
+
+   Use HoldAll and manually evaluate the ctx argument for 2-arg version *)
 
 SetAttributes[SetMainPrint, HoldAll];
 
+(* Context-aware setter - evaluate ctx explicitly, keep content held *)
+SetMainPrint[ctx_, content_] /; AssociationQ[ctx] :=
+  With[{evalCtx = ctx},
+    SetCtx[evalCtx, "MainPrint", Hold[content]]
+  ];
+
+(* Global setter - mutates global variable using SetDelayed *)
 SetMainPrint[content_] :=
   Module[{},
     $MainPrint := content
@@ -44,7 +64,72 @@ SetMainPrint[content_] :=
 
 Protect[SetMainPrint];
 
-WriteToFile[outputfile_] :=
+(* Context-aware WriteToFile - uses settings from context *)
+WriteToFile[ctx_Association, outputfile_String] :=
+  Module[{filepointer, mainPrint, tempVarType, printDate, printHeaderMacro},
+    (* Get settings from context *)
+    mainPrint = GetMainPrint[ctx];
+    tempVarType = GetTempVariableType[ctx];
+    printDate = GetPrintDate[ctx];
+    printHeaderMacro = GetPrintHeaderMacro[ctx];
+
+    If[Environment["QUIET"] =!= "1",
+      System`Print["Writing to \"", outputfile, "\"...\n"]
+    ];
+    If[FileExistsQ[outputfile],
+      If[Environment["QUIET"] =!= "1",
+        System`Print["\"", outputfile, "\" already exists, replacing it ...\n"]
+      ];
+      DeleteFile[outputfile]
+    ];
+    (* define pr *)
+    filepointer = OpenAppend[outputfile];
+    Block[{Global`pr},
+      Global`pr[x_:""] :=
+        Module[{},
+          If[x == tempVarType,
+            WriteString[filepointer, x]
+            ,
+            WriteLine[filepointer, x]
+          ]
+        ];
+      (* print first few lines *)
+      Global`pr["/* " <> FileNameTake[outputfile] <> " */"];
+      Global`pr[
+        "/* Produced with Generato" <>
+          If[printDate,
+            " on " <> DateString[{"Month", "/", "Day", "/", "Year"}]
+            ,
+            ""
+          ] <> " */"
+      ];
+      Global`pr[];
+      If[printHeaderMacro,
+        Global`pr["#ifndef " <> StringReplace[ToUpperCase[FileNameTake[outputfile]], "." -> "_"]];
+        Global`pr["#define " <> StringReplace[ToUpperCase[FileNameTake[outputfile]], "." -> "_"]];
+        Global`pr[]
+      ];
+      (* Evaluate the held main print content *)
+      If[Head[mainPrint] === Hold,
+        ReleaseHold[mainPrint]
+        ,
+        mainPrint
+      ];
+      Global`pr[];
+      If[printHeaderMacro,
+        Global`pr["#endif // #ifndef " <> StringReplace[ToUpperCase[FileNameTake[outputfile]], "." -> "_"]];
+        Global`pr[]
+      ];
+      Global`pr["/* " <> FileNameTake[outputfile] <> " */"];
+    ];
+    If[Environment["QUIET"] =!= "1",
+      System`Print["Done generating \"", outputfile, "\"\n"]
+    ];
+    Close[filepointer]
+  ];
+
+(* Global WriteToFile - uses global variables *)
+WriteToFile[outputfile_String] :=
   Module[{filepointer},
     If[Environment["QUIET"] =!= "1",
       System`Print["Writing to \"", outputfile, "\"...\n"]

--- a/test/regression/AMReX/output.c
+++ b/test/regression/AMReX/output.c
@@ -1,0 +1,15 @@
+MDD11*uU1 + MDD12*uU2 + MDD13*uU3
+MDD12*uU1 + MDD22*uU2 + MDD23*uU3
+MDD13*uU1 + MDD23*uU2 + MDD33*uU3
+rU1
+rU$RHS(List(1,cart))
+rU2
+rU$RHS(List(2,cart))
+rU3
+rU$RHS(List(3,cart))
+rU1
+rU$RHS(List(1,cart))
+rU2
+rU$RHS(List(2,cart))
+rU3
+rU$RHS(List(3,cart))

--- a/test/regression/CarpetXGPU/output.c
+++ b/test/regression/CarpetXGPU/output.c
@@ -1,0 +1,25 @@
+MDD11*uU1 + MDD12*uU2 + MDD13*uU3
+MDD12*uU1 + MDD22*uU2 + MDD23*uU3
+MDD13*uU1 + MDD23*uU2 + MDD33*uU3
+rU1
+rU$RHS(List(1,cart))
+rU2
+rU$RHS(List(2,cart))
+rU3
+rU$RHS(List(3,cart))
+rU1
+rU$RHS(List(1,cart))
+rU2
+rU$RHS(List(2,cart))
+rU3
+rU$RHS(List(3,cart))
+gridU1
+gridU2
+gridU3
+tileU1[tI]
+tempU1
+tileU2[tI]
+tempU2
+tileU3[tI]
+tempU3
+Power(dphi1,2) + Power(dphi2,2) + Power(dphi3,2)

--- a/test/unit/ComponentTests.wl
+++ b/test/unit/ComponentTests.wl
@@ -171,6 +171,140 @@ AppendTo[$AllTests,
   ]
 ];
 
+(* ========================================= *)
+(* Test: Context-Aware Getters *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware GetMapComponentToVarlist should return default value *)
+    Module[{ctx = CreateContext[]},
+      GetMapComponentToVarlist[ctx]
+    ],
+    <||>,
+    TestID -> "GetMapComponentToVarlist-Context-ReturnsDefault"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware GetProcessNewVarlist should return default value *)
+    Module[{ctx = CreateContext[]},
+      GetProcessNewVarlist[ctx]
+    ],
+    True,
+    TestID -> "GetProcessNewVarlist-Context-ReturnsDefault"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware GetSimplifyEquation should return default value *)
+    Module[{ctx = CreateContext[]},
+      GetSimplifyEquation[ctx]
+    ],
+    True,
+    TestID -> "GetSimplifyEquation-Context-ReturnsDefault"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware GetTempVariableType should return default value *)
+    Module[{ctx = CreateContext[]},
+      GetTempVariableType[ctx]
+    ],
+    "double",
+    TestID -> "GetTempVariableType-Context-ReturnsDefault"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware GetSuffixName should return default value *)
+    Module[{ctx = CreateContext[]},
+      GetSuffixName[ctx]
+    ],
+    "",
+    TestID -> "GetSuffixName-Context-ReturnsDefault"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware GetPrefixDt should return default value *)
+    Module[{ctx = CreateContext[]},
+      GetPrefixDt[ctx]
+    ],
+    "dt",
+    TestID -> "GetPrefixDt-Context-ReturnsDefault"
+  ]
+];
+
+(* ========================================= *)
+(* Test: Context-Aware Setters Return New Context *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetSimplifyEquation should return new context *)
+    Module[{ctx = CreateContext[], ctx2},
+      ctx2 = SetSimplifyEquation[ctx, False];
+      {GetSimplifyEquation[ctx], GetSimplifyEquation[ctx2]}
+    ],
+    {True, False},
+    TestID -> "SetSimplifyEquation-Context-ReturnsNewContext"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetTempVariableType should return new context *)
+    Module[{ctx = CreateContext[], ctx2},
+      ctx2 = SetTempVariableType[ctx, "CCTK_REAL"];
+      {GetTempVariableType[ctx], GetTempVariableType[ctx2]}
+    ],
+    {"double", "CCTK_REAL"},
+    TestID -> "SetTempVariableType-Context-ReturnsNewContext"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetSuffixName should return new context *)
+    Module[{ctx = CreateContext[], ctx2},
+      ctx2 = SetSuffixName[ctx, "_rhs"];
+      {GetSuffixName[ctx], GetSuffixName[ctx2]}
+    ],
+    {"", "_rhs"},
+    TestID -> "SetSuffixName-Context-ReturnsNewContext"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetProcessNewVarlist should return new context *)
+    Module[{ctx = CreateContext[], ctx2},
+      ctx2 = SetProcessNewVarlist[ctx, False];
+      {GetProcessNewVarlist[ctx], GetProcessNewVarlist[ctx2]}
+    ],
+    {True, False},
+    TestID -> "SetProcessNewVarlist-Context-ReturnsNewContext"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetMapComponentToVarlist should return new context *)
+    Module[{ctx = CreateContext[], ctx2, testMap = <|"test" -> 0|>},
+      ctx2 = SetMapComponentToVarlist[ctx, testMap];
+      {GetMapComponentToVarlist[ctx], GetMapComponentToVarlist[ctx2]}
+    ],
+    {<||>, <|"test" -> 0|>},
+    TestID -> "SetMapComponentToVarlist-Context-ReturnsNewContext"
+  ]
+];
+
 (* Reset state *)
 SetSimplifyEquation[True];
 SetUseLetterForTensorComponent[False];

--- a/test/unit/ContextTests.wl
+++ b/test/unit/ContextTests.wl
@@ -1,0 +1,269 @@
+(* ::Package:: *)
+
+(* ContextTests.wl *)
+(* Unit tests for Generato`Context module *)
+
+If[Environment["QUIET"] =!= "1", Print["Loading ContextTests.wl..."]];
+
+(* Load Generato *)
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
+
+(* Import Context explicitly to access functions *)
+Needs["Generato`Context`"];
+
+(* ========================================= *)
+(* Test: CreateContext *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    AssociationQ[ctx],
+    True,
+    TestID -> "CreateContext-ReturnsAssociation"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    (* Check that all expected keys are present *)
+    KeyExistsQ[ctx, "Phase"] &&
+    KeyExistsQ[ctx, "GridPointIndex"] &&
+    KeyExistsQ[ctx, "TempVariableType"] &&
+    KeyExistsQ[ctx, "MapComponentToVarlist"] &&
+    KeyExistsQ[ctx, "MainPrint"],
+    True,
+    TestID -> "CreateContext-HasExpectedKeys"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    GetCtx[ctx, "Phase"],
+    None,
+    TestID -> "CreateContext-PhaseDefaultsToNone"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    GetCtx[ctx, "GridPointIndex"],
+    "",
+    TestID -> "CreateContext-GridPointIndexDefaultsToEmpty"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    GetCtx[ctx, "TempVariableType"],
+    "double",
+    TestID -> "CreateContext-TempVariableTypeDefaultsToDouble"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    GetCtx[ctx, "DerivsOrder"],
+    1,
+    TestID -> "CreateContext-DerivsOrderDefaultsTo1"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    GetCtx[ctx, "DerivsAccuracy"],
+    4,
+    TestID -> "CreateContext-DerivsAccuracyDefaultsTo4"
+  ]
+];
+
+(* ========================================= *)
+(* Test: CreateContext with overrides *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[<|"GridPointIndex" -> "[[ijk]]"|>];
+    GetCtx[ctx, "GridPointIndex"],
+    "[[ijk]]",
+    TestID -> "CreateContext-WithOverride-GridPointIndex"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[<|"Phase" -> "SetComp", "TensorType" -> "Vect"|>];
+    {GetCtx[ctx, "Phase"], GetCtx[ctx, "TensorType"]},
+    {"SetComp", "Vect"},
+    TestID -> "CreateContext-WithMultipleOverrides"
+  ]
+];
+
+(* ========================================= *)
+(* Test: GetCtx / SetCtx *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    ctx2 = SetCtx[ctx, "GridPointIndex", "[[ijk]]"];
+    (* Original should be unchanged *)
+    GetCtx[ctx, "GridPointIndex"],
+    "",
+    TestID -> "SetCtx-OriginalUnchanged"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    ctx2 = SetCtx[ctx, "GridPointIndex", "[[ijk]]"];
+    (* New context should have updated value *)
+    GetCtx[ctx2, "GridPointIndex"],
+    "[[ijk]]",
+    TestID -> "SetCtx-NewContextHasUpdate"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    ctx2 = SetCtx[ctx, "Phase", "PrintComp"];
+    GetCtx[ctx2, "Phase"],
+    "PrintComp",
+    TestID -> "SetCtx-PhaseValue"
+  ]
+];
+
+(* ========================================= *)
+(* Test: UpdateCtx *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    ctx2 = UpdateCtx[ctx, <|"Phase" -> "SetComp", "TensorType" -> "Vect"|>];
+    {GetCtx[ctx2, "Phase"], GetCtx[ctx2, "TensorType"]},
+    {"SetComp", "Vect"},
+    TestID -> "UpdateCtx-WithAssociation"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    ctx2 = UpdateCtx[ctx, {{"Phase", "PrintComp"}, {"StorageType", "GF"}}];
+    {GetCtx[ctx2, "Phase"], GetCtx[ctx2, "StorageType"]},
+    {"PrintComp", "GF"},
+    TestID -> "UpdateCtx-WithList"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    ctx2 = UpdateCtx[ctx, <|"Phase" -> "SetComp"|>];
+    (* Original should be unchanged *)
+    GetCtx[ctx, "Phase"],
+    None,
+    TestID -> "UpdateCtx-OriginalUnchanged"
+  ]
+];
+
+(* ========================================= *)
+(* Test: WithContext *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[<|"GridPointIndex" -> "[[test]]"|>];
+    result = WithContext[ctx, $CurrentContext["GridPointIndex"]];
+    result,
+    "[[test]]",
+    TestID -> "WithContext-ScopesContext"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    originalCtx = $CurrentContext;
+    ctx = CreateContext[<|"Phase" -> "TestPhase"|>];
+    WithContext[ctx, Null];
+    (* $CurrentContext should be restored after WithContext *)
+    $CurrentContext["Phase"] === originalCtx["Phase"],
+    True,
+    TestID -> "WithContext-RestoresContext"
+  ]
+];
+
+(* ========================================= *)
+(* Test: Context has all 30 state variables *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    (* 10 Basic.wl + 11 ParseMode.wl + 8 Component.wl + 1 Writefile.wl = 30 keys *)
+    Length[ctx],
+    30,
+    TestID -> "CreateContext-Has30Keys"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    (* Verify all Basic.wl state variables *)
+    basicKeys = {"CheckInputEquations", "PVerbose", "QuietMode", "PrintDate",
+                 "PrintHeaderMacro", "GridPointIndex", "TilePointIndex",
+                 "SuffixUnprotected", "OutputFile", "Project"};
+    AllTrue[basicKeys, KeyExistsQ[ctx, #] &],
+    True,
+    TestID -> "CreateContext-HasAllBasicKeys"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    (* Verify all ParseMode.wl state variables *)
+    modeKeys = {"Phase", "IndependentVarlistIndex", "WithoutGridPointIndex",
+                "UseTilePointIndex", "PrintCompType", "InitializationsMode",
+                "TensorType", "StorageType", "DerivsOrder", "DerivsAccuracy",
+                "EquationsMode"};
+    AllTrue[modeKeys, KeyExistsQ[ctx, #] &],
+    True,
+    TestID -> "CreateContext-HasAllModeKeys"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    (* Verify all Component.wl state variables *)
+    compKeys = {"MapComponentToVarlist", "ProcessNewVarlist", "SimplifyEquation",
+                "UseLetterForTensorComponent", "TempVariableType",
+                "InterfaceWithNonCoordBasis", "SuffixName", "PrefixDt"};
+    AllTrue[compKeys, KeyExistsQ[ctx, #] &],
+    True,
+    TestID -> "CreateContext-HasAllComponentKeys"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ctx = CreateContext[];
+    (* Verify Writefile.wl state variable *)
+    KeyExistsQ[ctx, "MainPrint"],
+    True,
+    TestID -> "CreateContext-HasMainPrintKey"
+  ]
+];
+
+If[Environment["QUIET"] =!= "1", Print["ContextTests.wl completed."]];

--- a/test/unit/InterfaceTests.wl
+++ b/test/unit/InterfaceTests.wl
@@ -141,6 +141,153 @@ AppendTo[$AllTests,
   ]
 ];
 
+(* ========================================= *)
+(* Test: Context-aware DefTensors *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* DefTensors[ctx, varlist] should return the varlist *)
+    ctx = CreateContext[];
+    defList = DefTensors[ctx, {{intDefCtx[i], PrintAs -> "idc"}}];
+    ListQ[defList] && Length[defList] >= 1,
+    True,
+    TestID -> "DefTensors-ContextAware-ReturnsList"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* DefTensors[ctx, varlist] with symmetric tensor *)
+    ctx = CreateContext[];
+    defList = DefTensors[ctx, {{intDefCtxSym[-i, -j], Symmetric[{-i, -j}], PrintAs -> "idcs"}}];
+    Length[defList] >= 1,
+    True,
+    TestID -> "DefTensors-ContextAware-SymmetricTensor"
+  ]
+];
+
+(* ========================================= *)
+(* Test: Context-aware GridTensors *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* GridTensors[ctx, varlist] should return varlist *)
+    ctx = CreateContext[];
+    varlist = GridTensors[ctx, {{intCtxGridVec[i], PrintAs -> "icgv"}}];
+    ListQ[varlist] && Length[varlist] >= 1,
+    True,
+    TestID -> "GridTensors-ContextAware-ReturnsList"
+  ]
+];
+
+(* ========================================= *)
+(* Test: Context-aware TileTensors *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* TileTensors[ctx, varlist] should return varlist *)
+    ctx = CreateContext[];
+    tileList = TileTensors[ctx, {{intCtxTileVec[i], PrintAs -> "ictv"}}];
+    ListQ[tileList] && Length[tileList] >= 1,
+    True,
+    TestID -> "TileTensors-ContextAware-ReturnsList"
+  ]
+];
+
+(* ========================================= *)
+(* Test: Context-aware TempTensors *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* TempTensors[ctx, varlist] should return varlist *)
+    ctx = CreateContext[];
+    tempList = TempTensors[ctx, {{intCtxTempVec[i], PrintAs -> "ictp"}}];
+    ListQ[tempList] && Length[tempList] >= 1,
+    True,
+    TestID -> "TempTensors-ContextAware-ReturnsList"
+  ]
+];
+
+(* ========================================= *)
+(* Test: WithSetCompPhase *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* WithSetCompPhase should set phase to SetComp in context *)
+    ctx = CreateContext[];
+    result = WithSetCompPhase[ctx, GetPhase[$CurrentContext]];
+    result === "SetComp",
+    True,
+    TestID -> "WithSetCompPhase-SetsPhase"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* WithSetCompPhase should restore phase after body *)
+    ctx = CreateContext[];
+    (* Phase should be None after WithSetCompPhase completes *)
+    WithSetCompPhase[ctx, "dummy"];
+    GetPhase[] === None,
+    True,
+    TestID -> "WithSetCompPhase-RestoresPhase"
+  ]
+];
+
+(* ========================================= *)
+(* Test: WithPrintCompPhase *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* WithPrintCompPhase should set phase to PrintComp in context *)
+    ctx = CreateContext[];
+    result = WithPrintCompPhase[ctx, GetPhase[$CurrentContext]];
+    result === "PrintComp",
+    True,
+    TestID -> "WithPrintCompPhase-SetsPhase"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* WithPrintCompPhase should restore phase after body *)
+    ctx = CreateContext[];
+    (* Phase should be None after WithPrintCompPhase completes *)
+    WithPrintCompPhase[ctx, "dummy"];
+    GetPhase[] === None,
+    True,
+    TestID -> "WithPrintCompPhase-RestoresPhase"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* InSetCompPhase should return True inside WithSetCompPhase *)
+    ctx = CreateContext[];
+    result = WithSetCompPhase[ctx, InSetCompPhase[$CurrentContext]];
+    result === True,
+    True,
+    TestID -> "WithSetCompPhase-InSetCompPhase"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* InPrintCompPhase should return True inside WithPrintCompPhase *)
+    ctx = CreateContext[];
+    result = WithPrintCompPhase[ctx, InPrintCompPhase[$CurrentContext]];
+    result === True,
+    True,
+    TestID -> "WithPrintCompPhase-InPrintCompPhase"
+  ]
+];
+
 (* Reset state *)
 SetPVerbose[False];
 SetPrintDate[False];

--- a/test/unit/WritefileTests.wl
+++ b/test/unit/WritefileTests.wl
@@ -42,6 +42,44 @@ AppendTo[$AllTests,
 ];
 
 (* ========================================= *)
+(* Test: Context-aware SetMainPrint / GetMainPrint *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetMainPrint should store content in context *)
+    ctx = CreateContext[];
+    ctx2 = SetMainPrint[ctx, Print["context test"]];
+    GetMainPrint[ctx2] =!= Null,
+    True,
+    TestID -> "SetMainPrint-Context-StoresContent"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetMainPrint returns new context, original unchanged *)
+    ctx = CreateContext[];
+    ctx2 = SetMainPrint[ctx, Print["new content"]];
+    {GetMainPrint[ctx], GetMainPrint[ctx2] =!= Null},
+    {Null, True},
+    TestID -> "SetMainPrint-Context-ImmutableOriginal"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware SetMainPrint holds content *)
+    ctx = CreateContext[];
+    ctx2 = SetMainPrint[ctx, testContextVar = 99];
+    (* Content should be wrapped in Hold *)
+    Head[GetMainPrint[ctx2]],
+    Hold,
+    TestID -> "SetMainPrint-Context-HoldsContent"
+  ]
+];
+
+(* ========================================= *)
 (* Test: ReplaceGFIndexName *)
 (* ========================================= *)
 
@@ -109,6 +147,67 @@ AppendTo[$AllTests,
     !StringContainsQ[result, "#ifndef"],
     True,
     TestID -> "WriteToFile-NoHeaderMacro"
+  ]
+];
+
+(* ========================================= *)
+(* Test: Context-aware WriteToFile *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware WriteToFile should create a file with header and footer *)
+    tempFile = FileNameJoin[{$TemporaryDirectory, "test_ctx_write.hxx"}];
+    ctx = CreateContext[];
+    ctx = SetCtx[ctx, "PrintHeaderMacro", True];
+    ctx = SetCtx[ctx, "PrintDate", False];
+    ctx = SetMainPrint[ctx, Global`pr["// context test content"]];
+    WriteToFile[ctx, tempFile];
+    result = Import[tempFile, "Text"];
+    DeleteFile[tempFile];
+    (* Check for header comment and macro guards *)
+    StringContainsQ[result, "/* test_ctx_write.hxx */"] &&
+    StringContainsQ[result, "#ifndef TEST_CTX_WRITE_HXX"] &&
+    StringContainsQ[result, "// context test content"],
+    True,
+    TestID -> "WriteToFile-Context-CreatesFileWithHeader"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware WriteToFile without header macro *)
+    tempFile = FileNameJoin[{$TemporaryDirectory, "test_ctx_nomacro.hxx"}];
+    ctx = CreateContext[];
+    ctx = SetCtx[ctx, "PrintHeaderMacro", False];
+    ctx = SetCtx[ctx, "PrintDate", False];
+    ctx = SetMainPrint[ctx, Global`pr["// context only"]];
+    WriteToFile[ctx, tempFile];
+    result = Import[tempFile, "Text"];
+    DeleteFile[tempFile];
+    (* Should have comment but no macro guards *)
+    StringContainsQ[result, "/* test_ctx_nomacro.hxx */"] &&
+    !StringContainsQ[result, "#ifndef"],
+    True,
+    TestID -> "WriteToFile-Context-NoHeaderMacro"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    (* Context-aware WriteToFile evaluates held content *)
+    tempFile = FileNameJoin[{$TemporaryDirectory, "test_ctx_held.hxx"}];
+    ctx = CreateContext[];
+    ctx = SetCtx[ctx, "PrintHeaderMacro", False];
+    ctx = SetCtx[ctx, "PrintDate", False];
+    (* Use SetMainPrint which wraps in Hold *)
+    ctx = SetMainPrint[ctx, Global`pr["// held content evaluated"]];
+    WriteToFile[ctx, tempFile];
+    result = Import[tempFile, "Text"];
+    DeleteFile[tempFile];
+    StringContainsQ[result, "// held content evaluated"],
+    True,
+    TestID -> "WriteToFile-Context-EvaluatesHeldContent"
   ]
 ];
 


### PR DESCRIPTION
## Summary

- Introduce `GeneratoContext` association to encapsulate all state, enabling functional-style programming
- Add `src/Context.wl` with core context functions: `CreateContext`, `GetCtx`, `SetCtx`, `UpdateCtx`, `WithContext`
- Add context-aware overloads for all public API functions (`DefTensors`, `GridTensors`, `TileTensors`, `TempTensors`, `SetComponents`, `PrintEquations`, `PrintInitializations`)
- Add phase helpers `WithSetCompPhase` and `WithPrintCompPhase` for scoped phase management
- Refactor backends to use context parameter with automatic fallback to global state
- Extract common backend code into `BackendCommon.wl` helper functions
- Add comprehensive unit tests for new context functionality

## Test plan

- [ ] Run `wolframscript -script test/AllTests.wl` to verify all unit tests pass
- [ ] Run regression tests to ensure generated output matches expected
- [ ] Verify existing global-state API continues to work unchanged