### PR TITLE
Refactor: Remove global API wrappers and use flat keys in WithMode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ ctx = SetGridPointIndex[ctx, "[[ijk]]"];
 Use `WithMode` for scoped settings that auto-restore:
 ```wolfram
 WithMode[{
-  {"Phase"} -> "PrintComp",
-  {"PrintComp", "Type"} -> "Equations"
+  "Phase" -> "PrintComp",
+  "PrintCompType" -> "Equations"
 },
   (* body - settings restored after *)
 ];

--- a/codes/AMReX.wl
+++ b/codes/AMReX.wl
@@ -66,8 +66,8 @@ PrintFDExpression[accuracyOrd_?IntegerQ, fdOrd_?IntegerQ, strIdx_?StringQ] :=
 (*            Print initialization of each component of a tensor              *)
 (******************************************************************************)
 
-PrintComponentInitialization[ctx_Association, varinfo_, compname_] :=
-  Module[{varlistindex, compToValue, varname, symmetry, buf, subbuf, len,
+PrintComponentInitialization[varinfo_, compname_] :=
+  Module[{ctx = $CurrentContext, varlistindex, compToValue, varname, symmetry, buf, subbuf, len,
           fdorder, fdaccuracy},
     (* Extract common component info using shared function *)
     {varlistindex, compToValue, varname, symmetry, len} =
@@ -130,8 +130,9 @@ Protect[PrintComponentInitialization];
  *        introduced to replace say coordinates representation of metric.
  *)
 
-PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
-  Module[{outputfile = GetOutputFile[ctx], compToValue, rhssToValue},
+PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
+  Module[{ctx = $CurrentContext, outputfile, compToValue, rhssToValue},
+    outputfile = GetOutputFile[ctx];
     compToValue = (compname // ToValues) /. extrareplacerules;
     rhssToValue = ComputeRHSValue[ctx, coordinate, compname, extrareplacerules];
     PrintEquationByMode[ctx, compToValue, rhssToValue,
@@ -160,4 +161,4 @@ Protect[PrintComponentEquation];
 (*                                Write to files                              *)
 (******************************************************************************)
 
-WriteToFile[GetOutputFile[]];
+WriteToFile[$CurrentContext, GetOutputFile[$CurrentContext]];

--- a/codes/Carpet.wl
+++ b/codes/Carpet.wl
@@ -152,8 +152,8 @@ PrintFDExpressionMix2nd[accuracyOrd_?IntegerQ, strIdx_?StringQ] :=
 (*            Print initialization of each component of a tensor              *)
 (******************************************************************************)
 
-PrintComponentInitialization[ctx_Association, varinfo_, compname_] :=
-  Module[{varlistindex, compToValue, varname, symmetry, buf, subbuf, len,
+PrintComponentInitialization[varinfo_, compname_] :=
+  Module[{ctx = $CurrentContext, varlistindex, compToValue, varname, symmetry, buf, subbuf, len,
           fdorder, fdaccuracy},
     (* Extract common component info using shared function *)
     {varlistindex, compToValue, varname, symmetry, len} =
@@ -219,8 +219,9 @@ Protect[PrintComponentInitialization];
  *        introduced to replace say coordinates representation of metric.
  *)
 
-PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
-  Module[{outputfile = GetOutputFile[ctx], compToValue, rhssToValue},
+PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
+  Module[{ctx = $CurrentContext, outputfile, compToValue, rhssToValue},
+    outputfile = GetOutputFile[ctx];
     compToValue = compname // ToValues;
     rhssToValue = ComputeRHSValue[ctx, coordinate, compname, extrareplacerules];
     PrintEquationByMode[ctx, compToValue, rhssToValue,
@@ -249,4 +250,4 @@ Protect[PrintComponentEquation];
 (*                                Write to files                              *)
 (******************************************************************************)
 
-WriteToFile[GetOutputFile[]];
+WriteToFile[$CurrentContext, GetOutputFile[$CurrentContext]];

--- a/codes/CarpetX.wl
+++ b/codes/CarpetX.wl
@@ -25,8 +25,8 @@ Protect[PrintListInitializations];
     Print initialization of each component of a tensor
 *)
 
-PrintComponentInitialization[ctx_Association, varinfo_, compname_] :=
-  Module[{varlistindex, compToValue, varname, symmetry, buf, subbuf, len, isGF3D2, isGF3D5},
+PrintComponentInitialization[varinfo_, compname_] :=
+  Module[{ctx = $CurrentContext, varlistindex, compToValue, varname, symmetry, buf, subbuf, len, isGF3D2, isGF3D5},
     (* Extract common component info using shared function *)
     {varlistindex, compToValue, varname, symmetry, len} =
       ExtractComponentInfo[ctx, varinfo, compname];
@@ -130,8 +130,9 @@ Protect[PrintComponentInitialization];
  *        introduced to replace say coordinates representation of metric.
  *)
 
-PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
-  Module[{outputfile = GetOutputFile[ctx], compToValue, rhssToValue},
+PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
+  Module[{ctx = $CurrentContext, outputfile, compToValue, rhssToValue},
+    outputfile = GetOutputFile[ctx];
     compToValue = compname // ToValues;
     rhssToValue = ComputeRHSValue[ctx, coordinate, compname, extrareplacerules];
     PrintEquationByMode[ctx, compToValue, rhssToValue,
@@ -152,4 +153,4 @@ Protect[PrintComponentEquation];
 
 (******************************************************************************)
 
-WriteToFile[GetOutputFile[]];
+WriteToFile[$CurrentContext, GetOutputFile[$CurrentContext]];

--- a/codes/CarpetXGPU.wl
+++ b/codes/CarpetXGPU.wl
@@ -150,8 +150,8 @@ PrintFDExpressionMix2nd[accuracyOrd_?IntegerQ, strIdx_?StringQ] :=
 (*            Print initialization of each component of a tensor              *)
 (******************************************************************************)
 
-PrintComponentInitialization[ctx_Association, varinfo_, compname_] :=
-  Module[{varlistindex, compToValue, varname, symmetry, buf, subbuf, len,
+PrintComponentInitialization[varinfo_, compname_] :=
+  Module[{ctx = $CurrentContext, varlistindex, compToValue, varname, symmetry, buf, subbuf, len,
           fdorder, fdaccuracy},
     (* Extract common component info using shared function *)
     {varlistindex, compToValue, varname, symmetry, len} =
@@ -273,8 +273,9 @@ Protect[PrintComponentInitialization];
  *        introduced to replace say coordinates representation of metric.
  *)
 
-PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
-  Module[{outputfile = GetOutputFile[ctx], compToValue, rhssToValue},
+PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
+  Module[{ctx = $CurrentContext, outputfile, compToValue, rhssToValue},
+    outputfile = GetOutputFile[ctx];
     compToValue = (compname // ToValues) /. extrareplacerules;
     rhssToValue = ComputeRHSValue[ctx, coordinate, compname, extrareplacerules];
     PrintEquationByMode[ctx, compToValue, rhssToValue,
@@ -303,4 +304,4 @@ Protect[PrintComponentEquation];
 (*                                Write to files                              *)
 (******************************************************************************)
 
-WriteToFile[GetOutputFile[]];
+WriteToFile[$CurrentContext, GetOutputFile[$CurrentContext]];

--- a/codes/CarpetXPointDesc.wl
+++ b/codes/CarpetXPointDesc.wl
@@ -90,8 +90,8 @@ PrintFDExpressionMix2nd[accuracyOrd_?IntegerQ,
 (*            Print initialization of each component of a tensor              *)
 (******************************************************************************)
 
-PrintComponentInitialization[ctx_Association, varinfo_, compname_] :=
-  Module[{varlistindex, compToValue, varname, symmetry, buf, subbuf, len},
+PrintComponentInitialization[varinfo_, compname_] :=
+  Module[{ctx = $CurrentContext, varlistindex, compToValue, varname, symmetry, buf, subbuf, len},
     (* Extract common component info using shared function *)
     {varlistindex, compToValue, varname, symmetry, len} =
       ExtractComponentInfo[ctx, varinfo, compname];
@@ -142,8 +142,9 @@ Protect[PrintComponentInitialization];
  *        introduced to replace say coordinates representation of metric.
  *)
 
-PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
-  Module[{outputfile = GetOutputFile[ctx], compToValue, rhssToValue},
+PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
+  Module[{ctx = $CurrentContext, outputfile, compToValue, rhssToValue},
+    outputfile = GetOutputFile[ctx];
     compToValue = compname // ToValues;
     rhssToValue = ComputeRHSValue[ctx, coordinate, compname, extrareplacerules];
     PrintEquationByMode[ctx, compToValue, rhssToValue,
@@ -172,11 +173,11 @@ Protect[PrintComponentEquation];
 (*                                Write to files                              *)
 (******************************************************************************)
 
-WriteToFile[GetOutputFile[]];
+WriteToFile[$CurrentContext, GetOutputFile[$CurrentContext]];
 ReplaceGFIndexName[
-  GetOutputFile[],
+  GetOutputFile[$CurrentContext],
   StringDrop[
-    ToString[CForm[ToExpression["gf" <> GetGridPointIndex[]]]]
+    ToString[CForm[ToExpression["gf" <> GetGridPointIndex[$CurrentContext]]]]
     ,
     2
   ] -> "(p.I)"

--- a/codes/Nmesh.wl
+++ b/codes/Nmesh.wl
@@ -22,8 +22,8 @@ GetInitialComp[varname_] :=
     Print initialization of each component of a tensor
 *)
 
-PrintComponentInitialization[ctx_Association, varinfo_, compname_] :=
-  Module[{varlistindex, compToValue, varname, symmetry, len, buf},
+PrintComponentInitialization[varinfo_, compname_] :=
+  Module[{ctx = $CurrentContext, varlistindex, compToValue, varname, symmetry, len, buf},
     (* Extract common component info using shared function *)
     {varlistindex, compToValue, varname, symmetry, len} =
       ExtractComponentInfo[ctx, varinfo, compname];
@@ -77,8 +77,9 @@ Protect[PrintComponentInitialization];
  *        introduced to replace say coordinates representation of metric.
  *)
 
-PrintComponentEquation[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
-  Module[{outputfile = GetOutputFile[ctx], compToValue, rhssToValue},
+PrintComponentEquation[coordinate_, compname_, extrareplacerules_] :=
+  Module[{ctx = $CurrentContext, outputfile, compToValue, rhssToValue},
+    outputfile = GetOutputFile[ctx];
     compToValue = compname // ToValues;
     rhssToValue = ComputeRHSValue[ctx, coordinate, compname, extrareplacerules];
     PrintEquationByMode[ctx, compToValue, rhssToValue,
@@ -99,7 +100,7 @@ Protect[PrintComponentEquation];
     Write to files
 *)
 
-Module[{outputfile = GetOutputFile[], filepointer},
+Module[{outputfile = GetOutputFile[$CurrentContext], filepointer},
   If[Environment["QUIET"] =!= "1", System`Print["Writing to \"", outputfile, "\"...\n"]];
   If[FileExistsQ[outputfile],
     If[Environment["QUIET"] =!= "1", System`Print["\"", outputfile, "\" already exists, replacing it ...\n"]];
@@ -119,7 +120,7 @@ Module[{outputfile = GetOutputFile[], filepointer},
   pr["/* " <> FileNameTake[outputfile] <> " */"];
   pr[
     "/* Produced with Generato" <>
-      If[GetPrintDate[],
+      If[GetPrintDate[$CurrentContext],
         " on " <> DateString[{"Month", "/", "Day", "/", "Year"}]
         ,
         ""

--- a/src/BackendCommon.wl
+++ b/src/BackendCommon.wl
@@ -71,9 +71,6 @@ GetInterfaceName[ctx_Association, compname_] :=
     Return[intfname];
   ];
 
-(* Backwards compat *)
-GetInterfaceName[compname_] := GetInterfaceName[$CurrentContext, compname];
-
 Protect[GetInterfaceName];
 
 (*
@@ -93,10 +90,6 @@ ComputeRHSValue[ctx_Association, coordinate_, compname_, extrareplacerules_] :=
     ];
     rhssToValue
   ];
-
-(* Backwards compat *)
-ComputeRHSValue[coordinate_, compname_, extrareplacerules_] :=
-  ComputeRHSValue[$CurrentContext, coordinate, compname, extrareplacerules];
 
 Protect[ComputeRHSValue];
 
@@ -146,13 +139,6 @@ PrintEquationByMode[ctx_Association, compToValue_, rhssToValue_, mainFormatter_,
     ]
   ];
 
-(* Backwards compat *)
-PrintEquationByMode[compToValue_, rhssToValue_, mainFormatter_] :=
-  PrintEquationByMode[$CurrentContext, compToValue, rhssToValue, mainFormatter, Automatic];
-
-PrintEquationByMode[compToValue_, rhssToValue_, mainFormatter_, tempFormatter_] :=
-  PrintEquationByMode[$CurrentContext, compToValue, rhssToValue, mainFormatter, tempFormatter];
-
 PrintEquationByMode::EMode = "PrintEquationByMode: EquationsMode unrecognized!";
 
 Protect[PrintEquationByMode];
@@ -199,10 +185,6 @@ GetTensorIndexSubbuf[ctx_Association, len_Integer, varlistindex_Integer] :=
         Message[GetTensorIndexSubbuf::ETensorType]; ""
     ]
   ];
-
-(* Backwards compat *)
-GetTensorIndexSubbuf[len_Integer, varlistindex_Integer] :=
-  GetTensorIndexSubbuf[$CurrentContext, len, varlistindex];
 
 GetTensorIndexSubbuf::ELength = "GetTensorIndexSubbuf: Unsupported tensor rank for tensor type.";
 GetTensorIndexSubbuf::ETensorType = "GetTensorIndexSubbuf: Unknown tensor type.";

--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -85,28 +85,16 @@ Begin["`Private`"];
 (* Context-aware getter *)
 GetCheckInputEquations[ctx_Association] := GetCtx[ctx, "CheckInputEquations"];
 
-(* Global getter - reads from $CurrentContext *)
-GetCheckInputEquations[] := $CurrentContext["CheckInputEquations"];
-
 Protect[GetCheckInputEquations];
 
 (* Context-aware setter - returns new context *)
 SetCheckInputEquations[ctx_Association, checkinput_] :=
   SetCtx[ctx, "CheckInputEquations", checkinput];
 
-(* Global setter - writes to $CurrentContext *)
-SetCheckInputEquations[checkinput_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "CheckInputEquations", checkinput]
-  ];
-
 Protect[SetCheckInputEquations];
 
 (* Context-aware getter *)
 GetPVerbose[ctx_Association] := GetCtx[ctx, "PVerbose"];
-
-(* Global getter - reads from $CurrentContext *)
-GetPVerbose[] := $CurrentContext["PVerbose"];
 
 Protect[GetPVerbose];
 
@@ -114,19 +102,10 @@ Protect[GetPVerbose];
 SetPVerbose[ctx_Association, verbose_] :=
   SetCtx[ctx, "PVerbose", verbose];
 
-(* Global setter - writes to $CurrentContext *)
-SetPVerbose[verbose_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "PVerbose", verbose]
-  ];
-
 Protect[SetPVerbose];
 
 (* Context-aware getter *)
 GetPrintDate[ctx_Association] := GetCtx[ctx, "PrintDate"];
-
-(* Global getter - reads from $CurrentContext *)
-GetPrintDate[] := $CurrentContext["PrintDate"];
 
 Protect[GetPrintDate];
 
@@ -134,19 +113,10 @@ Protect[GetPrintDate];
 SetPrintDate[ctx_Association, print_] :=
   SetCtx[ctx, "PrintDate", print];
 
-(* Global setter - writes to $CurrentContext *)
-SetPrintDate[print_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "PrintDate", print]
-  ];
-
 Protect[SetPrintDate];
 
 (* Context-aware getter *)
 GetPrintHeaderMacro[ctx_Association] := GetCtx[ctx, "PrintHeaderMacro"];
-
-(* Global getter - reads from $CurrentContext *)
-GetPrintHeaderMacro[] := $CurrentContext["PrintHeaderMacro"];
 
 Protect[GetPrintHeaderMacro];
 
@@ -154,19 +124,10 @@ Protect[GetPrintHeaderMacro];
 SetPrintHeaderMacro[ctx_Association, print_] :=
   SetCtx[ctx, "PrintHeaderMacro", print];
 
-(* Global setter - writes to $CurrentContext *)
-SetPrintHeaderMacro[print_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "PrintHeaderMacro", print]
-  ];
-
 Protect[SetPrintHeaderMacro];
 
 (* Context-aware getter *)
 GetGridPointIndex[ctx_Association] := GetCtx[ctx, "GridPointIndex"];
-
-(* Global getter - reads from $CurrentContext *)
-GetGridPointIndex[] := $CurrentContext["GridPointIndex"];
 
 Protect[GetGridPointIndex];
 
@@ -174,19 +135,10 @@ Protect[GetGridPointIndex];
 SetGridPointIndex[ctx_Association, gridindex_] :=
   SetCtx[ctx, "GridPointIndex", gridindex];
 
-(* Global setter - writes to $CurrentContext *)
-SetGridPointIndex[gridindex_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "GridPointIndex", gridindex]
-  ];
-
 Protect[SetGridPointIndex];
 
 (* Context-aware getter *)
 GetTilePointIndex[ctx_Association] := GetCtx[ctx, "TilePointIndex"];
-
-(* Global getter - reads from $CurrentContext *)
-GetTilePointIndex[] := $CurrentContext["TilePointIndex"];
 
 Protect[GetTilePointIndex];
 
@@ -194,19 +146,10 @@ Protect[GetTilePointIndex];
 SetTilePointIndex[ctx_Association, tileindex_] :=
   SetCtx[ctx, "TilePointIndex", tileindex];
 
-(* Global setter - writes to $CurrentContext *)
-SetTilePointIndex[tileindex_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "TilePointIndex", tileindex]
-  ];
-
 Protect[SetTilePointIndex];
 
 (* Context-aware getter *)
 GetSuffixUnprotected[ctx_Association] := GetCtx[ctx, "SuffixUnprotected"];
-
-(* Global getter - reads from $CurrentContext *)
-GetSuffixUnprotected[] := $CurrentContext["SuffixUnprotected"];
 
 Protect[GetSuffixUnprotected];
 
@@ -214,19 +157,10 @@ Protect[GetSuffixUnprotected];
 SetSuffixUnprotected[ctx_Association, suffix_] :=
   SetCtx[ctx, "SuffixUnprotected", suffix];
 
-(* Global setter - writes to $CurrentContext *)
-SetSuffixUnprotected[suffix_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "SuffixUnprotected", suffix]
-  ];
-
 Protect[SetSuffixUnprotected];
 
 (* Context-aware getter *)
 GetOutputFile[ctx_Association] := GetCtx[ctx, "OutputFile"];
-
-(* Global getter - reads from $CurrentContext *)
-GetOutputFile[] := $CurrentContext["OutputFile"];
 
 Protect[GetOutputFile];
 
@@ -234,31 +168,16 @@ Protect[GetOutputFile];
 SetOutputFile[ctx_Association, filename_] :=
   SetCtx[ctx, "OutputFile", filename];
 
-(* Global setter - writes to $CurrentContext *)
-SetOutputFile[filename_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "OutputFile", filename]
-  ];
-
 Protect[SetOutputFile];
 
 (* Context-aware getter *)
 GetProject[ctx_Association] := GetCtx[ctx, "Project"];
-
-(* Global getter - reads from $CurrentContext *)
-GetProject[] := $CurrentContext["Project"];
 
 Protect[GetProject];
 
 (* Context-aware setter - returns new context *)
 SetProject[ctx_Association, name_] :=
   SetCtx[ctx, "Project", name];
-
-(* Global setter - writes to $CurrentContext *)
-SetProject[name_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "Project", name]
-  ];
 
 Protect[SetProject];
 
@@ -481,7 +400,7 @@ Protect[SetEQNDelayed];
 
 PrintVerbose[var__:""] :=
   Module[{},
-    If[GetPVerbose[],
+    If[GetPVerbose[$CurrentContext],
       System`Print[var]
     ]
   ];

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -57,28 +57,16 @@ Begin["`Private`"];
 (* Context-aware getter *)
 GetMapComponentToVarlist[ctx_Association] := GetCtx[ctx, "MapComponentToVarlist"];
 
-(* Global getter - reads from $CurrentContext *)
-GetMapComponentToVarlist[] := $CurrentContext["MapComponentToVarlist"];
-
 Protect[GetMapComponentToVarlist];
 
 (* Context-aware setter - returns new context *)
 SetMapComponentToVarlist[ctx_Association, map_] :=
   SetCtx[ctx, "MapComponentToVarlist", map];
 
-(* Global setter - writes to $CurrentContext *)
-SetMapComponentToVarlist[map_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "MapComponentToVarlist", map]
-  ];
-
 Protect[SetMapComponentToVarlist];
 
 (* Context-aware getter *)
 GetProcessNewVarlist[ctx_Association] := GetCtx[ctx, "ProcessNewVarlist"];
-
-(* Global getter - reads from $CurrentContext *)
-GetProcessNewVarlist[] := $CurrentContext["ProcessNewVarlist"];
 
 Protect[GetProcessNewVarlist];
 
@@ -86,19 +74,10 @@ Protect[GetProcessNewVarlist];
 SetProcessNewVarlist[ctx_Association, isnew_] :=
   SetCtx[ctx, "ProcessNewVarlist", isnew];
 
-(* Global setter - writes to $CurrentContext *)
-SetProcessNewVarlist[isnew_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "ProcessNewVarlist", isnew]
-  ];
-
 Protect[SetProcessNewVarlist];
 
 (* Context-aware getter *)
 GetSimplifyEquation[ctx_Association] := GetCtx[ctx, "SimplifyEquation"];
-
-(* Global getter - reads from $CurrentContext *)
-GetSimplifyEquation[] := $CurrentContext["SimplifyEquation"];
 
 Protect[GetSimplifyEquation];
 
@@ -106,19 +85,10 @@ Protect[GetSimplifyEquation];
 SetSimplifyEquation[ctx_Association, simplify_] :=
   SetCtx[ctx, "SimplifyEquation", simplify];
 
-(* Global setter - writes to $CurrentContext *)
-SetSimplifyEquation[simplify_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "SimplifyEquation", simplify]
-  ];
-
 Protect[SetSimplifyEquation];
 
 (* Context-aware getter *)
 GetUseLetterForTensorComponent[ctx_Association] := GetCtx[ctx, "UseLetterForTensorComponent"];
-
-(* Global getter - reads from $CurrentContext *)
-GetUseLetterForTensorComponent[] := $CurrentContext["UseLetterForTensorComponent"];
 
 Protect[GetUseLetterForTensorComponent];
 
@@ -126,19 +96,10 @@ Protect[GetUseLetterForTensorComponent];
 SetUseLetterForTensorComponent[ctx_Association, useletter_] :=
   SetCtx[ctx, "UseLetterForTensorComponent", useletter];
 
-(* Global setter - writes to $CurrentContext *)
-SetUseLetterForTensorComponent[useletter_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "UseLetterForTensorComponent", useletter]
-  ];
-
 Protect[SetUseLetterForTensorComponent];
 
 (* Context-aware getter *)
 GetTempVariableType[ctx_Association] := GetCtx[ctx, "TempVariableType"];
-
-(* Global getter - reads from $CurrentContext *)
-GetTempVariableType[] := $CurrentContext["TempVariableType"];
 
 Protect[GetTempVariableType];
 
@@ -146,19 +107,10 @@ Protect[GetTempVariableType];
 SetTempVariableType[ctx_Association, type_] :=
   SetCtx[ctx, "TempVariableType", type];
 
-(* Global setter - writes to $CurrentContext *)
-SetTempVariableType[type_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "TempVariableType", type]
-  ];
-
 Protect[SetTempVariableType];
 
 (* Context-aware getter *)
 GetInterfaceWithNonCoordBasis[ctx_Association] := GetCtx[ctx, "InterfaceWithNonCoordBasis"];
-
-(* Global getter - reads from $CurrentContext *)
-GetInterfaceWithNonCoordBasis[] := $CurrentContext["InterfaceWithNonCoordBasis"];
 
 Protect[GetInterfaceWithNonCoordBasis];
 
@@ -166,19 +118,10 @@ Protect[GetInterfaceWithNonCoordBasis];
 SetInterfaceWithNonCoordBasis[ctx_Association, noncoordbasis_] :=
   SetCtx[ctx, "InterfaceWithNonCoordBasis", noncoordbasis];
 
-(* Global setter - writes to $CurrentContext *)
-SetInterfaceWithNonCoordBasis[noncoordbasis_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "InterfaceWithNonCoordBasis", noncoordbasis]
-  ];
-
 Protect[SetInterfaceWithNonCoordBasis];
 
 (* Context-aware getter *)
 GetSuffixName[ctx_Association] := GetCtx[ctx, "SuffixName"];
-
-(* Global getter - reads from $CurrentContext *)
-GetSuffixName[] := $CurrentContext["SuffixName"];
 
 Protect[GetSuffixName];
 
@@ -186,31 +129,16 @@ Protect[GetSuffixName];
 SetSuffixName[ctx_Association, suffix_] :=
   SetCtx[ctx, "SuffixName", suffix];
 
-(* Global setter - writes to $CurrentContext *)
-SetSuffixName[suffix_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "SuffixName", suffix]
-  ];
-
 Protect[SetSuffixName];
 
 (* Context-aware getter *)
 GetPrefixDt[ctx_Association] := GetCtx[ctx, "PrefixDt"];
-
-(* Global getter - reads from $CurrentContext *)
-GetPrefixDt[] := $CurrentContext["PrefixDt"];
 
 Protect[GetPrefixDt];
 
 (* Context-aware setter - returns new context *)
 SetPrefixDt[ctx_Association, prefix_] :=
   SetCtx[ctx, "PrefixDt", prefix];
-
-(* Global setter - writes to $CurrentContext *)
-SetPrefixDt[prefix_] :=
-  Module[{},
-    $CurrentContext = SetCtx[$CurrentContext, "PrefixDt", prefix]
-  ];
 
 Protect[SetPrefixDt];
 
@@ -226,10 +154,10 @@ ParseComponent[varinfo_, compindexlist_?ListQ, coordinate_, extrareplacerules_?L
       Continue[]
     ];
     Which[
-      InSetCompPhase[],
+      InSetCompPhase[$CurrentContext],
         SetComponent[compname, SetExprName[varname, compindexlist, coordinate]]
       ,
-      InPrintCompPhase[],
+      InPrintCompPhase[$CurrentContext],
         PrintComponent[coordinate, varinfo, compname, extrareplacerules]
       ,
       True,
@@ -244,13 +172,13 @@ Protect[ParseComponent];
 PrintComponent[coordinate_, varinfo_, compname_, extrareplacerules_] :=
   Module[{},
     Which[
-      InInitializationsMode[],
+      InInitializationsMode[$CurrentContext],
         PrintVerbose["    PrintComponentInitialization ", compname, "..."];
-        Global`PrintComponentInitialization[$CurrentContext, varinfo, compname]
+        Global`PrintComponentInitialization[varinfo, compname]
       ,
-      InEquationsMode[],
+      InEquationsMode[$CurrentContext],
         PrintVerbose["    PrintComponentEquation ", compname, "..."];
-        Global`PrintComponentEquation[$CurrentContext, coordinate, compname, extrareplacerules]
+        Global`PrintComponentEquation[coordinate, compname, extrareplacerules]
       ,
       True,
         Throw @ Message[PrintComponent::EMode]
@@ -271,9 +199,9 @@ PrintComponent::EMode = "PrintMode unrecognized!";
 *)
 
 SetComponent[compname_, exprname_] :=
-  Module[{varlistindex, mapCtoV = GetMapComponentToVarlist[]},
+  Module[{varlistindex, mapCtoV = GetMapComponentToVarlist[$CurrentContext]},
     PrintVerbose["    SetComponent ", compname, "..."];
-    If[Length[mapCtoV] == 0 || GetProcessNewVarlist[] || (GetIndependentVarlistIndex[] && (compname[[0]] =!= Last[Keys[mapCtoV]][[0]])),
+    If[Length[mapCtoV] == 0 || GetProcessNewVarlist[$CurrentContext] || (GetIndependentVarlistIndex[$CurrentContext] && (compname[[0]] =!= Last[Keys[mapCtoV]][[0]])),
       varlistindex = 0(*C convention*)
       ,
       varlistindex = Last[mapCtoV] + 1
@@ -281,9 +209,9 @@ SetComponent[compname_, exprname_] :=
     ComponentValue[compname, exprname];
     If[!MemberQ[Keys[mapCtoV], compname],
       AppendTo[mapCtoV, compname -> varlistindex];
-      SetMapComponentToVarlist[mapCtoV]
+      $CurrentContext = SetMapComponentToVarlist[$CurrentContext, mapCtoV]
     ];
-    SetProcessNewVarlist[False]
+    $CurrentContext = SetProcessNewVarlist[$CurrentContext, False]
   ];
 
 (*
@@ -321,7 +249,7 @@ SetCompName[varname_, compindexlist_, coordinate_] :=
 
 SetExprName[varname_, compindexlist_, coordinate_] :=
   Module[{exprname, colist = {"t", "x", "y", "z"}},
-    exprname = StringTrim[ToString[varname[[0]]], GetSuffixUnprotected[]];
+    exprname = StringTrim[ToString[varname[[0]]], GetSuffixUnprotected[$CurrentContext]];
     If[Length[compindexlist] > 0, (*not scalar, ignore up/down*)
       If[coordinate =!= GetDefaultChart[],
         exprname = exprname <> ToString[coordinate]
@@ -329,7 +257,7 @@ SetExprName[varname_, compindexlist_, coordinate_] :=
       Do[
         exprname =
           exprname <>
-            If[GetUseLetterForTensorComponent[],
+            If[GetUseLetterForTensorComponent[$CurrentContext],
               colist[[compindexlist[[icomp]] + 1]]
               ,
               ToString @ compindexlist[[icomp]]
@@ -339,13 +267,13 @@ SetExprName[varname_, compindexlist_, coordinate_] :=
       ]
     ];
     exprname =
-      If[GetWithoutGridPointIndex[] || (GetInterfaceWithNonCoordBasis[] && coordinate === GetDefaultChart[]),
+      If[GetWithoutGridPointIndex[$CurrentContext] || (GetInterfaceWithNonCoordBasis[$CurrentContext] && coordinate === GetDefaultChart[]),
         ToExpression[exprname]
         ,
-        If[GetUseTilePointIndex[],
-          ToExpression[exprname <> GetTilePointIndex[]]
+        If[GetUseTilePointIndex[$CurrentContext],
+          ToExpression[exprname <> GetTilePointIndex[$CurrentContext]]
           ,
-          ToExpression[exprname <> GetGridPointIndex[]]
+          ToExpression[exprname <> GetGridPointIndex[$CurrentContext]]
         ]
       ];
     Return[exprname]

--- a/src/Interface.wl
+++ b/src/Interface.wl
@@ -82,7 +82,7 @@ GridTensors[ctx_Association, varlist_?ListQ] :=
 (* Original API: GridTensors[var1, var2, ...] *)
 GridTensors[vars__] :=
   Module[{arglist = List[vars]},
-    If[GetCheckInputEquations[],
+    If[GetCheckInputEquations[$CurrentContext],
       DefTensors[vars]
       ,
       SetComponents[arglist]
@@ -106,7 +106,7 @@ TileTensors[ctx_Association, varlist_?ListQ] :=
 (* Original API: TileTensors[var1, var2, ...] *)
 TileTensors[vars__] :=
   Module[{arglist = List[vars]},
-    If[GetCheckInputEquations[],
+    If[GetCheckInputEquations[$CurrentContext],
       DefTensors[vars]
       ,
       SetComponents[{UseTilePointIndex -> True}, arglist]
@@ -130,7 +130,7 @@ TempTensors[ctx_Association, varlist_?ListQ] :=
 (* Original API: TempTensors[var1, var2, ...] *)
 TempTensors[vars__] :=
   Module[{arglist = List[vars]},
-    If[GetCheckInputEquations[],
+    If[GetCheckInputEquations[$CurrentContext],
       DefTensors[vars]
       ,
       SetComponents[{WithoutGridPointIndex -> True}, arglist]
@@ -150,11 +150,11 @@ Options[SetComponents] :=
 SetComponents[OptionsPattern[], varlist_?ListQ] :=
   Module[{chartname, indepidx, nogpidx, tlidx},
     {chartname, indepidx, nogpidx, tlidx} = OptionValue[{ChartName, IndependentVarlistIndex, WithoutGridPointIndex, UseTilePointIndex}];
-    WithMode[{
-      {"Phase"} -> "SetComp",
-      {"IndexOptions", "IndependentVarlistIndex"} -> indepidx,
-      {"IndexOptions", "WithoutGridPointIndex"} -> nogpidx,
-      {"IndexOptions", "UseTilePointIndex"} -> tlidx
+    WithMode[$CurrentContext, {
+      "Phase" -> "SetComp",
+      "IndependentVarlistIndex" -> indepidx,
+      "WithoutGridPointIndex" -> nogpidx,
+      "UseTilePointIndex" -> tlidx
     },
       ParseVarlist[varlist, chartname]
     ]
@@ -180,16 +180,16 @@ PrintEquations[ctx_Association, options_?ListQ, varlist_?ListQ] :=
     mode = Lookup[optAssoc, Mode, "MainOut"];
     extrareplacerules = Lookup[optAssoc, ExtraReplaceRules, {}];
     If[suffixname =!= Null,
-      SetSuffixName[suffixname]
+      $CurrentContext = SetSuffixName[$CurrentContext, suffixname]
     ];
-    WithMode[{
-      {"Phase"} -> "PrintComp",
-      {"PrintComp", "Type"} -> "Equations",
-      {"PrintComp", "Equations", "Mode"} -> mode
+    WithMode[ctx, {
+      "Phase" -> "PrintComp",
+      "PrintCompType" -> "Equations",
+      "EquationsMode" -> mode
     },
       ParseVarlist[{ExtraReplaceRules -> extrareplacerules}, varlist, chartname]
     ];
-    SetSuffixName[""];
+    $CurrentContext = SetSuffixName[$CurrentContext, ""]
   ];
 
 (* Original API: PrintEquations[{opts}, varlist] *)
@@ -197,16 +197,16 @@ PrintEquations[OptionsPattern[], varlist_?ListQ] :=
   Module[{chartname, suffixname, mode, extrareplacerules},
     {chartname, suffixname, mode, extrareplacerules} = OptionValue[{ChartName, SuffixName, Mode, ExtraReplaceRules}];
     If[suffixname =!= Null,
-      SetSuffixName[suffixname]
+      $CurrentContext = SetSuffixName[$CurrentContext, suffixname]
     ];
-    WithMode[{
-      {"Phase"} -> "PrintComp",
-      {"PrintComp", "Type"} -> "Equations",
-      {"PrintComp", "Equations", "Mode"} -> mode
+    WithMode[$CurrentContext, {
+      "Phase" -> "PrintComp",
+      "PrintCompType" -> "Equations",
+      "EquationsMode" -> mode
     },
       ParseVarlist[{ExtraReplaceRules -> extrareplacerules}, varlist, chartname]
     ];
-    SetSuffixName[""];
+    $CurrentContext = SetSuffixName[$CurrentContext, ""]
   ];
 
 Protect[PrintEquations];
@@ -229,14 +229,14 @@ PrintInitializations[ctx_Association, options_?ListQ, varlist_?ListQ] :=
     derivsorder = Lookup[optAssoc, DerivsOrder, 1];
     accuracyorder = Lookup[optAssoc, DerivsAccuracy, 4];
 
-    WithMode[{
-      {"Phase"} -> "PrintComp",
-      {"PrintComp", "Type"} -> "Initializations",
-      {"PrintComp", "Initializations", "Mode"} -> mode,
-      {"PrintComp", "Initializations", "TensorType"} -> tensortype,
-      {"PrintComp", "Initializations", "StorageType"} -> storagetype,
-      {"PrintComp", "Initializations", "DerivsOrder"} -> derivsorder,
-      {"PrintComp", "Initializations", "DerivsAccuracy"} -> accuracyorder
+    WithMode[ctx, {
+      "Phase" -> "PrintComp",
+      "PrintCompType" -> "Initializations",
+      "InitializationsMode" -> mode,
+      "TensorType" -> tensortype,
+      "StorageType" -> storagetype,
+      "DerivsOrder" -> derivsorder,
+      "DerivsAccuracy" -> accuracyorder
     },
       ParseVarlist[varlist, chartname]
     ]
@@ -248,14 +248,14 @@ PrintInitializations[OptionsPattern[], varlist_?ListQ] :=
     {chartname, mode, tensortype, storagetype, derivsorder, accuracyorder} =
       OptionValue[{ChartName, Mode, TensorType, StorageType, DerivsOrder, DerivsAccuracy}];
 
-    WithMode[{
-      {"Phase"} -> "PrintComp",
-      {"PrintComp", "Type"} -> "Initializations",
-      {"PrintComp", "Initializations", "Mode"} -> mode,
-      {"PrintComp", "Initializations", "TensorType"} -> tensortype,
-      {"PrintComp", "Initializations", "StorageType"} -> storagetype,
-      {"PrintComp", "Initializations", "DerivsOrder"} -> derivsorder,
-      {"PrintComp", "Initializations", "DerivsAccuracy"} -> accuracyorder
+    WithMode[$CurrentContext, {
+      "Phase" -> "PrintComp",
+      "PrintCompType" -> "Initializations",
+      "InitializationsMode" -> mode,
+      "TensorType" -> tensortype,
+      "StorageType" -> storagetype,
+      "DerivsOrder" -> derivsorder,
+      "DerivsAccuracy" -> accuracyorder
     },
       ParseVarlist[varlist, chartname]
     ]

--- a/src/Varlist.wl
+++ b/src/Varlist.wl
@@ -42,7 +42,7 @@ ParseVarlist[OptionsPattern[], varlist_?ListQ, chartname_] :=
       ,
       iMin = 0
     ];
-    SetProcessNewVarlist[True];
+    $CurrentContext = SetProcessNewVarlist[$CurrentContext, True];
     Do[
       var = varlist[[ivar]];
       {varname, symmetry, printname} = ParseVar[var];
@@ -52,13 +52,13 @@ ParseVarlist[OptionsPattern[], varlist_?ListQ, chartname_] :=
         symindex = symmetry[[1]]
       ];
       If[!xTensorQ[varname[[0]]],
-        If[InSetCompPhase[],
+        If[InSetCompPhase[$CurrentContext],
           DefineTensor[varname, symmetry, printname]
           ,
           Throw @ Message[ParseVarlist::ETensorNonExist, ivar, varname]
         ]
         ,
-        If[!MemberQ[Keys[GetMapComponentToVarlist[]][[All, 0]], varname[[0]]],
+        If[!MemberQ[Keys[GetMapComponentToVarlist[$CurrentContext]][[All, 0]], varname[[0]]],
           Throw @ Message[ParseVarlist::ETensorExistOutside, ivar, varname]
         ]
       ];

--- a/test/regression/AMReX/test.wl
+++ b/test/regression/AMReX/test.wl
@@ -6,13 +6,13 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex[""];
+$CurrentContext = SetGridPointIndex[$CurrentContext, ""];
 
-SetTempVariableType["Real"];
+$CurrentContext = SetTempVariableType[$CurrentContext, "Real"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -43,11 +43,11 @@ SetEQN[{SuffixName -> "Msqr"}, rU[i_], euclid[i, k] MDD[-k, -j] vU[j]];
 
 SetEQN[{SuffixName -> "otherwise"}, rU[i_], vU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "test.hxx"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "test.hxx"}]];
 
 (* SetProject["AMReX"]; *)
 
-SetMainPrint[
+$MainPrint[] := (
   pr[];
   PrintInitializations[{Mode -> "MainOut"}, dtEvolVarlist];
   PrintInitializations[{Mode -> "MainIn"}, EvolVarlist];
@@ -63,6 +63,6 @@ SetMainPrint[
   pr["{"];
   PrintEquations[{Mode -> "MainOut", SuffixName -> "otherwise"}, dtEvolVarlist];
   pr["}"];
-];
+);
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/AMReX.wl"}]];

--- a/test/regression/Carpet/test.wl
+++ b/test/regression/Carpet/test.wl
@@ -6,13 +6,13 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex[""];
+$CurrentContext = SetGridPointIndex[$CurrentContext, ""];
 
-SetTempVariableType["CCTK_REAL"];
+$CurrentContext = SetTempVariableType[$CurrentContext, "CCTK_REAL"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -43,11 +43,11 @@ SetEQN[{SuffixName -> "Msqr"}, rU[i_], euclid[i, k] MDD[-k, -j] vU[j]];
 
 SetEQN[{SuffixName -> "otherwise"}, rU[i_], vU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "test.hxx"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "test.hxx"}]];
 
 (* SetProject["Carpet"]; *)
 
-SetMainPrint[
+$MainPrint[] := (
   pr[];
   PrintInitializations[{Mode -> "MainOut"}, dtEvolVarlist];
   PrintInitializations[{Mode -> "MainIn"}, EvolVarlist];
@@ -63,6 +63,6 @@ SetMainPrint[
   pr["{"];
   PrintEquations[{Mode -> "MainOut", SuffixName -> "otherwise"}, dtEvolVarlist];
   pr["}"];
-];
+);
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/Carpet.wl"}]];

--- a/test/regression/CarpetX/test.wl
+++ b/test/regression/CarpetX/test.wl
@@ -6,13 +6,13 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex[""];
+$CurrentContext = SetGridPointIndex[$CurrentContext, ""];
 
-SetTempVariableType["vreal"];
+$CurrentContext = SetTempVariableType[$CurrentContext, "vreal"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -45,11 +45,11 @@ SetEQN[{SuffixName -> "Msqr"}, rU[i_], euclid[i, k] MDD[-k, -j] vU[j]];
 
 SetEQN[{SuffixName -> "otherwise"}, rU[i_], vU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "test.hxx"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "test.hxx"}]];
 
 (* SetProject["CarpetX"]; *)
 
-SetMainPrint[
+$MainPrint[] := (
   pr[];
   PrintInitializations[{Mode -> "MainOut"}, dtEvolVarlist];
   PrintInitializations[{Mode -> "MainIn"}, EvolVarlist];
@@ -65,6 +65,6 @@ SetMainPrint[
   pr["{"];
   PrintEquations[{Mode -> "MainOut", SuffixName -> "otherwise"}, dtEvolVarlist];
   pr["}"];
-];
+);
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetX.wl"}]];

--- a/test/regression/CarpetXGPU/test.wl
+++ b/test/regression/CarpetXGPU/test.wl
@@ -6,13 +6,13 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex[""];
+$CurrentContext = SetGridPointIndex[$CurrentContext, ""];
 
-SetTempVariableType["vreal"];
+$CurrentContext = SetTempVariableType[$CurrentContext, "vreal"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -45,11 +45,11 @@ SetEQN[{SuffixName -> "Msqr"}, rU[i_], euclid[i, k] MDD[-k, -j] vU[j]];
 
 SetEQN[{SuffixName -> "otherwise"}, rU[i_], vU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "test.hxx"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "test.hxx"}]];
 
 (* SetProject["CarpetX"]; *)
 
-SetMainPrint[
+$MainPrint[] := (
   pr[];
   PrintInitializations[{Mode -> "MainOut"}, dtEvolVarlist];
   PrintInitializations[{Mode -> "MainIn"}, EvolVarlist];
@@ -65,6 +65,6 @@ SetMainPrint[
   pr["{"];
   PrintEquations[{Mode -> "MainOut", SuffixName -> "otherwise"}, dtEvolVarlist];
   pr["}"];
-];
+);
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetXGPU.wl"}]];

--- a/test/regression/CarpetXGPU/testDerivs.wl
+++ b/test/regression/CarpetXGPU/testDerivs.wl
@@ -7,13 +7,13 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex[""];
+$CurrentContext = SetGridPointIndex[$CurrentContext, ""];
 
-SetTempVariableType["vreal"];
+$CurrentContext = SetTempVariableType[$CurrentContext, "vreal"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -35,9 +35,9 @@ TempVarlist = TempTensors[{psi[], PrintAs -> "psi"}];
 (* Simple equation using the derivative *)
 SetEQN[psi[], euclid[i, j] dphi[-i] dphi[-j]];
 
-SetOutputFile[FileNameJoin[{Directory[], "testDerivs.hxx"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "testDerivs.hxx"}]];
 
-SetMainPrint[
+$MainPrint[] := (
   pr[];
   PrintInitializations[{Mode -> "MainIn"}, EvolVarlist];
   pr[];
@@ -45,6 +45,6 @@ SetMainPrint[
   PrintInitializations[{Mode -> "Derivs", TensorType -> "Vect", DerivsOrder -> 1, DerivsAccuracy -> 4}, DerivVarlist];
   pr[];
   PrintEquations[{Mode -> "Temp"}, TempVarlist];
-];
+);
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetXGPU.wl"}]];

--- a/test/regression/CarpetXGPU/testTile.wl
+++ b/test/regression/CarpetXGPU/testTile.wl
@@ -7,15 +7,15 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex[""];
+$CurrentContext = SetGridPointIndex[$CurrentContext, ""];
 
-SetTilePointIndex["[[tI]]"];
+$CurrentContext = SetTilePointIndex[$CurrentContext, "[[tI]]"];
 
-SetTempVariableType["vreal"];
+$CurrentContext = SetTempVariableType[$CurrentContext, "vreal"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -39,9 +39,9 @@ SetEQN[tempU[i_], gridU[i]];
 
 SetEQN[tileU[i_], tempU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "testTile.hxx"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "testTile.hxx"}]];
 
-SetMainPrint[
+$MainPrint[] := (
   pr[];
   PrintInitializations[{Mode -> "MainOut"}, TileVarlist];
   PrintInitializations[{Mode -> "MainIn", StorageType -> "Tile"}, GridVarlist];
@@ -49,6 +49,6 @@ SetMainPrint[
   PrintEquations[{Mode -> "Temp"}, TempVarlist];
   pr[];
   PrintEquations[{Mode -> "MainOut"}, TileVarlist];
-];
+);
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetXGPU.wl"}]];

--- a/test/regression/CarpetXPointDesc/test.wl
+++ b/test/regression/CarpetXPointDesc/test.wl
@@ -6,13 +6,13 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex["[[pI]]"];
+$CurrentContext = SetGridPointIndex[$CurrentContext, "[[pI]]"];
 
-SetTempVariableType["vreal"];
+$CurrentContext = SetTempVariableType[$CurrentContext, "vreal"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -45,11 +45,11 @@ SetEQN[{SuffixName -> "Msqr"}, rU[i_], euclid[i, k] MDD[-k, -j] vU[j]];
 
 SetEQN[{SuffixName -> "otherwise"}, rU[i_], vU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "test.hxx"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "test.hxx"}]];
 
 (* SetProject["CarpetXPointDesc"]; *)
 
-SetMainPrint[
+$MainPrint[] := (
   pr[];
   PrintInitializations[{Mode -> "MainOut"}, dtEvolVarlist];
   PrintInitializations[{Mode -> "MainIn"}, EvolVarlist];
@@ -65,6 +65,6 @@ SetMainPrint[
   pr["{"];
   PrintEquations[{Mode -> "MainOut", SuffixName -> "otherwise"}, dtEvolVarlist];
   pr["}"];
-];
+);
 
 Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetXPointDesc.wl"}]];

--- a/test/regression/Nmesh/GHG_rhs.wl
+++ b/test/regression/Nmesh/GHG_rhs.wl
@@ -6,11 +6,11 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex["[[ijk]]"];
+$CurrentContext = SetGridPointIndex[$CurrentContext, "[[ijk]]"];
 
 DefManifold[M4, 4, Union[Complement[IndexRange[a, z], {g}], Table[ToExpression["h" <> ToString[i]], {i, 1, 9}], Table[ToExpression["z" <> ToString[i]], {i, 1, 9}]]];
 
@@ -91,12 +91,12 @@ SetEQN[dtPhi[i_, a_, b_], -AdPhi[i, a, b] interior + 1/2 alpha[] nvec[c] nvec[d]
 
 (* Write to files *)
 
-SetOutputFile[FileNameJoin[{Directory[], "GHG_rhs.c"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "GHG_rhs.c"}]];
 
-SetProject["GHG"];
+$CurrentContext = SetProject[$CurrentContext, "GHG"];
 
 $MainPrint[] :=
-  Module[{project = GetProject[]},
+  Module[{project = GetProject[$CurrentContext]},
     pr["#include \"nmesh.h\""];
     pr["#include \"" <> project <> ".h\""];
     pr[];

--- a/test/regression/Nmesh/GHG_set_profile_ADM.wl
+++ b/test/regression/Nmesh/GHG_set_profile_ADM.wl
@@ -6,11 +6,11 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex["[[ijk]]"];
+$CurrentContext = SetGridPointIndex[$CurrentContext, "[[ijk]]"];
 
 DefManifold[M4, 4, Union[Complement[IndexRange[a, z], {g}], Table[ToExpression["h" <> ToString[i]], {i, 1, 9}], Table[ToExpression["z" <> ToString[i]], {i, 1, 9}]]];
 
@@ -261,12 +261,12 @@ SetEQN[the[a_], -beta[k] dH[-k, a]];
 
 (* ============== *)
 
-SetOutputFile[FileNameJoin[{Directory[], "GHG_set_profile_ADM.c"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "GHG_set_profile_ADM.c"}]];
 
-SetProject["GHG"];
+$CurrentContext = SetProject[$CurrentContext, "GHG"];
 
 $MainPrint[] :=
-  Module[{project = GetProject[]},
+  Module[{project = GetProject[$CurrentContext]},
     pr["#include \"nmesh.h\""];
     pr["#include \"" <> project <> ".h\""];
     pr[];
@@ -341,12 +341,12 @@ $MainPrint[] :=
       ,
       (* set d_k g_{ab} *)
       printdg[cc_, aa_, bb_] :=
-        WithMode[{
-          {"Phase"} -> "PrintComp",
-          {"PrintComp", "Type"} -> "Equations",
-          {"PrintComp", "Equations", "Mode"} -> "MainOut"
+        WithMode[$CurrentContext, {
+          "Phase" -> "PrintComp",
+          "PrintCompType" -> "Equations",
+          "EquationsMode" -> "MainOut"
         },
-          PrintComponentEquation[$CurrentContext, GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}]
+          PrintComponentEquation[GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}]
         ];
       Do[printdg[cc, aa, bb], {cc, 3, 1, -1}, {aa, 3, 0, -1}, {bb, 3, aa, -1}];
       (* set d_t g_{ab} *)
@@ -354,16 +354,16 @@ $MainPrint[] :=
       pr[];
       Module[{printdtgEin},
         printdtgEin[cc_, aa_, bb_] :=
-          Module[{savedSuffix = GetSuffixName[]},
-            SetSuffixName["Ein"];
-            WithMode[{
-              {"Phase"} -> "PrintComp",
-              {"PrintComp", "Type"} -> "Equations",
-              {"PrintComp", "Equations", "Mode"} -> "MainOut"
+          Module[{savedSuffix = GetSuffixName[$CurrentContext]},
+            $CurrentContext = SetSuffixName[$CurrentContext, "Ein"];
+            WithMode[$CurrentContext, {
+              "Phase" -> "PrintComp",
+              "PrintCompType" -> "Equations",
+              "EquationsMode" -> "MainOut"
             },
-              PrintComponentEquation[$CurrentContext, GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}]
+              PrintComponentEquation[GetDefaultChart[], dmetricg[{cc, -GetDefaultChart[]}, {aa, -GetDefaultChart[]}, {bb, -GetDefaultChart[]}], {}]
             ];
-            SetSuffixName[savedSuffix]
+            $CurrentContext = SetSuffixName[$CurrentContext, savedSuffix]
           ];
         Do[printdtgEin[0, aa, bb], {aa, 3, 0, -1}, {bb, 3, aa, -1}];
         pr[];

--- a/test/regression/Nmesh/test.wl
+++ b/test/regression/Nmesh/test.wl
@@ -6,11 +6,11 @@
 
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-SetPVerbose[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
 
-SetPrintDate[False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
-SetGridPointIndex["[[ijk]]"];
+$CurrentContext = SetGridPointIndex[$CurrentContext, "[[ijk]]"];
 
 DefManifold[M3, 3, IndexRange[a, z]];
 
@@ -43,12 +43,12 @@ SetEQN[{SuffixName -> "Msqr"}, rU[i_], euclid[i, k] MDD[-k, -j] vU[j]];
 
 SetEQN[{SuffixName -> "otherwise"}, rU[i_], vU[i]];
 
-SetOutputFile[FileNameJoin[{Directory[], "test.c"}]];
+$CurrentContext = SetOutputFile[$CurrentContext, FileNameJoin[{Directory[], "test.c"}]];
 
-SetProject["C3GH"];
+$CurrentContext = SetProject[$CurrentContext, "C3GH"];
 
 $MainPrint[] :=
-  Module[{project = GetProject[]},
+  Module[{project = GetProject[$CurrentContext]},
     pr["#include \"nmesh.h\""];
     pr["#include \"" <> project <> ".h\""];
     pr[];

--- a/test/unit/BasicTests.wl
+++ b/test/unit/BasicTests.wl
@@ -9,8 +9,8 @@ If[Environment["QUIET"] =!= "1", Print["Loading BasicTests.wl..."]];
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
 (* Suppress verbose output during tests *)
-SetPVerbose[False];
-SetPrintDate[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
 (* ========================================= *)
 (* Test: Global Configuration Functions *)
@@ -18,7 +18,7 @@ SetPrintDate[False];
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetPVerbose[True];
+    $CurrentContext = SetPVerbose[$CurrentContext, True];
     (* PVerbose should be settable without error *)
     True,
     True,
@@ -28,8 +28,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetPrintDate[False];
-    GetPrintDate[],
+    $CurrentContext = SetPrintDate[$CurrentContext, False];
+    GetPrintDate[$CurrentContext],
     False,
     TestID -> "GetSetPrintDate-ReturnsFalse"
   ]
@@ -37,8 +37,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetGridPointIndex["[[ijk]]"];
-    GetGridPointIndex[],
+    $CurrentContext = SetGridPointIndex[$CurrentContext, "[[ijk]]"];
+    GetGridPointIndex[$CurrentContext],
     "[[ijk]]",
     TestID -> "GetSetGridPointIndex-ReturnsValue"
   ]
@@ -46,8 +46,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetTilePointIndex["(ti,tj,tk)"];
-    GetTilePointIndex[],
+    $CurrentContext = SetTilePointIndex[$CurrentContext, "(ti,tj,tk)"];
+    GetTilePointIndex[$CurrentContext],
     "(ti,tj,tk)",
     TestID -> "GetSetTilePointIndex-ReturnsValue"
   ]
@@ -55,8 +55,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetOutputFile["/tmp/test_output.c"];
-    GetOutputFile[],
+    $CurrentContext = SetOutputFile[$CurrentContext, "/tmp/test_output.c"];
+    GetOutputFile[$CurrentContext],
     "/tmp/test_output.c",
     TestID -> "GetSetOutputFile-ReturnsPath"
   ]
@@ -64,8 +64,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetProject["TestProject"];
-    GetProject[],
+    $CurrentContext = SetProject[$CurrentContext, "TestProject"];
+    GetProject[$CurrentContext],
     "TestProject",
     TestID -> "GetSetProject-ReturnsValue"
   ]
@@ -124,8 +124,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetCheckInputEquations[True];
-    GetCheckInputEquations[],
+    $CurrentContext = SetCheckInputEquations[$CurrentContext, True];
+    GetCheckInputEquations[$CurrentContext],
     True,
     TestID -> "GetSetCheckInputEquations-True"
   ]
@@ -133,8 +133,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetCheckInputEquations[False];
-    GetCheckInputEquations[],
+    $CurrentContext = SetCheckInputEquations[$CurrentContext, False];
+    GetCheckInputEquations[$CurrentContext],
     False,
     TestID -> "GetSetCheckInputEquations-False"
   ]
@@ -146,8 +146,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetPrintHeaderMacro[True];
-    GetPrintHeaderMacro[],
+    $CurrentContext = SetPrintHeaderMacro[$CurrentContext, True];
+    GetPrintHeaderMacro[$CurrentContext],
     True,
     TestID -> "GetSetPrintHeaderMacro-True"
   ]
@@ -155,8 +155,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetPrintHeaderMacro[False];
-    GetPrintHeaderMacro[],
+    $CurrentContext = SetPrintHeaderMacro[$CurrentContext, False];
+    GetPrintHeaderMacro[$CurrentContext],
     False,
     TestID -> "GetSetPrintHeaderMacro-False"
   ]
@@ -168,8 +168,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetSuffixUnprotected["_test"];
-    GetSuffixUnprotected[],
+    $CurrentContext = SetSuffixUnprotected[$CurrentContext, "_test"];
+    GetSuffixUnprotected[$CurrentContext],
     "_test",
     TestID -> "GetSetSuffixUnprotected-String"
   ]
@@ -270,14 +270,14 @@ AppendTo[$AllTests,
 ];
 
 (* Reset to clean state - all modified variables *)
-SetPVerbose[False];
-SetPrintDate[False];
-SetGridPointIndex[""];
-SetTilePointIndex[""];
-SetOutputFile[""];
-SetProject[""];
-SetCheckInputEquations[True];
-SetPrintHeaderMacro[True];
-SetSuffixUnprotected[""];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
+$CurrentContext = SetGridPointIndex[$CurrentContext, ""];
+$CurrentContext = SetTilePointIndex[$CurrentContext, ""];
+$CurrentContext = SetOutputFile[$CurrentContext, ""];
+$CurrentContext = SetProject[$CurrentContext, ""];
+$CurrentContext = SetCheckInputEquations[$CurrentContext, True];
+$CurrentContext = SetPrintHeaderMacro[$CurrentContext, True];
+$CurrentContext = SetSuffixUnprotected[$CurrentContext, ""];
 
 If[Environment["QUIET"] =!= "1", Print["BasicTests.wl completed."]];

--- a/test/unit/ComponentTests.wl
+++ b/test/unit/ComponentTests.wl
@@ -8,8 +8,8 @@ If[Environment["QUIET"] =!= "1", Print["Loading ComponentTests.wl..."]];
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
-SetPVerbose[False];
-SetPrintDate[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
 (* ========================================= *)
 (* Test: Getter/Setter Functions *)
@@ -17,8 +17,8 @@ SetPrintDate[False];
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetSimplifyEquation[True];
-    GetSimplifyEquation[],
+    $CurrentContext = SetSimplifyEquation[$CurrentContext, True];
+    GetSimplifyEquation[$CurrentContext],
     True,
     TestID -> "GetSetSimplifyEquation-True"
   ]
@@ -26,8 +26,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetSimplifyEquation[False];
-    GetSimplifyEquation[],
+    $CurrentContext = SetSimplifyEquation[$CurrentContext, False];
+    GetSimplifyEquation[$CurrentContext],
     False,
     TestID -> "GetSetSimplifyEquation-False"
   ]
@@ -35,8 +35,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetUseLetterForTensorComponent[True];
-    GetUseLetterForTensorComponent[],
+    $CurrentContext = SetUseLetterForTensorComponent[$CurrentContext, True];
+    GetUseLetterForTensorComponent[$CurrentContext],
     True,
     TestID -> "GetSetUseLetterForTensorComponent-True"
   ]
@@ -44,8 +44,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetUseLetterForTensorComponent[False];
-    GetUseLetterForTensorComponent[],
+    $CurrentContext = SetUseLetterForTensorComponent[$CurrentContext, False];
+    GetUseLetterForTensorComponent[$CurrentContext],
     False,
     TestID -> "GetSetUseLetterForTensorComponent-False"
   ]
@@ -53,8 +53,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetTempVariableType["CCTK_REAL"];
-    GetTempVariableType[],
+    $CurrentContext = SetTempVariableType[$CurrentContext, "CCTK_REAL"];
+    GetTempVariableType[$CurrentContext],
     "CCTK_REAL",
     TestID -> "GetSetTempVariableType-ReturnsValue"
   ]
@@ -62,8 +62,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetInterfaceWithNonCoordBasis[True];
-    GetInterfaceWithNonCoordBasis[],
+    $CurrentContext = SetInterfaceWithNonCoordBasis[$CurrentContext, True];
+    GetInterfaceWithNonCoordBasis[$CurrentContext],
     True,
     TestID -> "GetSetInterfaceWithNonCoordBasis-ReturnsTrue"
   ]
@@ -71,8 +71,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetSuffixName["_rhs"];
-    GetSuffixName[],
+    $CurrentContext = SetSuffixName[$CurrentContext, "_rhs"];
+    GetSuffixName[$CurrentContext],
     "_rhs",
     TestID -> "GetSetSuffixName-ReturnsValue"
   ]
@@ -80,8 +80,8 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    SetSuffixName[""];
-    GetSuffixName[],
+    $CurrentContext = SetSuffixName[$CurrentContext, ""];
+    GetSuffixName[$CurrentContext],
     "",
     TestID -> "GetSetSuffixName-ReturnsEmpty"
   ]
@@ -152,7 +152,7 @@ AppendTo[$AllTests,
 AppendTo[$AllTests,
   VerificationTest[
     (* GetMapComponentToVarlist should return an Association *)
-    AssociationQ[GetMapComponentToVarlist[]],
+    AssociationQ[GetMapComponentToVarlist[$CurrentContext]],
     True,
     TestID -> "GetMapComponentToVarlist-ReturnsAssociation"
   ]
@@ -165,7 +165,7 @@ AppendTo[$AllTests,
 AppendTo[$AllTests,
   VerificationTest[
     (* GetPrefixDt should return a string *)
-    StringQ[GetPrefixDt[]],
+    StringQ[GetPrefixDt[$CurrentContext]],
     True,
     TestID -> "GetPrefixDt-ReturnsString"
   ]
@@ -306,10 +306,10 @@ AppendTo[$AllTests,
 ];
 
 (* Reset state *)
-SetSimplifyEquation[True];
-SetUseLetterForTensorComponent[False];
-SetTempVariableType["double"];
-SetInterfaceWithNonCoordBasis[False];
-SetSuffixName[""];
+$CurrentContext = SetSimplifyEquation[$CurrentContext, True];
+$CurrentContext = SetUseLetterForTensorComponent[$CurrentContext, False];
+$CurrentContext = SetTempVariableType[$CurrentContext, "double"];
+$CurrentContext = SetInterfaceWithNonCoordBasis[$CurrentContext, False];
+$CurrentContext = SetSuffixName[$CurrentContext, ""];
 
 If[Environment["QUIET"] =!= "1", Print["ComponentTests.wl completed."]];

--- a/test/unit/InterfaceTests.wl
+++ b/test/unit/InterfaceTests.wl
@@ -11,8 +11,8 @@ If[!MemberQ[$Packages, "Generato`Interface`"],
   Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 ];
 
-SetPVerbose[False];
-SetPrintDate[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
 (* ========================================= *)
 (* Setup: Use existing test manifold from BasicTests *)
@@ -233,7 +233,7 @@ AppendTo[$AllTests,
     ctx = CreateContext[];
     (* Phase should be None after WithSetCompPhase completes *)
     WithSetCompPhase[ctx, "dummy"];
-    GetPhase[] === None,
+    GetPhase[$CurrentContext] === None,
     True,
     TestID -> "WithSetCompPhase-RestoresPhase"
   ]
@@ -260,7 +260,7 @@ AppendTo[$AllTests,
     ctx = CreateContext[];
     (* Phase should be None after WithPrintCompPhase completes *)
     WithPrintCompPhase[ctx, "dummy"];
-    GetPhase[] === None,
+    GetPhase[$CurrentContext] === None,
     True,
     TestID -> "WithPrintCompPhase-RestoresPhase"
   ]
@@ -289,7 +289,7 @@ AppendTo[$AllTests,
 ];
 
 (* Reset state *)
-SetPVerbose[False];
-SetPrintDate[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
 If[Environment["QUIET"] =!= "1", Print["InterfaceTests.wl completed."]];

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -8,20 +8,18 @@ If[Environment["QUIET"] =!= "1", Print["Loading ParseModeTests.wl..."]];
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
-SetPVerbose[False];
-SetPrintDate[False];
-
-(* Helper to reset context to defaults *)
-ResetContext[] := ($CurrentContext = CreateContext[]);
+$CurrentContext = SetPVerbose[$CurrentContext, False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
 (* ========================================= *)
-(* Test: WithMode with nested path syntax *)
+(* Test: WithMode with flat key syntax *)
 (* ========================================= *)
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"Phase"} -> "SetComp"}, GetPhase[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"Phase" -> "SetComp"}, GetPhase[$CurrentContext]]
+    ],
     "SetComp",
     TestID -> "Mode-Phase-SetComp"
   ]
@@ -29,8 +27,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"Phase"} -> "PrintComp"}, GetPhase[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"Phase" -> "PrintComp"}, GetPhase[$CurrentContext]]
+    ],
     "PrintComp",
     TestID -> "Mode-Phase-PrintComp"
   ]
@@ -38,8 +37,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    GetPhase[],
+    Module[{ctx = CreateContext[]},
+      GetPhase[ctx]
+    ],
     None,
     TestID -> "Mode-Phase-Default-None"
   ]
@@ -51,8 +51,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"IndexOptions", "IndependentVarlistIndex"} -> True}, GetIndependentVarlistIndex[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"IndependentVarlistIndex" -> True}, GetIndependentVarlistIndex[$CurrentContext]]
+    ],
     True,
     TestID -> "Mode-IndexOptions-IndependentVarlistIndex"
   ]
@@ -60,8 +61,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"IndexOptions", "WithoutGridPointIndex"} -> True}, GetWithoutGridPointIndex[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"WithoutGridPointIndex" -> True}, GetWithoutGridPointIndex[$CurrentContext]]
+    ],
     True,
     TestID -> "Mode-IndexOptions-WithoutGridPointIndex"
   ]
@@ -69,8 +71,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"IndexOptions", "UseTilePointIndex"} -> True}, GetUseTilePointIndex[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"UseTilePointIndex" -> True}, GetUseTilePointIndex[$CurrentContext]]
+    ],
     True,
     TestID -> "Mode-IndexOptions-UseTilePointIndex"
   ]
@@ -82,11 +85,12 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{
-      {"PrintComp", "Type"} -> "Initializations",
-      {"PrintComp", "Initializations", "Mode"} -> "MainIn"
-    }, GetInitializationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {
+        "PrintCompType" -> "Initializations",
+        "InitializationsMode" -> "MainIn"
+      }, GetInitializationsMode[$CurrentContext]]
+    ],
     "MainIn",
     TestID -> "Mode-PrintComp-Initializations-MainIn"
   ]
@@ -94,8 +98,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Initializations", "TensorType"} -> "Vect"}, GetTensorType[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"TensorType" -> "Vect"}, GetTensorType[$CurrentContext]]
+    ],
     "Vect",
     TestID -> "Mode-PrintComp-Initializations-TensorType-Vect"
   ]
@@ -103,8 +108,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Initializations", "StorageType"} -> "Tile"}, GetStorageType[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"StorageType" -> "Tile"}, GetStorageType[$CurrentContext]]
+    ],
     "Tile",
     TestID -> "Mode-PrintComp-Initializations-StorageType-Tile"
   ]
@@ -112,11 +118,12 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{
-      {"PrintComp", "Initializations", "DerivsOrder"} -> 2,
-      {"PrintComp", "Initializations", "DerivsAccuracy"} -> 6
-    }, {GetDerivsOrder[], GetDerivsAccuracy[]}],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {
+        "DerivsOrder" -> 2,
+        "DerivsAccuracy" -> 6
+      }, {GetDerivsOrder[$CurrentContext], GetDerivsAccuracy[$CurrentContext]}]
+    ],
     {2, 6},
     TestID -> "Mode-PrintComp-Initializations-Derivs"
   ]
@@ -128,8 +135,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Equations", "Mode"} -> "Temp"}, GetEquationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"EquationsMode" -> "Temp"}, GetEquationsMode[$CurrentContext]]
+    ],
     "Temp",
     TestID -> "Mode-PrintComp-Equations-Temp"
   ]
@@ -137,8 +145,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Equations", "Mode"} -> "MainOut"}, GetEquationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"EquationsMode" -> "MainOut"}, GetEquationsMode[$CurrentContext]]
+    ],
     "MainOut",
     TestID -> "Mode-PrintComp-Equations-MainOut"
   ]
@@ -146,8 +155,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Equations", "Mode"} -> "AddToMainOut"}, GetEquationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"EquationsMode" -> "AddToMainOut"}, GetEquationsMode[$CurrentContext]]
+    ],
     "AddToMainOut",
     TestID -> "Mode-PrintComp-Equations-AddToMainOut"
   ]
@@ -159,8 +169,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"Phase"} -> "SetComp"}, InSetCompPhase[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"Phase" -> "SetComp"}, InSetCompPhase[$CurrentContext]]
+    ],
     True,
     TestID -> "Mode-Helper-InSetCompPhase"
   ]
@@ -168,8 +179,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"Phase"} -> "PrintComp"}, InPrintCompPhase[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"Phase" -> "PrintComp"}, InPrintCompPhase[$CurrentContext]]
+    ],
     True,
     TestID -> "Mode-Helper-InPrintCompPhase"
   ]
@@ -177,8 +189,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Type"} -> "Initializations"}, InInitializationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"PrintCompType" -> "Initializations"}, InInitializationsMode[$CurrentContext]]
+    ],
     True,
     TestID -> "Mode-Helper-InInitializationsMode"
   ]
@@ -186,8 +199,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Type"} -> "Equations"}, InEquationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"PrintCompType" -> "Equations"}, InEquationsMode[$CurrentContext]]
+    ],
     True,
     TestID -> "Mode-Helper-InEquationsMode"
   ]
@@ -195,8 +209,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Initializations", "Mode"} -> "MainOut"}, GetInitializationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"InitializationsMode" -> "MainOut"}, GetInitializationsMode[$CurrentContext]]
+    ],
     "MainOut",
     TestID -> "Mode-Helper-GetInitializationsMode"
   ]
@@ -204,8 +219,9 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    WithMode[{{"PrintComp", "Equations", "Mode"} -> "MainOut"}, GetEquationsMode[]],
+    Module[{ctx = CreateContext[]},
+      WithMode[ctx, {"EquationsMode" -> "MainOut"}, GetEquationsMode[$CurrentContext]]
+    ],
     "MainOut",
     TestID -> "Mode-Helper-GetEquationsMode"
   ]
@@ -217,20 +233,22 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    (* Set initial values, then verify WithMode restores them *)
-    $CurrentContext = SetCtx[$CurrentContext, "InitializationsMode", "MainIn"];
-    $CurrentContext = SetCtx[$CurrentContext, "TensorType", "Vect"];
-    (* WithMode should temporarily change, then restore *)
-    WithMode[{
-      {"PrintComp", "Initializations", "Mode"} -> "Temp",
-      {"PrintComp", "Initializations", "TensorType"} -> "Scal"
-    },
-      (* Inside WithMode, check the temp values *)
-      GetInitializationsMode[] === "Temp" && GetTensorType[] === "Scal"
-    ] &&
-    (* After WithMode, check restored values *)
-    GetInitializationsMode[] === "MainIn" && GetTensorType[] === "Vect",
+    Module[{ctx, result},
+      (* Create context with specific values *)
+      ctx = CreateContext[];
+      ctx = SetCtx[ctx, "InitializationsMode", "MainIn"];
+      ctx = SetCtx[ctx, "TensorType", "Vect"];
+      (* WithMode should provide modified context inside body via $CurrentContext *)
+      result = WithMode[ctx, {
+        "InitializationsMode" -> "Temp",
+        "TensorType" -> "Scal"
+      },
+        (* Inside WithMode, check the temp values via context-aware getters (reads $CurrentContext) *)
+        GetInitializationsMode[$CurrentContext] === "Temp" && GetTensorType[$CurrentContext] === "Scal"
+      ];
+      (* Original ctx is unchanged (functional style) *)
+      result && GetInitializationsMode[ctx] === "MainIn" && GetTensorType[ctx] === "Vect"
+    ],
     True,
     TestID -> "Mode-Context-Isolation"
   ]
@@ -242,18 +260,12 @@ AppendTo[$AllTests,
 
 AppendTo[$AllTests,
   VerificationTest[
-    ResetContext[];
-    ctx = CreateContext[];
-    Quiet[Catch[SetPhase[ctx, "InvalidPhase"]], SetPhase::EInvalidValue],
+    Module[{ctx = CreateContext[]},
+      Quiet[Catch[SetPhase[ctx, "InvalidPhase"]], SetPhase::EInvalidValue]
+    ],
     Null,
     TestID -> "Mode-Validation-InvalidPhase"
   ]
 ];
-
-(* ========================================= *)
-(* Cleanup *)
-(* ========================================= *)
-
-ResetContext[];
 
 If[Environment["QUIET"] =!= "1", Print["ParseModeTests.wl completed."]];

--- a/test/unit/VarlistTests.wl
+++ b/test/unit/VarlistTests.wl
@@ -9,8 +9,8 @@ If[Environment["QUIET"] =!= "1", Print["Loading VarlistTests.wl..."]];
 (* Load Generato *)
 Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
 
-SetPVerbose[False];
-SetPrintDate[False];
+$CurrentContext = SetPVerbose[$CurrentContext, False];
+$CurrentContext = SetPrintDate[$CurrentContext, False];
 
 (* ========================================= *)
 (* Setup: Use existing test manifold from BasicTests *)
@@ -175,11 +175,13 @@ AppendTo[$AllTests,
   VerificationTest[
     (* ParseVarlist should process a list of variable definitions *)
     (* This is a basic smoke test - full functionality tested via GridTensors *)
-    varlist = {{parseVarlistTest[i], PrintAs -> "pvt"}};
-    WithMode[{{"Phase"} -> "SetComp"},
-      ParseVarlist[varlist, testCart]
-    ];
-    True,
+    Module[{ctx = CreateContext[], varlist},
+      varlist = {{parseVarlistTest[i], PrintAs -> "pvt"}};
+      WithMode[ctx, {"Phase" -> "SetComp"},
+        ParseVarlist[varlist, testCart]
+      ];
+      True
+    ],
     True,
     TestID -> "ParseVarlist-BasicSmoke"
   ]


### PR DESCRIPTION
## Summary
- Remove global (no-argument) versions of getters and setters, requiring explicit `$CurrentContext` parameter
- Simplify `WithMode` to use flat keys directly instead of nested paths (e.g., `"Phase" -> "PrintComp"` instead of `{"Phase"} -> "PrintComp"`)
- Remove `PathToFlatKey` mapping function and backward-compatibility wrappers in `BackendCommon.wl`
- Update all backends and call sites to use the new explicit context pattern

## Test plan
- [ ] Run `wolframscript -script test/AllTests.wl` to verify all unit and regression tests pass
- [ ] Verify code generation output remains unchanged for existing projects