### PR TITLE
Centralize state validation in Context.wl

### DIFF
--- a/src/Basic.wl
+++ b/src/Basic.wl
@@ -88,8 +88,13 @@ Protect[GetCheckInputEquations];
 
 SetCheckInputEquations[checkinput_] :=
   Module[{},
+    If[!ValidateContextModeValue["CheckInputEquations", checkinput],
+      Throw @ Message[SetCheckInputEquations::EInvalidValue, checkinput]
+    ];
     $CurrentContext = Append[$CurrentContext, "CheckInputEquations" -> checkinput]
   ];
+
+SetCheckInputEquations::EInvalidValue = "Invalid CheckInputEquations value: `1`. Expected True or False.";
 
 Protect[SetCheckInputEquations];
 
@@ -99,8 +104,13 @@ Protect[GetPVerbose];
 
 SetPVerbose[verbose_] :=
   Module[{},
+    If[!ValidateContextModeValue["PVerbose", verbose],
+      Throw @ Message[SetPVerbose::EInvalidValue, verbose]
+    ];
     $CurrentContext = Append[$CurrentContext, "PVerbose" -> verbose]
   ];
+
+SetPVerbose::EInvalidValue = "Invalid PVerbose value: `1`. Expected True or False.";
 
 Protect[SetPVerbose];
 
@@ -110,8 +120,13 @@ Protect[GetPrintDate];
 
 SetPrintDate[print_] :=
   Module[{},
+    If[!ValidateContextModeValue["PrintDate", print],
+      Throw @ Message[SetPrintDate::EInvalidValue, print]
+    ];
     $CurrentContext = Append[$CurrentContext, "PrintDate" -> print]
   ];
+
+SetPrintDate::EInvalidValue = "Invalid PrintDate value: `1`. Expected True or False.";
 
 Protect[SetPrintDate];
 
@@ -121,8 +136,13 @@ Protect[GetPrintHeaderMacro];
 
 SetPrintHeaderMacro[print_] :=
   Module[{},
+    If[!ValidateContextModeValue["PrintHeaderMacro", print],
+      Throw @ Message[SetPrintHeaderMacro::EInvalidValue, print]
+    ];
     $CurrentContext = Append[$CurrentContext, "PrintHeaderMacro" -> print]
   ];
+
+SetPrintHeaderMacro::EInvalidValue = "Invalid PrintHeaderMacro value: `1`. Expected True or False.";
 
 Protect[SetPrintHeaderMacro];
 
@@ -132,8 +152,13 @@ Protect[GetGridPointIndex];
 
 SetGridPointIndex[gridindex_] :=
   Module[{},
+    If[!ValidateContextModeValue["GridPointIndex", gridindex],
+      Throw @ Message[SetGridPointIndex::EInvalidValue, gridindex]
+    ];
     $CurrentContext = Append[$CurrentContext, "GridPointIndex" -> gridindex]
   ];
+
+SetGridPointIndex::EInvalidValue = "Invalid GridPointIndex value: `1`. Expected a String.";
 
 Protect[SetGridPointIndex];
 
@@ -143,8 +168,13 @@ Protect[GetTilePointIndex];
 
 SetTilePointIndex[tileindex_] :=
   Module[{},
+    If[!ValidateContextModeValue["TilePointIndex", tileindex],
+      Throw @ Message[SetTilePointIndex::EInvalidValue, tileindex]
+    ];
     $CurrentContext = Append[$CurrentContext, "TilePointIndex" -> tileindex]
   ];
+
+SetTilePointIndex::EInvalidValue = "Invalid TilePointIndex value: `1`. Expected a String.";
 
 Protect[SetTilePointIndex];
 
@@ -154,8 +184,13 @@ Protect[GetSuffixUnprotected];
 
 SetSuffixUnprotected[suffix_] :=
   Module[{},
+    If[!ValidateContextModeValue["SuffixUnprotected", suffix],
+      Throw @ Message[SetSuffixUnprotected::EInvalidValue, suffix]
+    ];
     $CurrentContext = Append[$CurrentContext, "SuffixUnprotected" -> suffix]
   ];
+
+SetSuffixUnprotected::EInvalidValue = "Invalid SuffixUnprotected value: `1`. Expected a String.";
 
 Protect[SetSuffixUnprotected];
 
@@ -165,8 +200,13 @@ Protect[GetOutputFile];
 
 SetOutputFile[filename_] :=
   Module[{},
+    If[!ValidateContextModeValue["OutputFile", filename],
+      Throw @ Message[SetOutputFile::EInvalidValue, filename]
+    ];
     $CurrentContext = Append[$CurrentContext, "OutputFile" -> filename]
   ];
+
+SetOutputFile::EInvalidValue = "Invalid OutputFile value: `1`. Expected a String.";
 
 Protect[SetOutputFile];
 
@@ -176,8 +216,13 @@ Protect[GetProject];
 
 SetProject[name_] :=
   Module[{},
+    If[!ValidateContextModeValue["Project", name],
+      Throw @ Message[SetProject::EInvalidValue, name]
+    ];
     $CurrentContext = Append[$CurrentContext, "Project" -> name]
   ];
+
+SetProject::EInvalidValue = "Invalid Project value: `1`. Expected a String.";
 
 Protect[SetProject];
 

--- a/src/Component.wl
+++ b/src/Component.wl
@@ -60,8 +60,13 @@ Protect[GetMapComponentToVarlist];
 
 SetMapComponentToVarlist[map_] :=
   Module[{},
+    If[!ValidateContextModeValue["MapComponentToVarlist", map],
+      Throw @ Message[SetMapComponentToVarlist::EInvalidValue, map]
+    ];
     $CurrentContext = Append[$CurrentContext, "MapComponentToVarlist" -> map]
   ];
+
+SetMapComponentToVarlist::EInvalidValue = "Invalid MapComponentToVarlist value: `1`. Expected an Association.";
 
 Protect[SetMapComponentToVarlist];
 
@@ -71,8 +76,13 @@ Protect[GetProcessNewVarlist];
 
 SetProcessNewVarlist[isnew_] :=
   Module[{},
+    If[!ValidateContextModeValue["ProcessNewVarlist", isnew],
+      Throw @ Message[SetProcessNewVarlist::EInvalidValue, isnew]
+    ];
     $CurrentContext = Append[$CurrentContext, "ProcessNewVarlist" -> isnew]
   ];
+
+SetProcessNewVarlist::EInvalidValue = "Invalid ProcessNewVarlist value: `1`. Expected True or False.";
 
 Protect[SetProcessNewVarlist];
 
@@ -82,8 +92,13 @@ Protect[GetSimplifyEquation];
 
 SetSimplifyEquation[simplify_] :=
   Module[{},
+    If[!ValidateContextModeValue["SimplifyEquation", simplify],
+      Throw @ Message[SetSimplifyEquation::EInvalidValue, simplify]
+    ];
     $CurrentContext = Append[$CurrentContext, "SimplifyEquation" -> simplify]
   ];
+
+SetSimplifyEquation::EInvalidValue = "Invalid SimplifyEquation value: `1`. Expected True or False.";
 
 Protect[SetSimplifyEquation];
 
@@ -93,8 +108,13 @@ Protect[GetUseLetterForTensorComponent];
 
 SetUseLetterForTensorComponent[useletter_] :=
   Module[{},
+    If[!ValidateContextModeValue["UseLetterForTensorComponent", useletter],
+      Throw @ Message[SetUseLetterForTensorComponent::EInvalidValue, useletter]
+    ];
     $CurrentContext = Append[$CurrentContext, "UseLetterForTensorComponent" -> useletter]
   ];
+
+SetUseLetterForTensorComponent::EInvalidValue = "Invalid UseLetterForTensorComponent value: `1`. Expected True or False.";
 
 Protect[SetUseLetterForTensorComponent];
 
@@ -104,8 +124,13 @@ Protect[GetTempVariableType];
 
 SetTempVariableType[type_] :=
   Module[{},
+    If[!ValidateContextModeValue["TempVariableType", type],
+      Throw @ Message[SetTempVariableType::EInvalidValue, type]
+    ];
     $CurrentContext = Append[$CurrentContext, "TempVariableType" -> type]
   ];
+
+SetTempVariableType::EInvalidValue = "Invalid TempVariableType value: `1`. Expected a String.";
 
 Protect[SetTempVariableType];
 
@@ -115,8 +140,13 @@ Protect[GetInterfaceWithNonCoordBasis];
 
 SetInterfaceWithNonCoordBasis[noncoordbasis_] :=
   Module[{},
+    If[!ValidateContextModeValue["InterfaceWithNonCoordBasis", noncoordbasis],
+      Throw @ Message[SetInterfaceWithNonCoordBasis::EInvalidValue, noncoordbasis]
+    ];
     $CurrentContext = Append[$CurrentContext, "InterfaceWithNonCoordBasis" -> noncoordbasis]
   ];
+
+SetInterfaceWithNonCoordBasis::EInvalidValue = "Invalid InterfaceWithNonCoordBasis value: `1`. Expected True or False.";
 
 Protect[SetInterfaceWithNonCoordBasis];
 
@@ -126,8 +156,13 @@ Protect[GetSuffixName];
 
 SetSuffixName[suffix_] :=
   Module[{},
+    If[!ValidateContextModeValue["SuffixName", suffix],
+      Throw @ Message[SetSuffixName::EInvalidValue, suffix]
+    ];
     $CurrentContext = Append[$CurrentContext, "SuffixName" -> suffix]
   ];
+
+SetSuffixName::EInvalidValue = "Invalid SuffixName value: `1`. Expected a String.";
 
 Protect[SetSuffixName];
 
@@ -137,8 +172,13 @@ Protect[GetPrefixDt];
 
 SetPrefixDt[prefix_] :=
   Module[{},
+    If[!ValidateContextModeValue["PrefixDt", prefix],
+      Throw @ Message[SetPrefixDt::EInvalidValue, prefix]
+    ];
     $CurrentContext = Append[$CurrentContext, "PrefixDt" -> prefix]
   ];
+
+SetPrefixDt::EInvalidValue = "Invalid PrefixDt value: `1`. Expected a String.";
 
 Protect[SetPrefixDt];
 

--- a/src/Context.wl
+++ b/src/Context.wl
@@ -51,6 +51,64 @@ $ContextDefaults = <|
   "MainPrint" -> Null
 |>;
 
+(* Valid values for context keys - used by setters for validation *)
+$ContextModeValidValues::usage = "$ContextModeValidValues contains validation rules for context keys.";
+
+$ContextModeValidValues = <|
+  (* Basic.wl keys *)
+  "CheckInputEquations" -> {True, False},
+  "PVerbose" -> {True, False},
+  "PrintDate" -> {True, False},
+  "PrintHeaderMacro" -> {True, False},
+  "GridPointIndex" -> _String,
+  "TilePointIndex" -> _String,
+  "SuffixUnprotected" -> _String,
+  "OutputFile" -> _String,
+  "Project" -> _String,
+
+  (* ParseMode.wl keys *)
+  "Phase" -> {None, "SetComp", "PrintComp"},
+  "IndependentVarlistIndex" -> {True, False},
+  "WithoutGridPointIndex" -> {True, False},
+  "UseTilePointIndex" -> {True, False},
+  "PrintCompType" -> {None, "Initializations", "Equations"},
+  "InitializationsMode" -> {None, "MainOut", "MainIn", "Derivs", "Derivs1st", "Derivs2nd", "MoreInOut", "Temp"},
+  "TensorType" -> {None, "Scal", "Vect", "Smat"},
+  "StorageType" -> {None, "GF", "Tile"},
+  "DerivsOrder" -> _Integer,
+  "DerivsAccuracy" -> _Integer,
+  "EquationsMode" -> {None, "Temp", "MainOut", "AddToMainOut"},
+
+  (* Component.wl keys *)
+  "MapComponentToVarlist" -> _Association,
+  "ProcessNewVarlist" -> {True, False},
+  "SimplifyEquation" -> {True, False},
+  "UseLetterForTensorComponent" -> {True, False},
+  "TempVariableType" -> _String,
+  "InterfaceWithNonCoordBasis" -> {True, False},
+  "SuffixName" -> _String,
+  "PrefixDt" -> _String
+|>;
+
+(* Validate value for context key *)
+ValidateContextModeValue::usage = "ValidateContextModeValue[key, value] returns True if value is valid for key.";
+
+ValidateContextModeValue[key_String, value_] :=
+  Module[{validValues},
+    If[!KeyExistsQ[$ContextModeValidValues, key],
+      (* No validation for this key - allow any value *)
+      True
+      ,
+      validValues = $ContextModeValidValues[key];
+      If[ListQ[validValues],
+        MemberQ[validValues, value]
+        ,
+        (* It's a pattern (e.g., _Integer) - use pattern matching *)
+        MatchQ[value, validValues]
+      ]
+    ]
+  ];
+
 (* Initialize global context with defaults *)
 $CurrentContext = $ContextDefaults;
 

--- a/src/ParseMode.wl
+++ b/src/ParseMode.wl
@@ -51,42 +51,9 @@ SetUseTilePointIndex::usage = "SetUseTilePointIndex[val] sets UseTilePointIndex.
 
 Begin["`Private`"];
 
-(* Valid values for flat context keys *)
-$ContextModeValidValues = <|
-  "Phase" -> {None, "SetComp", "PrintComp"},
-  "IndependentVarlistIndex" -> {True, False},
-  "WithoutGridPointIndex" -> {True, False},
-  "UseTilePointIndex" -> {True, False},
-  "PrintCompType" -> {None, "Initializations", "Equations"},
-  "InitializationsMode" -> {None, "MainOut", "MainIn", "Derivs", "Derivs1st", "Derivs2nd", "MoreInOut", "Temp"},
-  "TensorType" -> {None, "Scal", "Vect", "Smat"},
-  "StorageType" -> {None, "GF", "Tile"},
-  "DerivsOrder" -> _Integer,
-  "DerivsAccuracy" -> _Integer,
-  "EquationsMode" -> {None, "Temp", "MainOut", "AddToMainOut"}
-|>;
-
-
 (* ========================================= *)
 (* Core Functions *)
 (* ========================================= *)
-
-(* Validate value for flat context key *)
-ValidateContextModeValue[key_String, value_] :=
-  Module[{validValues},
-    If[!KeyExistsQ[$ContextModeValidValues, key],
-      (* No validation for this key - allow any value *)
-      True
-      ,
-      validValues = $ContextModeValidValues[key];
-      If[ListQ[validValues],
-        MemberQ[validValues, value]
-        ,
-        (* It's a pattern (e.g., _Integer) - use pattern matching *)
-        MatchQ[value, validValues]
-      ]
-    ]
-  ];
 
 (* Scoped mode settings with automatic restore *)
 (* settings is a list of "FlatKey" -> value rules *)

--- a/test/unit/ValidationTests.wl
+++ b/test/unit/ValidationTests.wl
@@ -1,0 +1,188 @@
+(* ::Package:: *)
+
+(* ValidationTests.wl *)
+(* Validation Tests for Basic.wl and Component.wl setters *)
+
+If[Environment["QUIET"] =!= "1", Print["Loading ValidationTests.wl..."]];
+
+(* Load Generato *)
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
+
+SetPVerbose[False];
+SetPrintDate[False];
+
+(* Test helper *)
+ResetContext[] := ($CurrentContext = $ContextDefaults);
+
+(* ===== Basic.wl Setter Validation Tests ===== *)
+
+(* Boolean setters should reject non-boolean values *)
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    Catch[
+      SetCheckInputEquations["invalid"];
+      "NoThrow"
+    ],
+    Null,  (* Message returns Null, Throw propagates it *)
+    {SetCheckInputEquations::EInvalidValue},
+    TestID -> "SetCheckInputEquations rejects string"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    SetCheckInputEquations[True];
+    GetCheckInputEquations[],
+    True,
+    TestID -> "SetCheckInputEquations accepts True"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    Catch[
+      SetPVerbose[1];
+      "NoThrow"
+    ],
+    Null,
+    {SetPVerbose::EInvalidValue},
+    TestID -> "SetPVerbose rejects integer"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    SetPVerbose[False];
+    GetPVerbose[],
+    False,
+    TestID -> "SetPVerbose accepts False"
+  ]
+];
+
+(* String setters should reject non-string values *)
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    Catch[
+      SetGridPointIndex[123];
+      "NoThrow"
+    ],
+    Null,
+    {SetGridPointIndex::EInvalidValue},
+    TestID -> "SetGridPointIndex rejects integer"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    SetGridPointIndex["[ijk]"];
+    GetGridPointIndex[],
+    "[ijk]",
+    TestID -> "SetGridPointIndex accepts string"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    Catch[
+      SetOutputFile[True];
+      "NoThrow"
+    ],
+    Null,
+    {SetOutputFile::EInvalidValue},
+    TestID -> "SetOutputFile rejects boolean"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    SetOutputFile["myfile.cxx"];
+    GetOutputFile[],
+    "myfile.cxx",
+    TestID -> "SetOutputFile accepts string"
+  ]
+];
+
+(* ===== Component.wl Setter Validation Tests ===== *)
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    Catch[
+      SetSimplifyEquation["yes"];
+      "NoThrow"
+    ],
+    Null,
+    {SetSimplifyEquation::EInvalidValue},
+    TestID -> "SetSimplifyEquation rejects string"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    SetSimplifyEquation[False];
+    GetSimplifyEquation[],
+    False,
+    TestID -> "SetSimplifyEquation accepts False"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    Catch[
+      SetTempVariableType[123];
+      "NoThrow"
+    ],
+    Null,
+    {SetTempVariableType::EInvalidValue},
+    TestID -> "SetTempVariableType rejects integer"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    SetTempVariableType["float"];
+    GetTempVariableType[],
+    "float",
+    TestID -> "SetTempVariableType accepts string"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    Catch[
+      SetMapComponentToVarlist[{1, 2, 3}];
+      "NoThrow"
+    ],
+    Null,
+    {SetMapComponentToVarlist::EInvalidValue},
+    TestID -> "SetMapComponentToVarlist rejects list"
+  ]
+];
+
+AppendTo[$AllTests,
+  VerificationTest[
+    ResetContext[];
+    SetMapComponentToVarlist[<|"a" -> 1|>];
+    GetMapComponentToVarlist[],
+    <|"a" -> 1|>,
+    TestID -> "SetMapComponentToVarlist accepts association"
+  ]
+];
+
+(* ===== Cleanup ===== *)
+
+ResetContext[];
+
+If[Environment["QUIET"] =!= "1", Print["ValidationTests.wl completed."]];


### PR DESCRIPTION
## Summary
- Move validation infrastructure (`$ContextModeValidValues` and `ValidateContextModeValue`) from ParseMode.wl to Context.wl
- Add validation to all 9 Basic.wl setters and all 8 Component.wl setters
- Add ValidationTests.wl with 12 unit tests covering rejection and acceptance cases

## Test plan
- [x] All existing tests pass: `wolframscript -script test/AllTests.wl`
- [x] New ValidationTests.wl passes all 12 tests
- [x] Manual verification of invalid value rejection (e.g., `SetPVerbose["invalid"]` throws error)