### PR TITLE
Update documentation: fix paths, add API tables, condense CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,76 +13,22 @@ Generato file1.wl file2.wl          # Multiple files
 ## Architecture
 
 ### Core (src/)
-- **Generato.wl** - Package loader
-- **Context.wl** - Global state management via `$CurrentContext`
-- **Basic.wl** - Config state, tensor utilities, SetEQN/SetEQNDelayed
-- **ParseMode.wl** - Phase management (SetComp/PrintComp phases), WithMode for scoped settings
-- **Component.wl** - Tensor component to varlist index mapping
+- **Context.wl** - Global state via `$CurrentContext`
+- **Basic.wl** - Config, tensor utilities, SetEQN/SetEQNDelayed
+- **ParseMode.wl** - Phase management, WithMode for scoped settings
+- **Component.wl** - Tensor component to varlist mapping
 - **Varlist.wl** - Tensor definitions via ParseVarlist
-- **Interface.wl** - Public API: DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations
+- **Interface.wl** - Public API (DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations)
 - **BackendCommon.wl** - Shared backend utilities
-- **Derivation.wl** - Testing utilities (TestEQN)
 - **Writefile.wl** - Output buffering (SetMainPrint/GetMainPrint)
-- **stencils/FiniteDifferenceStencils.wl** - FD stencils for orders 2-12
 
 ### Backends (codes/)
-Each implements `PrintComponentInitialization[varinfo, compname]` and `PrintComponentEquation[coordinate, compname, extrareplacerules]`:
-- **CarpetX.wl**, **CarpetXGPU.wl**, **CarpetXPointDesc.wl** - CarpetX variants
-- **Carpet.wl** - Original Carpet framework
-- **AMReX.wl** - AMReX library
-- **Nmesh.wl** - Structured mesh (C output)
+Each implements `PrintComponentInitialization` and `PrintComponentEquation`:
+- CarpetX.wl, CarpetXGPU.wl, CarpetXPointDesc.wl, Carpet.wl, AMReX.wl, Nmesh.wl
 
-Common backend code is in `BackendCommon.wl`.
-
-### State Management
-
-All state is stored in `$CurrentContext`, a flat association that serves as the single source of truth. All getters/setters read/write `$CurrentContext` directly.
-
-```wolfram
-(* Global API - reads/writes $CurrentContext *)
-SetGridPointIndex["[[ijk]]"];
-GetGridPointIndex[];
-```
-
-Use `WithMode` for scoped settings that auto-restore:
-```wolfram
-WithMode[{
-  "Phase" -> "PrintComp",
-  "PrintCompType" -> "Equations"
-},
-  (* body - settings restored after *)
-];
-```
-
-### Two-Phase Processing
-
-Code generation uses explicit phases:
-
-1. **SetComp Phase**: Maps tensor components to varlist indices
-```wolfram
-WithMode[{"Phase" -> "SetComp"},
-  SetComponents[varlist]
-];
-```
-
-2. **PrintComp Phase**: Generates C/C++ code
-```wolfram
-WithMode[{
-  "Phase" -> "PrintComp",
-  "PrintCompType" -> "Initializations",
-  "InitializationsMode" -> "MainOut"
-},
-  PrintInitializations[varlist]
-];
-
-WithMode[{
-  "Phase" -> "PrintComp",
-  "PrintCompType" -> "Equations",
-  "EquationsMode" -> "Temp"
-},
-  PrintEquations[varlist]
-];
-```
+### Key Patterns
+- **State**: All in `$CurrentContext`; use `WithMode[{...}, body]` for scoped settings
+- **Two phases**: SetComp (map components) then PrintComp (generate code)
 
 ## Tests
 
@@ -93,7 +39,7 @@ wolframscript -script test/AllTests.wl --unit-only  # Unit tests only
 
 ## Wolframscript Tips
 
-Shell escaping with backticks causes misleading errors. Use pipe instead:
+Shell escaping with backticks causes errors. Use pipe instead:
 ```bash
-echo 'Needs["Generato`ParseMode`"]; Print["success"]' | wolframscript
+echo 'Needs["Generato`"]; Print["success"]' | wolframscript
 ```

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ Generate C/C++ Code from Tensor Expression and So On
 * Small toy
 
 ```bash
-cd test/CarpetX
+cd test/regression/CarpetX
 
 Generato test.wl
 ```
 
 * GHG formulation of Einstein's equations
 
-Please take a look at the example script for GHG system: [test/Nmesh/GHG_rhs.ipynb](https://github.com/lwJi/Generato/blob/main/test/Nmesh/GHG_rhs.ipynb). Or
+Please take a look at the example script for GHG system: [test/regression/Nmesh/GHG_rhs.ipynb](https://github.com/lwJi/Generato/blob/main/test/regression/Nmesh/GHG_rhs.ipynb). Or
 
 ```bash
-cd test/Nmesh
+cd test/regression/Nmesh
 
 Generato GHG_rhs.wl
 ```
@@ -51,12 +51,27 @@ Generato GHG_rhs.wl
 
 ### Backends (codes/)
 Each backend implements `PrintComponentInitialization[varinfo, compname]` and `PrintComponentEquation[coordinate, compname, extrareplacerules]`:
-- **CarpetX.wl** - CarpetX AMR with GF3D2 storage
-- **CarpetXGPU.wl** - GPU-enabled CarpetX
-- **CarpetXPointDesc.wl** - Point description variant
-- **Carpet.wl** - Original Carpet framework
-- **AMReX.wl** - AMReX AMR library
-- **Nmesh.wl** - Structured mesh framework (C output)
+
+| Backend | Output | Description |
+|---------|--------|-------------|
+| CarpetX.wl | `.hxx` | CarpetX AMR with GF3D2 storage |
+| CarpetXGPU.wl | `.hxx` | GPU-enabled CarpetX |
+| CarpetXPointDesc.wl | `.hxx` | Point descriptor variant |
+| Carpet.wl | `.hxx` | Original Carpet framework |
+| AMReX.wl | `.hxx` | AMReX AMR library |
+| Nmesh.wl | `.c` | Structured mesh (C output) |
+
+### Public API (Interface.wl)
+
+| Function | Description |
+|----------|-------------|
+| `DefTensors[var1, ...]` | Define tensors without setting components |
+| `GridTensors[var1, ...]` | Define tensors with grid point indices |
+| `TileTensors[var1, ...]` | Define tensors with tile point indices |
+| `TempTensors[var1, ...]` | Define temporary tensors (no grid index) |
+| `SetComponents[varlist]` | Map tensor components to varlist indices |
+| `PrintEquations[{opts}, varlist]` | Generate C/C++ equations |
+| `PrintInitializations[{opts}, varlist]` | Generate initialization code |
 
 ## Recommendations
 


### PR DESCRIPTION
## Summary
- Fix outdated test paths in README.md (`test/CarpetX` → `test/regression/CarpetX`)
- Add backend comparison table with output formats to README.md
- Add public API summary table for Interface.wl functions
- Condense CLAUDE.md from ~100 to ~45 lines, keeping essential info

## Test plan
- [ ] Review documentation changes for accuracy
- [ ] Verify test paths match actual directory structure