### PR TITLE
Add validation to WithMode for consistent error handling

### DIFF
--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -96,6 +96,15 @@ WithMode[settings_List, body_] :=
   Module[{flatKeys, savedValues},
     (* Extract flat keys from settings *)
     flatKeys = First /@ settings;
+    (* Validate all settings before applying any *)
+    Scan[
+      Function[setting,
+        If[!ValidateContextModeValue[First[setting], Last[setting]],
+          Throw @ Message[WithMode::EInvalidValue, First[setting], Last[setting]]
+        ]
+      ],
+      settings
+    ];
     (* Save current values for keys we're about to modify *)
     savedValues = $CurrentContext[#] & /@ flatKeys;
     (* Apply new settings *)
@@ -116,6 +125,8 @@ WithMode[settings_List, body_] :=
   ];
 
 Protect[WithMode];
+
+WithMode::EInvalidValue = "Invalid value for key \"`1`\": `2`";
 
 (* ========================================= *)
 (* Convenience Helpers *)

--- a/test/unit/ParseModeTests.wl
+++ b/test/unit/ParseModeTests.wl
@@ -237,6 +237,48 @@ AppendTo[$AllTests,
 ];
 
 (* ========================================= *)
+(* Test: WithMode validation *)
+(* ========================================= *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    (* WithMode should throw on invalid Phase value *)
+    Catch[
+      WithMode[{"Phase" -> "InvalidPhase"}, GetPhase[]];
+      "NoThrow"
+    ],
+    Null,  (* Message returns Null, Throw propagates it *)
+    {WithMode::EInvalidValue},
+    TestID -> "Mode-WithMode-Validation-InvalidPhase"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    (* WithMode should throw on invalid DerivsOrder value *)
+    Catch[
+      WithMode[{"DerivsOrder" -> "NotAnInteger"}, GetDerivsOrder[]];
+      "NoThrow"
+    ],
+    Null,
+    {WithMode::EInvalidValue},
+    TestID -> "Mode-WithMode-Validation-InvalidDerivsOrder"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    (* Keys without validation rules should still work *)
+    WithMode[{"SuffixName" -> "anything"}, GetSuffixName[]],
+    "anything",
+    TestID -> "Mode-WithMode-NoValidation-SuffixName"
+  ]
+];
+
+(* ========================================= *)
 (* Cleanup *)
 (* ========================================= *)
 


### PR DESCRIPTION
## Summary

- Add upfront validation to `WithMode` function before applying any settings
- Ensure atomic behavior - either all settings are valid and applied, or none are
- Add `WithMode::EInvalidValue` error message for clear error reporting
- Add unit tests for validation behavior

## Test plan

- [x] All existing unit tests pass
- [x] New validation tests pass (`Mode-WithMode-Validation-InvalidPhase`, `Mode-WithMode-Validation-InvalidDerivsOrder`, `Mode-WithMode-NoValidation-SuffixName`)
- [x] Manual verification: `WithMode[{"Phase" -> "Invalid"}, GetPhase[]]` throws error
- [x] Manual verification: `WithMode[{"Phase" -> "SetComp"}, GetPhase[]]` returns `"SetComp"`