### PR TITLE
Unify all state management to use $CurrentContext as single source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Generato file1.wl file2.wl          # Multiple files
 - **Generato.wl** - Package loader
 - **Context.wl** - Context-based state management (CreateContext, GetCtx, SetCtx, UpdateCtx, WithContext)
 - **Basic.wl** - Config state, tensor utilities, SetEQN/SetEQNDelayed
-- **ParseMode.wl** - Mode management (SetComp/PrintComp phases)
+- **ParseMode.wl** - Phase management (SetComp/PrintComp phases), WithMode for scoped settings
 - **Component.wl** - Tensor component to varlist index mapping
 - **Varlist.wl** - Tensor definitions via ParseVarlist
 - **Interface.wl** - Public API: DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations
@@ -34,13 +34,28 @@ Each implements `PrintComponentInitialization[ctx, varinfo, compname]` and `Prin
 
 Common backend code is in `BackendCommon.wl`.
 
-### Context-Based State Management
+### State Management
 
-All state is encapsulated in a `GeneratoContext` association. Functions take context as first parameter.
+All state is stored in `$CurrentContext`, a flat association that serves as the single source of truth. Global getters/setters read/write `$CurrentContext` directly, and context-aware functions take `ctx` as the first parameter.
 
 ```wolfram
+(* Global API - reads/writes $CurrentContext *)
+SetGridPointIndex["[[ijk]]"];
+GetGridPointIndex[];
+
+(* Context-aware API - functional, returns new context *)
 ctx = CreateContext[];
 ctx = SetGridPointIndex[ctx, "[[ijk]]"];
+```
+
+Use `WithMode` for scoped settings that auto-restore:
+```wolfram
+WithMode[{
+  {"Phase"} -> "PrintComp",
+  {"PrintComp", "Type"} -> "Equations"
+},
+  (* body - settings restored after *)
+];
 ```
 
 ### Two-Phase Processing

--- a/codes/AMReX.wl
+++ b/codes/AMReX.wl
@@ -154,13 +154,6 @@ PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerule
     ]
   ];
 
-(* Backwards compat: old 3-argument signature *)
-PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
-  Module[{},
-    SyncModeToContext[];
-    PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
-  ];
-
 Protect[PrintComponentEquation];
 
 

--- a/codes/Carpet.wl
+++ b/codes/Carpet.wl
@@ -243,13 +243,6 @@ PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerule
     ]
   ];
 
-(* Backwards compat: old 3-argument signature *)
-PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
-  Module[{},
-    SyncModeToContext[];
-    PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
-  ];
-
 Protect[PrintComponentEquation];
 
 

--- a/codes/CarpetX.wl
+++ b/codes/CarpetX.wl
@@ -142,13 +142,6 @@ PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerule
     ]
   ];
 
-(* Backwards compat: old 3-argument signature *)
-PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
-  Module[{},
-    SyncModeToContext[];
-    PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
-  ];
-
 Protect[PrintComponentEquation];
 
 (******************************************************************************)

--- a/codes/CarpetXGPU.wl
+++ b/codes/CarpetXGPU.wl
@@ -297,13 +297,6 @@ PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerule
     ]
   ];
 
-(* Backwards compat: old 3-argument signature *)
-PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
-  Module[{},
-    SyncModeToContext[];
-    PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
-  ];
-
 Protect[PrintComponentEquation];
 
 

--- a/codes/CarpetXPointDesc.wl
+++ b/codes/CarpetXPointDesc.wl
@@ -166,13 +166,6 @@ PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerule
     ]
   ];
 
-(* Backwards compat: old 3-argument signature *)
-PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
-  Module[{},
-    SyncModeToContext[];
-    PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
-  ];
-
 Protect[PrintComponentEquation];
 
 

--- a/codes/Nmesh.wl
+++ b/codes/Nmesh.wl
@@ -91,13 +91,6 @@ PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerule
     ]
   ];
 
-(* Backwards compat: old 3-argument signature *)
-PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
-  Module[{},
-    SyncModeToContext[];
-    PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
-  ];
-
 Protect[PrintComponentEquation];
 
 (*

--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -80,37 +80,13 @@ PrintVerbose::usage = "PrintVerbose[expr] prints expr if verbose mode is enabled
 
 Begin["`Private`"];
 
-(* Data *)
-
-$CheckInputEquations = False;
-
-$PVerbose = False;
-
-(* Quiet mode - suppress all output when QUIET=1 environment variable is set *)
-
-$QuietMode = (Environment["QUIET"] === "1");
-
-$PrintDate = True;
-
-$PrintHeaderMacro = True;
-
-$GridPointIndex = "";
-
-$TilePointIndex = "";
-
-$SuffixUnprotected = "$Upt";
-
-$OutputFile = "output.c";
-
-$Project = "TEST";
-
 (* Function *)
 
 (* Context-aware getter *)
 GetCheckInputEquations[ctx_Association] := GetCtx[ctx, "CheckInputEquations"];
 
-(* Global getter - uses current context *)
-GetCheckInputEquations[] := $CheckInputEquations;
+(* Global getter - reads from $CurrentContext *)
+GetCheckInputEquations[] := $CurrentContext["CheckInputEquations"];
 
 Protect[GetCheckInputEquations];
 
@@ -118,10 +94,10 @@ Protect[GetCheckInputEquations];
 SetCheckInputEquations[ctx_Association, checkinput_] :=
   SetCtx[ctx, "CheckInputEquations", checkinput];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetCheckInputEquations[checkinput_] :=
   Module[{},
-    $CheckInputEquations = checkinput
+    $CurrentContext = SetCtx[$CurrentContext, "CheckInputEquations", checkinput]
   ];
 
 Protect[SetCheckInputEquations];
@@ -129,8 +105,8 @@ Protect[SetCheckInputEquations];
 (* Context-aware getter *)
 GetPVerbose[ctx_Association] := GetCtx[ctx, "PVerbose"];
 
-(* Global getter - uses current context *)
-GetPVerbose[] := $PVerbose;
+(* Global getter - reads from $CurrentContext *)
+GetPVerbose[] := $CurrentContext["PVerbose"];
 
 Protect[GetPVerbose];
 
@@ -138,10 +114,10 @@ Protect[GetPVerbose];
 SetPVerbose[ctx_Association, verbose_] :=
   SetCtx[ctx, "PVerbose", verbose];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetPVerbose[verbose_] :=
   Module[{},
-    $PVerbose = verbose
+    $CurrentContext = SetCtx[$CurrentContext, "PVerbose", verbose]
   ];
 
 Protect[SetPVerbose];
@@ -149,8 +125,8 @@ Protect[SetPVerbose];
 (* Context-aware getter *)
 GetPrintDate[ctx_Association] := GetCtx[ctx, "PrintDate"];
 
-(* Global getter - uses current context *)
-GetPrintDate[] := $PrintDate;
+(* Global getter - reads from $CurrentContext *)
+GetPrintDate[] := $CurrentContext["PrintDate"];
 
 Protect[GetPrintDate];
 
@@ -158,10 +134,10 @@ Protect[GetPrintDate];
 SetPrintDate[ctx_Association, print_] :=
   SetCtx[ctx, "PrintDate", print];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetPrintDate[print_] :=
   Module[{},
-    $PrintDate = print
+    $CurrentContext = SetCtx[$CurrentContext, "PrintDate", print]
   ];
 
 Protect[SetPrintDate];
@@ -169,8 +145,8 @@ Protect[SetPrintDate];
 (* Context-aware getter *)
 GetPrintHeaderMacro[ctx_Association] := GetCtx[ctx, "PrintHeaderMacro"];
 
-(* Global getter - uses current context *)
-GetPrintHeaderMacro[] := $PrintHeaderMacro;
+(* Global getter - reads from $CurrentContext *)
+GetPrintHeaderMacro[] := $CurrentContext["PrintHeaderMacro"];
 
 Protect[GetPrintHeaderMacro];
 
@@ -178,10 +154,10 @@ Protect[GetPrintHeaderMacro];
 SetPrintHeaderMacro[ctx_Association, print_] :=
   SetCtx[ctx, "PrintHeaderMacro", print];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetPrintHeaderMacro[print_] :=
   Module[{},
-    $PrintHeaderMacro = print
+    $CurrentContext = SetCtx[$CurrentContext, "PrintHeaderMacro", print]
   ];
 
 Protect[SetPrintHeaderMacro];
@@ -189,8 +165,8 @@ Protect[SetPrintHeaderMacro];
 (* Context-aware getter *)
 GetGridPointIndex[ctx_Association] := GetCtx[ctx, "GridPointIndex"];
 
-(* Global getter - uses current context *)
-GetGridPointIndex[] := $GridPointIndex;
+(* Global getter - reads from $CurrentContext *)
+GetGridPointIndex[] := $CurrentContext["GridPointIndex"];
 
 Protect[GetGridPointIndex];
 
@@ -198,10 +174,10 @@ Protect[GetGridPointIndex];
 SetGridPointIndex[ctx_Association, gridindex_] :=
   SetCtx[ctx, "GridPointIndex", gridindex];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetGridPointIndex[gridindex_] :=
   Module[{},
-    $GridPointIndex = gridindex
+    $CurrentContext = SetCtx[$CurrentContext, "GridPointIndex", gridindex]
   ];
 
 Protect[SetGridPointIndex];
@@ -209,8 +185,8 @@ Protect[SetGridPointIndex];
 (* Context-aware getter *)
 GetTilePointIndex[ctx_Association] := GetCtx[ctx, "TilePointIndex"];
 
-(* Global getter - uses current context *)
-GetTilePointIndex[] := $TilePointIndex;
+(* Global getter - reads from $CurrentContext *)
+GetTilePointIndex[] := $CurrentContext["TilePointIndex"];
 
 Protect[GetTilePointIndex];
 
@@ -218,10 +194,10 @@ Protect[GetTilePointIndex];
 SetTilePointIndex[ctx_Association, tileindex_] :=
   SetCtx[ctx, "TilePointIndex", tileindex];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetTilePointIndex[tileindex_] :=
   Module[{},
-    $TilePointIndex = tileindex
+    $CurrentContext = SetCtx[$CurrentContext, "TilePointIndex", tileindex]
   ];
 
 Protect[SetTilePointIndex];
@@ -229,8 +205,8 @@ Protect[SetTilePointIndex];
 (* Context-aware getter *)
 GetSuffixUnprotected[ctx_Association] := GetCtx[ctx, "SuffixUnprotected"];
 
-(* Global getter - uses current context *)
-GetSuffixUnprotected[] := $SuffixUnprotected;
+(* Global getter - reads from $CurrentContext *)
+GetSuffixUnprotected[] := $CurrentContext["SuffixUnprotected"];
 
 Protect[GetSuffixUnprotected];
 
@@ -238,10 +214,10 @@ Protect[GetSuffixUnprotected];
 SetSuffixUnprotected[ctx_Association, suffix_] :=
   SetCtx[ctx, "SuffixUnprotected", suffix];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetSuffixUnprotected[suffix_] :=
   Module[{},
-    $SuffixUnprotected = suffix
+    $CurrentContext = SetCtx[$CurrentContext, "SuffixUnprotected", suffix]
   ];
 
 Protect[SetSuffixUnprotected];
@@ -249,8 +225,8 @@ Protect[SetSuffixUnprotected];
 (* Context-aware getter *)
 GetOutputFile[ctx_Association] := GetCtx[ctx, "OutputFile"];
 
-(* Global getter - uses current context *)
-GetOutputFile[] := $OutputFile;
+(* Global getter - reads from $CurrentContext *)
+GetOutputFile[] := $CurrentContext["OutputFile"];
 
 Protect[GetOutputFile];
 
@@ -258,10 +234,10 @@ Protect[GetOutputFile];
 SetOutputFile[ctx_Association, filename_] :=
   SetCtx[ctx, "OutputFile", filename];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetOutputFile[filename_] :=
   Module[{},
-    $OutputFile = filename
+    $CurrentContext = SetCtx[$CurrentContext, "OutputFile", filename]
   ];
 
 Protect[SetOutputFile];
@@ -269,8 +245,8 @@ Protect[SetOutputFile];
 (* Context-aware getter *)
 GetProject[ctx_Association] := GetCtx[ctx, "Project"];
 
-(* Global getter - uses current context *)
-GetProject[] := $Project;
+(* Global getter - reads from $CurrentContext *)
+GetProject[] := $CurrentContext["Project"];
 
 Protect[GetProject];
 
@@ -278,10 +254,10 @@ Protect[GetProject];
 SetProject[ctx_Association, name_] :=
   SetCtx[ctx, "Project", name];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetProject[name_] :=
   Module[{},
-    $Project = name
+    $CurrentContext = SetCtx[$CurrentContext, "Project", name]
   ];
 
 Protect[SetProject];

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -52,31 +52,13 @@ Is3DAbstractIndex::usage = "Is3DAbstractIndex[index] returns True if the abstrac
 
 Begin["`Private`"];
 
-(* Data *)
-
-$MapComponentToVarlist = <||>;(*store all varlist's map*)
-
-$ProcessNewVarlist = True;
-
-$SimplifyEquation = True;
-
-$UseLetterForTensorComponent = False;
-
-$TempVariableType = "double";
-
-$InterfaceWithNonCoordBasis = False;
-
-$SuffixName = "";
-
-$PrefixDt = "dt";
-
 (* Function *)
 
 (* Context-aware getter *)
 GetMapComponentToVarlist[ctx_Association] := GetCtx[ctx, "MapComponentToVarlist"];
 
-(* Global getter - uses global variable *)
-GetMapComponentToVarlist[] := $MapComponentToVarlist;
+(* Global getter - reads from $CurrentContext *)
+GetMapComponentToVarlist[] := $CurrentContext["MapComponentToVarlist"];
 
 Protect[GetMapComponentToVarlist];
 
@@ -84,10 +66,10 @@ Protect[GetMapComponentToVarlist];
 SetMapComponentToVarlist[ctx_Association, map_] :=
   SetCtx[ctx, "MapComponentToVarlist", map];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetMapComponentToVarlist[map_] :=
   Module[{},
-    $MapComponentToVarlist = map
+    $CurrentContext = SetCtx[$CurrentContext, "MapComponentToVarlist", map]
   ];
 
 Protect[SetMapComponentToVarlist];
@@ -95,8 +77,8 @@ Protect[SetMapComponentToVarlist];
 (* Context-aware getter *)
 GetProcessNewVarlist[ctx_Association] := GetCtx[ctx, "ProcessNewVarlist"];
 
-(* Global getter - uses global variable *)
-GetProcessNewVarlist[] := $ProcessNewVarlist;
+(* Global getter - reads from $CurrentContext *)
+GetProcessNewVarlist[] := $CurrentContext["ProcessNewVarlist"];
 
 Protect[GetProcessNewVarlist];
 
@@ -104,10 +86,10 @@ Protect[GetProcessNewVarlist];
 SetProcessNewVarlist[ctx_Association, isnew_] :=
   SetCtx[ctx, "ProcessNewVarlist", isnew];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetProcessNewVarlist[isnew_] :=
   Module[{},
-    $ProcessNewVarlist = isnew
+    $CurrentContext = SetCtx[$CurrentContext, "ProcessNewVarlist", isnew]
   ];
 
 Protect[SetProcessNewVarlist];
@@ -115,8 +97,8 @@ Protect[SetProcessNewVarlist];
 (* Context-aware getter *)
 GetSimplifyEquation[ctx_Association] := GetCtx[ctx, "SimplifyEquation"];
 
-(* Global getter - uses global variable *)
-GetSimplifyEquation[] := $SimplifyEquation;
+(* Global getter - reads from $CurrentContext *)
+GetSimplifyEquation[] := $CurrentContext["SimplifyEquation"];
 
 Protect[GetSimplifyEquation];
 
@@ -124,10 +106,10 @@ Protect[GetSimplifyEquation];
 SetSimplifyEquation[ctx_Association, simplify_] :=
   SetCtx[ctx, "SimplifyEquation", simplify];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetSimplifyEquation[simplify_] :=
   Module[{},
-    $SimplifyEquation = simplify
+    $CurrentContext = SetCtx[$CurrentContext, "SimplifyEquation", simplify]
   ];
 
 Protect[SetSimplifyEquation];
@@ -135,8 +117,8 @@ Protect[SetSimplifyEquation];
 (* Context-aware getter *)
 GetUseLetterForTensorComponent[ctx_Association] := GetCtx[ctx, "UseLetterForTensorComponent"];
 
-(* Global getter - uses global variable *)
-GetUseLetterForTensorComponent[] := $UseLetterForTensorComponent;
+(* Global getter - reads from $CurrentContext *)
+GetUseLetterForTensorComponent[] := $CurrentContext["UseLetterForTensorComponent"];
 
 Protect[GetUseLetterForTensorComponent];
 
@@ -144,10 +126,10 @@ Protect[GetUseLetterForTensorComponent];
 SetUseLetterForTensorComponent[ctx_Association, useletter_] :=
   SetCtx[ctx, "UseLetterForTensorComponent", useletter];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetUseLetterForTensorComponent[useletter_] :=
   Module[{},
-    $UseLetterForTensorComponent = useletter
+    $CurrentContext = SetCtx[$CurrentContext, "UseLetterForTensorComponent", useletter]
   ];
 
 Protect[SetUseLetterForTensorComponent];
@@ -155,8 +137,8 @@ Protect[SetUseLetterForTensorComponent];
 (* Context-aware getter *)
 GetTempVariableType[ctx_Association] := GetCtx[ctx, "TempVariableType"];
 
-(* Global getter - uses global variable *)
-GetTempVariableType[] := $TempVariableType;
+(* Global getter - reads from $CurrentContext *)
+GetTempVariableType[] := $CurrentContext["TempVariableType"];
 
 Protect[GetTempVariableType];
 
@@ -164,10 +146,10 @@ Protect[GetTempVariableType];
 SetTempVariableType[ctx_Association, type_] :=
   SetCtx[ctx, "TempVariableType", type];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetTempVariableType[type_] :=
   Module[{},
-    $TempVariableType = type
+    $CurrentContext = SetCtx[$CurrentContext, "TempVariableType", type]
   ];
 
 Protect[SetTempVariableType];
@@ -175,8 +157,8 @@ Protect[SetTempVariableType];
 (* Context-aware getter *)
 GetInterfaceWithNonCoordBasis[ctx_Association] := GetCtx[ctx, "InterfaceWithNonCoordBasis"];
 
-(* Global getter - uses global variable *)
-GetInterfaceWithNonCoordBasis[] := $InterfaceWithNonCoordBasis;
+(* Global getter - reads from $CurrentContext *)
+GetInterfaceWithNonCoordBasis[] := $CurrentContext["InterfaceWithNonCoordBasis"];
 
 Protect[GetInterfaceWithNonCoordBasis];
 
@@ -184,10 +166,10 @@ Protect[GetInterfaceWithNonCoordBasis];
 SetInterfaceWithNonCoordBasis[ctx_Association, noncoordbasis_] :=
   SetCtx[ctx, "InterfaceWithNonCoordBasis", noncoordbasis];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetInterfaceWithNonCoordBasis[noncoordbasis_] :=
   Module[{},
-    $InterfaceWithNonCoordBasis = noncoordbasis
+    $CurrentContext = SetCtx[$CurrentContext, "InterfaceWithNonCoordBasis", noncoordbasis]
   ];
 
 Protect[SetInterfaceWithNonCoordBasis];
@@ -195,8 +177,8 @@ Protect[SetInterfaceWithNonCoordBasis];
 (* Context-aware getter *)
 GetSuffixName[ctx_Association] := GetCtx[ctx, "SuffixName"];
 
-(* Global getter - uses global variable *)
-GetSuffixName[] := $SuffixName;
+(* Global getter - reads from $CurrentContext *)
+GetSuffixName[] := $CurrentContext["SuffixName"];
 
 Protect[GetSuffixName];
 
@@ -204,10 +186,10 @@ Protect[GetSuffixName];
 SetSuffixName[ctx_Association, suffix_] :=
   SetCtx[ctx, "SuffixName", suffix];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetSuffixName[suffix_] :=
   Module[{},
-    $SuffixName = suffix
+    $CurrentContext = SetCtx[$CurrentContext, "SuffixName", suffix]
   ];
 
 Protect[SetSuffixName];
@@ -215,8 +197,8 @@ Protect[SetSuffixName];
 (* Context-aware getter *)
 GetPrefixDt[ctx_Association] := GetCtx[ctx, "PrefixDt"];
 
-(* Global getter - uses global variable *)
-GetPrefixDt[] := $PrefixDt;
+(* Global getter - reads from $CurrentContext *)
+GetPrefixDt[] := $CurrentContext["PrefixDt"];
 
 Protect[GetPrefixDt];
 
@@ -224,10 +206,10 @@ Protect[GetPrefixDt];
 SetPrefixDt[ctx_Association, prefix_] :=
   SetCtx[ctx, "PrefixDt", prefix];
 
-(* Global setter - mutates global variable *)
+(* Global setter - writes to $CurrentContext *)
 SetPrefixDt[prefix_] :=
   Module[{},
-    $PrefixDt = prefix
+    $CurrentContext = SetCtx[$CurrentContext, "PrefixDt", prefix]
   ];
 
 Protect[SetPrefixDt];
@@ -261,8 +243,6 @@ Protect[ParseComponent];
 
 PrintComponent[coordinate_, varinfo_, compname_, extrareplacerules_] :=
   Module[{},
-    (* Sync global state to $CurrentContext before calling backend *)
-    SyncModeToContext[];
     Which[
       InInitializationsMode[],
         PrintVerbose["    PrintComponentInitialization ", compname, "..."];

--- a/test/regression/Nmesh/GHG_set_profile_ADM.wl
+++ b/test/regression/Nmesh/GHG_set_profile_ADM.wl
@@ -341,12 +341,12 @@ $MainPrint[] :=
       ,
       (* set d_k g_{ab} *)
       printdg[cc_, aa_, bb_] :=
-        Module[{},
-          SetMode["Phase" -> "PrintComp"];
-          SetMode["PrintComp", "Type" -> "Equations"];
-          SetMode["PrintComp", "Equations", "Mode" -> "MainOut"];
-          PrintComponentEquation[GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}];
-          ResetMode["PrintComp", "Equations"];
+        WithMode[{
+          {"Phase"} -> "PrintComp",
+          {"PrintComp", "Type"} -> "Equations",
+          {"PrintComp", "Equations", "Mode"} -> "MainOut"
+        },
+          PrintComponentEquation[$CurrentContext, GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}]
         ];
       Do[printdg[cc, aa, bb], {cc, 3, 1, -1}, {aa, 3, 0, -1}, {bb, 3, aa, -1}];
       (* set d_t g_{ab} *)
@@ -354,14 +354,16 @@ $MainPrint[] :=
       pr[];
       Module[{printdtgEin},
         printdtgEin[cc_, aa_, bb_] :=
-          Module[{},
+          Module[{savedSuffix = GetSuffixName[]},
             SetSuffixName["Ein"];
-            SetMode["Phase" -> "PrintComp"];
-            SetMode["PrintComp", "Type" -> "Equations"];
-            SetMode["PrintComp", "Equations", "Mode" -> "MainOut"];
-            PrintComponentEquation[GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}];
-            ResetMode["PrintComp", "Equations"];
-            SetSuffixName[""];
+            WithMode[{
+              {"Phase"} -> "PrintComp",
+              {"PrintComp", "Type"} -> "Equations",
+              {"PrintComp", "Equations", "Mode"} -> "MainOut"
+            },
+              PrintComponentEquation[$CurrentContext, GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}]
+            ];
+            SetSuffixName[savedSuffix]
           ];
         Do[printdtgEin[0, aa, bb], {aa, 3, 0, -1}, {bb, 3, aa, -1}];
         pr[];

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -1,7 +1,7 @@
 (* ::Package:: *)
 
 (* ParseModeTests.wl *)
-(* Unit tests for Generato`ParseMode module - New Nested Mode System *)
+(* Unit tests for Generato`ParseMode module - Flat Context-Based System *)
 
 If[Environment["QUIET"] =!= "1", Print["Loading ParseModeTests.wl..."]];
 
@@ -11,15 +11,17 @@ Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 SetPVerbose[False];
 SetPrintDate[False];
 
+(* Helper to reset context to defaults *)
+ResetContext[] := ($CurrentContext = CreateContext[]);
+
 (* ========================================= *)
-(* Test: GetMode / SetMode / ResetMode *)
+(* Test: WithMode with nested path syntax *)
 (* ========================================= *)
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["Phase" -> "SetComp"];
-    GetMode["Phase"],
+    ResetContext[];
+    WithMode[{{"Phase"} -> "SetComp"}, GetPhase[]],
     "SetComp",
     TestID -> "Mode-Phase-SetComp"
   ]
@@ -27,9 +29,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["Phase" -> "PrintComp"];
-    GetMode["Phase"],
+    ResetContext[];
+    WithMode[{{"Phase"} -> "PrintComp"}, GetPhase[]],
     "PrintComp",
     TestID -> "Mode-Phase-PrintComp"
   ]
@@ -37,8 +38,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    GetMode["Phase"],
+    ResetContext[];
+    GetPhase[],
     None,
     TestID -> "Mode-Phase-Default-None"
   ]
@@ -50,9 +51,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["IndexOptions", "IndependentVarlistIndex" -> True];
-    GetMode["IndexOptions", "IndependentVarlistIndex"],
+    ResetContext[];
+    WithMode[{{"IndexOptions", "IndependentVarlistIndex"} -> True}, GetIndependentVarlistIndex[]],
     True,
     TestID -> "Mode-IndexOptions-IndependentVarlistIndex"
   ]
@@ -60,9 +60,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["IndexOptions", "WithoutGridPointIndex" -> True];
-    GetMode["IndexOptions", "WithoutGridPointIndex"],
+    ResetContext[];
+    WithMode[{{"IndexOptions", "WithoutGridPointIndex"} -> True}, GetWithoutGridPointIndex[]],
     True,
     TestID -> "Mode-IndexOptions-WithoutGridPointIndex"
   ]
@@ -70,9 +69,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["IndexOptions", "UseTilePointIndex" -> True];
-    GetMode["IndexOptions", "UseTilePointIndex"],
+    ResetContext[];
+    WithMode[{{"IndexOptions", "UseTilePointIndex"} -> True}, GetUseTilePointIndex[]],
     True,
     TestID -> "Mode-IndexOptions-UseTilePointIndex"
   ]
@@ -84,10 +82,11 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Type" -> "Initializations"];
-    SetMode["PrintComp", "Initializations", "Mode" -> "MainIn"];
-    GetMode["PrintComp", "Initializations", "Mode"],
+    ResetContext[];
+    WithMode[{
+      {"PrintComp", "Type"} -> "Initializations",
+      {"PrintComp", "Initializations", "Mode"} -> "MainIn"
+    }, GetInitializationsMode[]],
     "MainIn",
     TestID -> "Mode-PrintComp-Initializations-MainIn"
   ]
@@ -95,9 +94,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Initializations", "TensorType" -> "Vect"];
-    GetMode["PrintComp", "Initializations", "TensorType"],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Initializations", "TensorType"} -> "Vect"}, GetTensorType[]],
     "Vect",
     TestID -> "Mode-PrintComp-Initializations-TensorType-Vect"
   ]
@@ -105,9 +103,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Initializations", "StorageType" -> "Tile"];
-    GetMode["PrintComp", "Initializations", "StorageType"],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Initializations", "StorageType"} -> "Tile"}, GetStorageType[]],
     "Tile",
     TestID -> "Mode-PrintComp-Initializations-StorageType-Tile"
   ]
@@ -115,10 +112,11 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Initializations", "DerivsOrder" -> 2];
-    SetMode["PrintComp", "Initializations", "DerivsAccuracy" -> 6];
-    {GetMode["PrintComp", "Initializations", "DerivsOrder"], GetMode["PrintComp", "Initializations", "DerivsAccuracy"]},
+    ResetContext[];
+    WithMode[{
+      {"PrintComp", "Initializations", "DerivsOrder"} -> 2,
+      {"PrintComp", "Initializations", "DerivsAccuracy"} -> 6
+    }, {GetDerivsOrder[], GetDerivsAccuracy[]}],
     {2, 6},
     TestID -> "Mode-PrintComp-Initializations-Derivs"
   ]
@@ -130,9 +128,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Equations", "Mode" -> "Temp"];
-    GetMode["PrintComp", "Equations", "Mode"],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Equations", "Mode"} -> "Temp"}, GetEquationsMode[]],
     "Temp",
     TestID -> "Mode-PrintComp-Equations-Temp"
   ]
@@ -140,9 +137,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Equations", "Mode" -> "MainOut"];
-    GetMode["PrintComp", "Equations", "Mode"],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Equations", "Mode"} -> "MainOut"}, GetEquationsMode[]],
     "MainOut",
     TestID -> "Mode-PrintComp-Equations-MainOut"
   ]
@@ -150,9 +146,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Equations", "Mode" -> "AddToMainOut"];
-    GetMode["PrintComp", "Equations", "Mode"],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Equations", "Mode"} -> "AddToMainOut"}, GetEquationsMode[]],
     "AddToMainOut",
     TestID -> "Mode-PrintComp-Equations-AddToMainOut"
   ]
@@ -164,9 +159,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["Phase" -> "SetComp"];
-    InSetCompPhase[],
+    ResetContext[];
+    WithMode[{{"Phase"} -> "SetComp"}, InSetCompPhase[]],
     True,
     TestID -> "Mode-Helper-InSetCompPhase"
   ]
@@ -174,9 +168,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["Phase" -> "PrintComp"];
-    InPrintCompPhase[],
+    ResetContext[];
+    WithMode[{{"Phase"} -> "PrintComp"}, InPrintCompPhase[]],
     True,
     TestID -> "Mode-Helper-InPrintCompPhase"
   ]
@@ -184,9 +177,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Type" -> "Initializations"];
-    InInitializationsMode[],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Type"} -> "Initializations"}, InInitializationsMode[]],
     True,
     TestID -> "Mode-Helper-InInitializationsMode"
   ]
@@ -194,9 +186,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Type" -> "Equations"];
-    InEquationsMode[],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Type"} -> "Equations"}, InEquationsMode[]],
     True,
     TestID -> "Mode-Helper-InEquationsMode"
   ]
@@ -204,9 +195,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Initializations", "Mode" -> "MainOut"];
-    GetInitializationsMode[],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Initializations", "Mode"} -> "MainOut"}, GetInitializationsMode[]],
     "MainOut",
     TestID -> "Mode-Helper-GetInitializationsMode"
   ]
@@ -214,27 +204,35 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Equations", "Mode" -> "MainOut"];
-    GetEquationsMode[],
+    ResetContext[];
+    WithMode[{{"PrintComp", "Equations", "Mode"} -> "MainOut"}, GetEquationsMode[]],
     "MainOut",
     TestID -> "Mode-Helper-GetEquationsMode"
   ]
 ];
 
 (* ========================================= *)
-(* Test: ResetMode Subtree *)
+(* Test: Context isolation in WithMode *)
 (* ========================================= *)
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    SetMode["PrintComp", "Initializations", "Mode" -> "MainIn"];
-    SetMode["PrintComp", "Initializations", "TensorType" -> "Vect"];
-    ResetMode["PrintComp", "Initializations"];
-    {GetMode["PrintComp", "Initializations", "Mode"], GetMode["PrintComp", "Initializations", "TensorType"]},
-    {None, None},
-    TestID -> "Mode-ResetMode-Subtree"
+    ResetContext[];
+    (* Set initial values, then verify WithMode restores them *)
+    $CurrentContext = SetCtx[$CurrentContext, "InitializationsMode", "MainIn"];
+    $CurrentContext = SetCtx[$CurrentContext, "TensorType", "Vect"];
+    (* WithMode should temporarily change, then restore *)
+    WithMode[{
+      {"PrintComp", "Initializations", "Mode"} -> "Temp",
+      {"PrintComp", "Initializations", "TensorType"} -> "Scal"
+    },
+      (* Inside WithMode, check the temp values *)
+      GetInitializationsMode[] === "Temp" && GetTensorType[] === "Scal"
+    ] &&
+    (* After WithMode, check restored values *)
+    GetInitializationsMode[] === "MainIn" && GetTensorType[] === "Vect",
+    True,
+    TestID -> "Mode-Context-Isolation"
   ]
 ];
 
@@ -244,8 +242,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetMode[];
-    Quiet[Catch[SetMode["Phase" -> "InvalidPhase"]], SetMode::EInvalidValue],
+    ResetContext[];
+    ctx = CreateContext[];
+    Quiet[Catch[SetPhase[ctx, "InvalidPhase"]], SetPhase::EInvalidValue],
     Null,
     TestID -> "Mode-Validation-InvalidPhase"
   ]
@@ -255,6 +254,6 @@ AppendTo[$AllTests,
 (* Cleanup *)
 (* ========================================= *)
 
-ResetMode[];
+ResetContext[];
 
 If[Environment["QUIET"] =!= "1", Print["ParseModeTests.wl completed."]];

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -176,8 +176,9 @@ AppendTo[$AllTests,
     (* ParseVarlist should process a list of variable definitions *)
     (* This is a basic smoke test - full functionality tested via GridTensors *)
     varlist = {{parseVarlistTest[i], PrintAs -> "pvt"}};
-    SetMode["Phase" -> "SetComp"];
-    ParseVarlist[varlist, testCart];
+    WithMode[{{"Phase"} -> "SetComp"},
+      ParseVarlist[varlist, testCart]
+    ];
     True,
     True,
     TestID -> "ParseVarlist-BasicSmoke"


### PR DESCRIPTION
## Summary
- Removes duplicate global variables (`$Mode`, `$CheckInputEquations`, etc.) from Basic.wl, Component.wl, ParseMode.wl, Writefile.wl
- Global getters/setters now read/write directly to `$CurrentContext` instead of maintaining separate variables
- Eliminates `SyncModeToContext()` and nested `$Mode` structure as they are no longer needed
- Simplifies `WithMode` to work with flat context keys via `PathToFlatKey` mapping
- Removes backwards-compatible 3-argument `PrintComponentEquation` signatures from all backends

## Test plan
- [ ] Run `wolframscript -script test/AllTests.wl` to verify all unit and regression tests pass
- [ ] Verify `WithMode` properly saves/restores only modified keys
- [ ] Check that global getters return correct values from `$CurrentContext`