### PR TITLE
Rewrite CLAUDE.md and README.md for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Repository Guidelines
+# Generato
 
-Generato is a Wolfram Language code generator that produces C/C++ from symbolic tensor expressions using xAct.
+Wolfram Language code generator that produces C/C++ from symbolic tensor expressions using xAct.
 
 ## Running
 
@@ -13,14 +13,16 @@ Generato file1.wl file2.wl          # Multiple files
 ## Architecture
 
 ### Core (src/)
-- **Context.wl** - Global state via `$CurrentContext`
+- **Generato.wl** - Package loader, imports modules in dependency order
+- **Context.wl** - Global state via `$CurrentContext`, accessor generation
 - **Basic.wl** - Config, tensor utilities, SetEQN/SetEQNDelayed
-- **ParseMode.wl** - Phase management, WithMode for scoped settings
+- **ParseMode.wl** - Phase management, `WithMode[{...}, body]` for scoped settings
 - **Component.wl** - Tensor component to varlist mapping
 - **Varlist.wl** - Tensor definitions via ParseVarlist
-- **Interface.wl** - Public API (DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations)
+- **Interface.wl** - Public API: DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations
 - **BackendCommon.wl** - Shared backend utilities
 - **Writefile.wl** - Output buffering (SetMainPrint/GetMainPrint)
+- **stencils/FiniteDifferenceStencils.wl** - Finite difference stencil generation
 
 ### Backends (codes/)
 Each implements `PrintComponentInitialization` and `PrintComponentEquation`:
@@ -28,7 +30,8 @@ Each implements `PrintComponentInitialization` and `PrintComponentEquation`:
 
 ### Key Patterns
 - **State**: All in `$CurrentContext`; use `WithMode[{...}, body]` for scoped settings
-- **Two phases**: SetComp (map components) then PrintComp (generate code)
+- **Two phases**: SetComp (map components) → PrintComp (generate code)
+- **Equations**: Use `SetEQN` normally; use `SetEQNDelayed` when RHS contains `If` statements
 
 ## Tests
 
@@ -37,7 +40,7 @@ wolframscript -script test/AllTests.wl              # All tests
 wolframscript -script test/AllTests.wl --unit-only  # Unit tests only
 ```
 
-## Wolframscript Tips
+## Tips
 
 Shell escaping with backticks causes errors. Use pipe instead:
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,184 +1,159 @@
 # Generato
 
-Generate C/C++ Code from Tensor Expression and So On
+A Wolfram Language code generator that produces C/C++ from symbolic tensor expressions using xAct. Designed for numerical relativity and computational physics applications.
 
 ## Pre-Requisites
 
-* Install free Wolfram Engine for Developers from https://www.wolfram.com/developer/.
-(If you are rich, you can install the totally worth-it Mathematica instead, versions that support `wolframscript`.)
-
-* Download xAct from http://www.xact.es and install it properly.
+- [Wolfram Engine](https://www.wolfram.com/developer/) (free) or Mathematica
+- [xAct](http://www.xact.es) tensor algebra package
 
 ## Installation
 
-* clone repo: `git clone https://github.com/lwJi/Generato.git`
-
-* set environment variable: `export GENERATO="/your/repo/path"`
-
-## Example
-
-* Small toy
-
 ```bash
-cd test/regression/CarpetX
-
-Generato test.wl
+git clone https://github.com/lwJi/Generato.git
+export GENERATO="/path/to/Generato"
 ```
 
-* GHG formulation of Einstein's equations
+## Quick Start
 
-Please take a look at the example script for GHG system: [test/regression/Nmesh/GHG_rhs.ipynb](https://github.com/lwJi/Generato/blob/main/test/regression/Nmesh/GHG_rhs.ipynb). Or
+```wolfram
+(* Load Generato *)
+Needs["xAct`xCoba`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]]
 
-```bash
-cd test/regression/Nmesh
+(* Define 3D manifold and coordinates *)
+DefManifold[M3, 3, IndexRange[a, z]];
+DefChart[cart, M3, {1, 2, 3}, {X[], Y[], Z[]}, ChartColor -> Blue];
+DefMetric[1, euclid[-i, -j], CD];
+MetricInBasis[euclid, -cart, DiagonalMatrix[{1, 1, 1}]];
 
-Generato GHG_rhs.wl
+(* Define tensors *)
+OutputVars = GridTensors[{rU[i], PrintAs -> "r"}];
+InputVars = GridTensors[{uU[i], PrintAs -> "u"}];
+
+(* Set equations *)
+SetEQN[rU[i_], 2 uU[i]];
+
+(* Generate code *)
+SetOutputFile["output.hxx"];
+SetMainPrint[
+  PrintInitializations[{Mode -> "MainOut"}, OutputVars];
+  PrintInitializations[{Mode -> "MainIn"}, InputVars];
+  PrintEquations[{Mode -> "MainOut"}, OutputVars];
+];
+Import[FileNameJoin[{Environment["GENERATO"], "codes/CarpetX.wl"}]];
 ```
+
+Run with: `Generato script.wl`
+
+## Examples
+
+**Simple example:**
+```bash
+cd test/regression/CarpetX && Generato test.wl
+```
+
+**GHG formulation of Einstein's equations:**
+- Notebook: [test/regression/Nmesh/GHG_rhs.ipynb](https://github.com/lwJi/Generato/blob/main/test/regression/Nmesh/GHG_rhs.ipynb)
+- Script: `cd test/regression/Nmesh && Generato GHG_rhs.wl`
 
 ## Architecture
 
+### Two-Phase Processing
+
+1. **SetComp phase**: Map tensor components to C/C++ variable indices
+2. **PrintComp phase**: Generate initialization and equation code
+
 ### Core Modules (src/)
-- **Generato.wl** - Package loader, imports modules in dependency order
-- **Basic.wl** - Global config state, tensor utilities, equation setting (SetEQN/SetEQNDelayed)
-- **ParseMode.wl** - Mode management system tracking execution state (SetComp/PrintComp phases)
-- **Component.wl** - Maps tensor components to varlist indices, handles symmetries
-- **Varlist.wl** - Processes tensor definitions via ParseVarlist
-- **Interface.wl** - Public API: DefTensors, GridTensors, TileTensors, TempTensors, SetComponents, PrintEquations, PrintInitializations
-- **BackendCommon.wl** - Shared backend utilities
-- **Derivation.wl** - Testing utilities
-- **Writefile.wl** - Output buffering (SetMainPrint/GetMainPrint)
-- **stencils/FiniteDifferenceStencils.wl** - Finite difference stencil generation
+
+| Module | Purpose |
+|--------|---------|
+| Generato.wl | Package loader |
+| Context.wl | Global state (`$CurrentContext`) |
+| Basic.wl | Config, SetEQN/SetEQNDelayed |
+| ParseMode.wl | Phase management, WithMode |
+| Component.wl | Component-to-varlist mapping |
+| Varlist.wl | Tensor definitions (ParseVarlist) |
+| Interface.wl | Public API |
+| BackendCommon.wl | Shared backend utilities |
+| Writefile.wl | Output buffering |
+| stencils/*.wl | Finite difference stencils |
 
 ### Backends (codes/)
-Each backend implements `PrintComponentInitialization[varinfo, compname]` and `PrintComponentEquation[coordinate, compname, extrareplacerules]`:
 
 | Backend | Output | Description |
 |---------|--------|-------------|
-| CarpetX.wl | `.hxx` | CarpetX AMR with GF3D2 storage |
-| CarpetXGPU.wl | `.hxx` | GPU-enabled CarpetX |
-| CarpetXPointDesc.wl | `.hxx` | Point descriptor variant |
-| Carpet.wl | `.hxx` | Original Carpet framework |
-| AMReX.wl | `.hxx` | AMReX AMR library |
-| Nmesh.wl | `.c` | Structured mesh (C output) |
+| CarpetX.wl | .hxx | CarpetX AMR with GF3D2 storage |
+| CarpetXGPU.wl | .hxx | GPU-enabled CarpetX |
+| CarpetXPointDesc.wl | .hxx | Point descriptor variant |
+| Carpet.wl | .hxx | Original Carpet framework |
+| AMReX.wl | .hxx | AMReX AMR library |
+| Nmesh.wl | .c | Structured mesh (C output) |
 
-### Public API (Interface.wl)
+## API Reference
+
+### Tensor Definition
 
 | Function | Description |
 |----------|-------------|
-| `DefTensors[var1, ...]` | Define tensors without setting components |
-| `GridTensors[var1, ...]` | Define tensors with grid point indices |
-| `TileTensors[var1, ...]` | Define tensors with tile point indices |
-| `TempTensors[var1, ...]` | Define temporary tensors (no grid index) |
-| `SetComponents[varlist]` | Map tensor components to varlist indices |
-| `PrintEquations[{opts}, varlist]` | Generate C/C++ equations |
-| `PrintInitializations[{opts}, varlist]` | Generate initialization code |
+| `DefTensors[var, ...]` | Define tensors without setting components |
+| `GridTensors[var, ...]` | Define tensors with grid point indices |
+| `TileTensors[var, ...]` | Define tensors with tile point indices |
+| `TempTensors[var, ...]` | Define temporary tensors (no grid index) |
 
-## Recommendations
+### Code Generation
 
-* Use lower case to name variables (to avoid conflict with say `Pi`)
+| Function | Key Options |
+|----------|-------------|
+| `SetComponents[varlist]` | `ChartName`, `IndependentVarlistIndex` |
+| `PrintInitializations[{opts}, varlist]` | `Mode` ("MainOut", "MainIn", "Derivs", "Temp"), `TensorType`, `StorageType` |
+| `PrintEquations[{opts}, varlist]` | `Mode`, `SuffixName`, `ChartName`, `ExtraReplaceRules` |
+
+### Equation Setting
+
+| Function | When to Use |
+|----------|-------------|
+| `SetEQN[lhs, rhs]` | Default choice; validates RHS terms |
+| `SetEQNDelayed[lhs, rhs]` | When RHS contains `If` statements |
+
+Options: `SuffixName`, `CheckRHS` (SetEQN only)
 
 ## Tips
 
-* Use `SetEQNDelayed` if your right-hand side (rhs) includes an `If` statement to handle different component cases. Otherwise, `SetEQN` is preferred because it has an option, `CheckRHS`, which checks if all the terms appearing in the rhs are well-defined.
-
-* `IsDefined[term]` is very useful for debugging.
+- **Variable naming**: Use lowercase to avoid conflicts with built-ins like `Pi`
+- **Debugging**: Use `IsDefined[term]` to check if a tensor/component is defined
+- **Conditional code**: Use `SuffixName` option to generate different code paths
 
 ## Running Tests
 
 ```bash
-# Run all tests (runs unit tests + regression tests)
-wolframscript -script test/AllTests.wl
-
-# Run with verbose output
-wolframscript -script test/AllTests.wl --verbose
-
-# Run unit tests only (skip regression tests)
-wolframscript -script test/AllTests.wl --unit-only
-
-# Update golden files with new outputs
-wolframscript -script test/AllTests.wl --generate
+wolframscript -script test/AllTests.wl              # All tests
+wolframscript -script test/AllTests.wl --verbose    # Show progress
+wolframscript -script test/AllTests.wl --unit-only  # Unit tests only
+wolframscript -script test/AllTests.wl --generate   # Update golden files
 ```
 
-### Output Control Options
+**Environment options:**
+- `QUIET=1` - Suppress xAct banners and processing messages
 
-- **`--verbose`** - Controls test runner output (test progress, results)
-- **`QUIET=1`** - Environment variable that suppresses xAct loading banners and Generato processing messages
-
-These operate at different levels and can be combined:
-
-```bash
-# Quiet test run (default) - minimal output
-wolframscript -script test/AllTests.wl
-
-# Verbose test run - shows test progress and results
-wolframscript -script test/AllTests.wl --verbose
-
-# Combined - verbose test results but suppressed xAct banners
-QUIET=1 wolframscript -script test/AllTests.wl --verbose
-```
-
-The test suite includes:
-
-- **Unit tests** (`test/unit/`) - Test individual module functions
-- **Integration tests** - Generate output for each backend
-- **Golden file regression** (`test/regression/golden/`) - Compare outputs against expected results
-
-### Test Directory Structure
+### Test Structure
 
 ```
 test/
-├── AllTests.wl              # Master test runner
-├── TestConfig.wl            # Shared configuration module
-├── test_cases.txt           # Regression test case definitions
-├── compare_golden.wl        # Golden file comparison module
-├── unit/                    # Unit tests (one file per module)
-│   ├── BasicTests.wl
-│   ├── ComponentTests.wl
-│   ├── VarlistTests.wl
-│   └── ...
-└── regression/              # Regression tests
-    ├── golden/              # Reference outputs (.golden files)
-    │   ├── CarpetX/
-    │   ├── Nmesh/
-    │   └── ...
-    ├── CarpetX/             # Backend test directories
-    ├── Nmesh/
-    └── ...
+├── AllTests.wl           # Test runner
+├── unit/                 # Unit tests (one per module)
+└── regression/           # Backend integration tests
+    ├── golden/           # Reference outputs
+    └── <Backend>/        # Test scripts
 ```
 
-### Adding New Unit Tests
+### Adding Tests
 
-Create a new file in `test/unit/` following this pattern:
-
+**Unit test** - Create `test/unit/MyTests.wl`:
 ```wolfram
-If[Environment["QUIET"] =!= "1", Print["Loading MyModuleTests.wl..."]];
-Needs["Generato`", FileNameJoin[{Environment["GENERATO"], "src/Generato.wl"}]];
-SetPVerbose[False];
-SetPrintDate[False];
-
-AppendTo[$AllTests,
-  VerificationTest[
-    (* test code *),
-    (* expected result *),
-    TestID -> "MyModule-DescriptiveTestName"
-  ]
-];
-
-If[Environment["QUIET"] =!= "1", Print["MyModuleTests.wl completed."]];
+AppendTo[$AllTests, VerificationTest[expr, expected, TestID -> "MyTest"]];
 ```
 
-### Adding New Regression Tests
-
-1. Create test file in `test/regression/<Backend>/testname.wl`
-2. Add entry to `test/test_cases.txt`:
-   ```
-   Backend:testname:extension
-   ```
-   Format: `backend:testname:extension` (e.g., `CarpetX:mytest:.hxx`)
-3. Run `wolframscript -script test/AllTests.wl --generate` to create golden file
-
-### Test Examples
-
-- `test/regression/CarpetX/test.wl` - Simple CarpetX example with 3 vectors
-- `test/regression/Nmesh/GHG_rhs.wl` - GHG formulation of Einstein's equations (complex example)
-- `test/regression/Nmesh/GHG_rhs.ipynb` - Jupyter notebook with documentation
+**Regression test**:
+1. Create `test/regression/<Backend>/testname.wl`
+2. Add to `test/test_cases.txt`: `Backend:testname:extension`
+3. Run `--generate` to create golden file


### PR DESCRIPTION
## Summary
- Rewrote CLAUDE.md to be more concise (48 lines) with all modules documented
- Rewrote README.md with better organization and a Quick Start section

## Test plan
- [x] Review CLAUDE.md covers all src/ modules and backends
- [x] Verify README.md Quick Start example is accurate
- [ ] Manual review of documentation clarity