### PR TITLE
Enable dtPi equation in GHG_rhs test case

### DIFF
--- a/test/regression/Nmesh/GHG_rhs.wl
+++ b/test/regression/Nmesh/GHG_rhs.wl
@@ -20,7 +20,7 @@ dtEvolVarlist =
   GridTensors[
     {dtg[-a, -b], Symmetric[{-a, -b}]}
     ,
-    (*{dtPi[-a, -b], Symmetric[{-a, -b}], PrintAs -> "dt\[CapitalPi]"},*)
+    {dtPi[-a, -b], Symmetric[{-a, -b}], PrintAs -> "dt\[CapitalPi]"},
     {dtPhi[-k, -a, -b], Symmetric[{-a, -b}], PrintAs -> "dt\[CapitalPhi]"}
   ];
 
@@ -83,9 +83,7 @@ SetEQN[trGam[c_], invg[a, b] Gam[c, -a, -b]];
 
 SetEQN[dtg[a_, b_], -Adg[a, b] interior - alpha[] Pi$Upt[a, b] - gamma1 beta[c] Phi[-c, a, b]];
 
-(*
 SetEQN[dtPi[a_, b_], -AdPi[a, b] interior + 2 alpha[] invg[c, d] (invh[i, j] Phi[-i, -c, a] Phi[-j, -d, b] - Pi$Upt[-c, a] Pi$Upt[-d, b] - invg[e, f] Gam[a, -c, -e] Gam[b, -d, -f]) - 1/2 alpha[] nvec[c] nvec[d] Pi$Upt[-c, -d] Pi$Upt[a, b] - alpha[] nvec[c] Pi$Upt[-c, -i] invh[i, j] Phi[-j, a, b] + 2 alpha[] (invg[c, d] Gam[-c, a, b] H[-d]) + gamma0 alpha[] ((H[a] + trGam[a]) ndua[b] + (H[b] + trGam[b]) ndua[a] - g[a, b] nvec[c] (H[-c] + trGam[-c])) - gamma1 gamma2 beta[i] Phi[-i, a, b] - srcSdH[a, b]];
-*)
 
 SetEQN[dtPhi[i_, a_, b_], -AdPhi[i, a, b] interior + 1/2 alpha[] nvec[c] nvec[d] Phi[i, -c, -d] Pi$Upt[a, b] + alpha[] invh[j, k] nvec[c] Phi[i, -j, -c] Phi[-k, a, b] - gamma2 alpha[] Phi[i, a, b]];
 

--- a/test/regression/golden/Nmesh/GHG_rhs.c.golden
+++ b/test/regression/golden/Nmesh/GHG_rhs.c.golden
@@ -38,6 +38,16 @@ double *dtg13 = Vard(node, Vind(vlr,GHG->i_gtt+6));
 double *dtg22 = Vard(node, Vind(vlr,GHG->i_gtt+7));
 double *dtg23 = Vard(node, Vind(vlr,GHG->i_gtt+8));
 double *dtg33 = Vard(node, Vind(vlr,GHG->i_gtt+9));
+double *dtPi00 = Vard(node, Vind(vlr,GHG->i_Pitt));
+double *dtPi01 = Vard(node, Vind(vlr,GHG->i_Pitt+1));
+double *dtPi02 = Vard(node, Vind(vlr,GHG->i_Pitt+2));
+double *dtPi03 = Vard(node, Vind(vlr,GHG->i_Pitt+3));
+double *dtPi11 = Vard(node, Vind(vlr,GHG->i_Pitt+4));
+double *dtPi12 = Vard(node, Vind(vlr,GHG->i_Pitt+5));
+double *dtPi13 = Vard(node, Vind(vlr,GHG->i_Pitt+6));
+double *dtPi22 = Vard(node, Vind(vlr,GHG->i_Pitt+7));
+double *dtPi23 = Vard(node, Vind(vlr,GHG->i_Pitt+8));
+double *dtPi33 = Vard(node, Vind(vlr,GHG->i_Pitt+9));
 double *dtPhi100 = Vard(node, Vind(vlr,GHG->i_Phixtt));
 double *dtPhi101 = Vard(node, Vind(vlr,GHG->i_Phixtt+1));
 double *dtPhi102 = Vard(node, Vind(vlr,GHG->i_Phixtt+2));
@@ -833,6 +843,2451 @@ dtg33[ijk]
 -(interior*Adg33[ijk]) - gamma1*beta1[ijk]*Phi133[ijk] -
   gamma1*beta2[ijk]*Phi233[ijk] - gamma1*beta3[ijk]*Phi333[ijk] -
   alpha[ijk]*Pi33[ijk]
+;
+
+dtPi00[ijk]
+=
+-(interior*AdPi00[ijk]) - gamma1*gamma2*beta1[ijk]*Phi100[ijk] -
+  gamma1*gamma2*beta2[ijk]*Phi200[ijk] -
+  gamma1*gamma2*beta3[ijk]*Phi300[ijk] -
+  (alpha[ijk]*(4*Power(Gam000,2)*Power(invg00,2) +
+       16*Gam000*Gam001*invg00*invg01 +
+       8*Power(Gam001,2)*Power(invg01,2) +
+       8*Gam000*Gam011*Power(invg01,2) + 16*Gam000*Gam002*invg00*invg02 +
+       16*Gam001*Gam002*invg01*invg02 + 16*Gam000*Gam012*invg01*invg02 +
+       8*Power(Gam002,2)*Power(invg02,2) +
+       8*Gam000*Gam022*Power(invg02,2) + 16*Gam000*Gam003*invg00*invg03 +
+       16*Gam001*Gam003*invg01*invg03 + 16*Gam000*Gam013*invg01*invg03 +
+       16*Gam002*Gam003*invg02*invg03 + 16*Gam000*Gam023*invg02*invg03 +
+       8*Power(Gam003,2)*Power(invg03,2) +
+       8*Gam000*Gam033*Power(invg03,2) + 8*Power(Gam001,2)*invg00*invg11 +
+       16*Gam001*Gam011*invg01*invg11 + 16*Gam001*Gam012*invg02*invg11 +
+       16*Gam001*Gam013*invg03*invg11 +
+       4*Power(Gam011,2)*Power(invg11,2) +
+       16*Gam001*Gam002*invg00*invg12 + 16*Gam002*Gam011*invg01*invg12 +
+       16*Gam001*Gam012*invg01*invg12 + 16*Gam002*Gam012*invg02*invg12 +
+       16*Gam001*Gam022*invg02*invg12 + 16*Gam002*Gam013*invg03*invg12 +
+       16*Gam001*Gam023*invg03*invg12 + 16*Gam011*Gam012*invg11*invg12 +
+       8*Power(Gam012,2)*Power(invg12,2) +
+       8*Gam011*Gam022*Power(invg12,2) + 16*Gam001*Gam003*invg00*invg13 +
+       16*Gam003*Gam011*invg01*invg13 + 16*Gam001*Gam013*invg01*invg13 +
+       16*Gam003*Gam012*invg02*invg13 + 16*Gam001*Gam023*invg02*invg13 +
+       16*Gam003*Gam013*invg03*invg13 + 16*Gam001*Gam033*invg03*invg13 +
+       16*Gam011*Gam013*invg11*invg13 + 16*Gam012*Gam013*invg12*invg13 +
+       16*Gam011*Gam023*invg12*invg13 +
+       8*Power(Gam013,2)*Power(invg13,2) +
+       8*Gam011*Gam033*Power(invg13,2) + 8*Power(Gam002,2)*invg00*invg22 +
+       16*Gam002*Gam012*invg01*invg22 + 16*Gam002*Gam022*invg02*invg22 +
+       16*Gam002*Gam023*invg03*invg22 + 8*Power(Gam012,2)*invg11*invg22 +
+       16*Gam012*Gam022*invg12*invg22 + 16*Gam012*Gam023*invg13*invg22 +
+       4*Power(Gam022,2)*Power(invg22,2) +
+       16*Gam002*Gam003*invg00*invg23 + 16*Gam003*Gam012*invg01*invg23 +
+       16*Gam002*Gam013*invg01*invg23 + 16*Gam003*Gam022*invg02*invg23 +
+       16*Gam002*Gam023*invg02*invg23 + 16*Gam003*Gam023*invg03*invg23 +
+       16*Gam002*Gam033*invg03*invg23 + 16*Gam012*Gam013*invg11*invg23 +
+       16*Gam013*Gam022*invg12*invg23 + 16*Gam012*Gam023*invg12*invg23 +
+       16*Gam013*Gam023*invg13*invg23 + 16*Gam012*Gam033*invg13*invg23 +
+       16*Gam022*Gam023*invg22*invg23 +
+       8*Power(Gam023,2)*Power(invg23,2) +
+       8*Gam022*Gam033*Power(invg23,2) + 8*Power(Gam003,2)*invg00*invg33 +
+       16*Gam003*Gam013*invg01*invg33 + 16*Gam003*Gam023*invg02*invg33 +
+       16*Gam003*Gam033*invg03*invg33 + 8*Power(Gam013,2)*invg11*invg33 +
+       16*Gam013*Gam023*invg12*invg33 + 16*Gam013*Gam033*invg13*invg33 +
+       8*Power(Gam023,2)*invg22*invg33 + 16*Gam023*Gam033*invg23*invg33 +
+       4*Power(Gam033,2)*Power(invg33,2) - 4*gamma0*ndua0*trGam0 -
+       4*(Gam000*invg00 + Gam100*invg01 + Gam200*invg02 +
+          Gam300*invg03 + gamma0*ndua0)*H0[ijk] -
+       4*Gam000*invg01*H1[ijk] - 4*Gam100*invg11*H1[ijk] -
+       4*Gam200*invg12*H1[ijk] - 4*Gam300*invg13*H1[ijk] -
+       4*Gam000*invg02*H2[ijk] - 4*Gam100*invg12*H2[ijk] -
+       4*Gam200*invg22*H2[ijk] - 4*Gam300*invg23*H2[ijk] -
+       4*Gam000*invg03*H3[ijk] - 4*Gam100*invg13*H3[ijk] -
+       4*Gam200*invg23*H3[ijk] - 4*Gam300*invg33*H3[ijk] +
+       2*gamma0*g00[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Power(Phi100[ijk],2) -
+       8*invg01*invh11*Phi100[ijk]*Phi101[ijk] -
+       4*invg11*invh11*Power(Phi101[ijk],2) -
+       8*invg02*invh11*Phi100[ijk]*Phi102[ijk] -
+       8*invg12*invh11*Phi101[ijk]*Phi102[ijk] -
+       4*invg22*invh11*Power(Phi102[ijk],2) -
+       8*invg03*invh11*Phi100[ijk]*Phi103[ijk] -
+       8*invg13*invh11*Phi101[ijk]*Phi103[ijk] -
+       8*invg23*invh11*Phi102[ijk]*Phi103[ijk] -
+       4*invg33*invh11*Power(Phi103[ijk],2) -
+       8*invg00*invh12*Phi100[ijk]*Phi200[ijk] -
+       8*invg01*invh12*Phi101[ijk]*Phi200[ijk] -
+       8*invg02*invh12*Phi102[ijk]*Phi200[ijk] -
+       8*invg03*invh12*Phi103[ijk]*Phi200[ijk] -
+       4*invg00*invh22*Power(Phi200[ijk],2) -
+       8*invg01*invh12*Phi100[ijk]*Phi201[ijk] -
+       8*invg11*invh12*Phi101[ijk]*Phi201[ijk] -
+       8*invg12*invh12*Phi102[ijk]*Phi201[ijk] -
+       8*invg13*invh12*Phi103[ijk]*Phi201[ijk] -
+       8*invg01*invh22*Phi200[ijk]*Phi201[ijk] -
+       4*invg11*invh22*Power(Phi201[ijk],2) -
+       8*invg02*invh12*Phi100[ijk]*Phi202[ijk] -
+       8*invg12*invh12*Phi101[ijk]*Phi202[ijk] -
+       8*invg22*invh12*Phi102[ijk]*Phi202[ijk] -
+       8*invg23*invh12*Phi103[ijk]*Phi202[ijk] -
+       8*invg02*invh22*Phi200[ijk]*Phi202[ijk] -
+       8*invg12*invh22*Phi201[ijk]*Phi202[ijk] -
+       4*invg22*invh22*Power(Phi202[ijk],2) -
+       8*invg03*invh12*Phi100[ijk]*Phi203[ijk] -
+       8*invg13*invh12*Phi101[ijk]*Phi203[ijk] -
+       8*invg23*invh12*Phi102[ijk]*Phi203[ijk] -
+       8*invg33*invh12*Phi103[ijk]*Phi203[ijk] -
+       8*invg03*invh22*Phi200[ijk]*Phi203[ijk] -
+       8*invg13*invh22*Phi201[ijk]*Phi203[ijk] -
+       8*invg23*invh22*Phi202[ijk]*Phi203[ijk] -
+       4*invg33*invh22*Power(Phi203[ijk],2) -
+       8*invg00*invh13*Phi100[ijk]*Phi300[ijk] -
+       8*invg01*invh13*Phi101[ijk]*Phi300[ijk] -
+       8*invg02*invh13*Phi102[ijk]*Phi300[ijk] -
+       8*invg03*invh13*Phi103[ijk]*Phi300[ijk] -
+       8*invg00*invh23*Phi200[ijk]*Phi300[ijk] -
+       8*invg01*invh23*Phi201[ijk]*Phi300[ijk] -
+       8*invg02*invh23*Phi202[ijk]*Phi300[ijk] -
+       8*invg03*invh23*Phi203[ijk]*Phi300[ijk] -
+       4*invg00*invh33*Power(Phi300[ijk],2) -
+       8*invg01*invh13*Phi100[ijk]*Phi301[ijk] -
+       8*invg11*invh13*Phi101[ijk]*Phi301[ijk] -
+       8*invg12*invh13*Phi102[ijk]*Phi301[ijk] -
+       8*invg13*invh13*Phi103[ijk]*Phi301[ijk] -
+       8*invg01*invh23*Phi200[ijk]*Phi301[ijk] -
+       8*invg11*invh23*Phi201[ijk]*Phi301[ijk] -
+       8*invg12*invh23*Phi202[ijk]*Phi301[ijk] -
+       8*invg13*invh23*Phi203[ijk]*Phi301[ijk] -
+       8*invg01*invh33*Phi300[ijk]*Phi301[ijk] -
+       4*invg11*invh33*Power(Phi301[ijk],2) -
+       8*invg02*invh13*Phi100[ijk]*Phi302[ijk] -
+       8*invg12*invh13*Phi101[ijk]*Phi302[ijk] -
+       8*invg22*invh13*Phi102[ijk]*Phi302[ijk] -
+       8*invg23*invh13*Phi103[ijk]*Phi302[ijk] -
+       8*invg02*invh23*Phi200[ijk]*Phi302[ijk] -
+       8*invg12*invh23*Phi201[ijk]*Phi302[ijk] -
+       8*invg22*invh23*Phi202[ijk]*Phi302[ijk] -
+       8*invg23*invh23*Phi203[ijk]*Phi302[ijk] -
+       8*invg02*invh33*Phi300[ijk]*Phi302[ijk] -
+       8*invg12*invh33*Phi301[ijk]*Phi302[ijk] -
+       4*invg22*invh33*Power(Phi302[ijk],2) -
+       8*invg03*invh13*Phi100[ijk]*Phi303[ijk] -
+       8*invg13*invh13*Phi101[ijk]*Phi303[ijk] -
+       8*invg23*invh13*Phi102[ijk]*Phi303[ijk] -
+       8*invg33*invh13*Phi103[ijk]*Phi303[ijk] -
+       8*invg03*invh23*Phi200[ijk]*Phi303[ijk] -
+       8*invg13*invh23*Phi201[ijk]*Phi303[ijk] -
+       8*invg23*invh23*Phi202[ijk]*Phi303[ijk] -
+       8*invg33*invh23*Phi203[ijk]*Phi303[ijk] -
+       8*invg03*invh33*Phi300[ijk]*Phi303[ijk] -
+       8*invg13*invh33*Phi301[ijk]*Phi303[ijk] -
+       8*invg23*invh33*Phi302[ijk]*Phi303[ijk] -
+       4*invg33*invh33*Power(Phi303[ijk],2) +
+       4*invg00*Power(Pi00[ijk],2) + Power(nvec0,2)*Power(Pi00[ijk],2) +
+       2*invh11*nvec0*Phi100[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi200[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi300[ijk]*Pi01[ijk] +
+       8*invg01*Pi00[ijk]*Pi01[ijk] + 2*nvec0*nvec1*Pi00[ijk]*Pi01[ijk] +
+       4*invg11*Power(Pi01[ijk],2) +
+       2*invh12*nvec0*Phi100[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi200[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi300[ijk]*Pi02[ijk] +
+       8*invg02*Pi00[ijk]*Pi02[ijk] + 2*nvec0*nvec2*Pi00[ijk]*Pi02[ijk] +
+       8*invg12*Pi01[ijk]*Pi02[ijk] + 4*invg22*Power(Pi02[ijk],2) +
+       2*invh13*nvec0*Phi100[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi200[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi300[ijk]*Pi03[ijk] +
+       8*invg03*Pi00[ijk]*Pi03[ijk] + 2*nvec0*nvec3*Pi00[ijk]*Pi03[ijk] +
+       8*invg13*Pi01[ijk]*Pi03[ijk] + 8*invg23*Pi02[ijk]*Pi03[ijk] +
+       4*invg33*Power(Pi03[ijk],2) +
+       2*invh11*nvec1*Phi100[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi200[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi300[ijk]*Pi11[ijk] +
+       Power(nvec1,2)*Pi00[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi100[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi100[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi200[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi200[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi300[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi300[ijk]*Pi12[ijk] +
+       2*nvec1*nvec2*Pi00[ijk]*Pi12[ijk] +
+       2*invh13*nvec1*Phi100[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi100[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi200[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi200[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi300[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi300[ijk]*Pi13[ijk] +
+       2*nvec1*nvec3*Pi00[ijk]*Pi13[ijk] +
+       2*invh12*nvec2*Phi100[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi200[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi300[ijk]*Pi22[ijk] +
+       Power(nvec2,2)*Pi00[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi100[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi100[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi200[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi200[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi300[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi300[ijk]*Pi23[ijk] +
+       2*nvec2*nvec3*Pi00[ijk]*Pi23[ijk] +
+       2*invh13*nvec3*Phi100[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi200[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi300[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi00[ijk]*Pi33[ijk]))/2. - srcSdH00[ijk]
+;
+
+dtPi01[ijk]
+=
+(-2*interior*AdPi01[ijk] - alpha[ijk]*
+     (4*Gam000*Gam100*Power(invg00,2) + 8*Gam001*Gam100*invg00*invg01 +
+       8*Gam000*Gam101*invg00*invg01 + 4*Gam011*Gam100*Power(invg01,2) +
+       8*Gam001*Gam101*Power(invg01,2) + 4*Gam000*Gam111*Power(invg01,2) +
+       8*Gam002*Gam100*invg00*invg02 + 8*Gam000*Gam102*invg00*invg02 +
+       8*Gam012*Gam100*invg01*invg02 + 8*Gam002*Gam101*invg01*invg02 +
+       8*Gam001*Gam102*invg01*invg02 + 8*Gam000*Gam112*invg01*invg02 +
+       4*Gam022*Gam100*Power(invg02,2) + 8*Gam002*Gam102*Power(invg02,2) +
+       4*Gam000*Gam122*Power(invg02,2) + 8*Gam003*Gam100*invg00*invg03 +
+       8*Gam000*Gam103*invg00*invg03 + 8*Gam013*Gam100*invg01*invg03 +
+       8*Gam003*Gam101*invg01*invg03 + 8*Gam001*Gam103*invg01*invg03 +
+       8*Gam000*Gam113*invg01*invg03 + 8*Gam023*Gam100*invg02*invg03 +
+       8*Gam003*Gam102*invg02*invg03 + 8*Gam002*Gam103*invg02*invg03 +
+       8*Gam000*Gam123*invg02*invg03 + 4*Gam033*Gam100*Power(invg03,2) +
+       8*Gam003*Gam103*Power(invg03,2) + 4*Gam000*Gam133*Power(invg03,2) +
+       8*Gam001*Gam101*invg00*invg11 + 8*Gam011*Gam101*invg01*invg11 +
+       8*Gam001*Gam111*invg01*invg11 + 8*Gam012*Gam101*invg02*invg11 +
+       8*Gam001*Gam112*invg02*invg11 + 8*Gam013*Gam101*invg03*invg11 +
+       8*Gam001*Gam113*invg03*invg11 + 4*Gam011*Gam111*Power(invg11,2) +
+       8*Gam002*Gam101*invg00*invg12 + 8*Gam001*Gam102*invg00*invg12 +
+       8*Gam012*Gam101*invg01*invg12 + 8*Gam011*Gam102*invg01*invg12 +
+       8*Gam002*Gam111*invg01*invg12 + 8*Gam001*Gam112*invg01*invg12 +
+       8*Gam022*Gam101*invg02*invg12 + 8*Gam012*Gam102*invg02*invg12 +
+       8*Gam002*Gam112*invg02*invg12 + 8*Gam001*Gam122*invg02*invg12 +
+       8*Gam023*Gam101*invg03*invg12 + 8*Gam013*Gam102*invg03*invg12 +
+       8*Gam002*Gam113*invg03*invg12 + 8*Gam001*Gam123*invg03*invg12 +
+       8*Gam012*Gam111*invg11*invg12 + 8*Gam011*Gam112*invg11*invg12 +
+       4*Gam022*Gam111*Power(invg12,2) + 8*Gam012*Gam112*Power(invg12,2) +
+       4*Gam011*Gam122*Power(invg12,2) + 8*Gam003*Gam101*invg00*invg13 +
+       8*Gam001*Gam103*invg00*invg13 + 8*Gam013*Gam101*invg01*invg13 +
+       8*Gam011*Gam103*invg01*invg13 + 8*Gam003*Gam111*invg01*invg13 +
+       8*Gam001*Gam113*invg01*invg13 + 8*Gam023*Gam101*invg02*invg13 +
+       8*Gam012*Gam103*invg02*invg13 + 8*Gam003*Gam112*invg02*invg13 +
+       8*Gam001*Gam123*invg02*invg13 + 8*Gam033*Gam101*invg03*invg13 +
+       8*Gam013*Gam103*invg03*invg13 + 8*Gam003*Gam113*invg03*invg13 +
+       8*Gam001*Gam133*invg03*invg13 + 8*Gam013*Gam111*invg11*invg13 +
+       8*Gam011*Gam113*invg11*invg13 + 8*Gam023*Gam111*invg12*invg13 +
+       8*Gam013*Gam112*invg12*invg13 + 8*Gam012*Gam113*invg12*invg13 +
+       8*Gam011*Gam123*invg12*invg13 + 4*Gam033*Gam111*Power(invg13,2) +
+       8*Gam013*Gam113*Power(invg13,2) + 4*Gam011*Gam133*Power(invg13,2) +
+       8*Gam002*Gam102*invg00*invg22 + 8*Gam012*Gam102*invg01*invg22 +
+       8*Gam002*Gam112*invg01*invg22 + 8*Gam022*Gam102*invg02*invg22 +
+       8*Gam002*Gam122*invg02*invg22 + 8*Gam023*Gam102*invg03*invg22 +
+       8*Gam002*Gam123*invg03*invg22 + 8*Gam012*Gam112*invg11*invg22 +
+       8*Gam022*Gam112*invg12*invg22 + 8*Gam012*Gam122*invg12*invg22 +
+       8*Gam023*Gam112*invg13*invg22 + 8*Gam012*Gam123*invg13*invg22 +
+       4*Gam022*Gam122*Power(invg22,2) + 8*Gam003*Gam102*invg00*invg23 +
+       8*Gam002*Gam103*invg00*invg23 + 8*Gam013*Gam102*invg01*invg23 +
+       8*Gam012*Gam103*invg01*invg23 + 8*Gam003*Gam112*invg01*invg23 +
+       8*Gam002*Gam113*invg01*invg23 + 8*Gam023*Gam102*invg02*invg23 +
+       8*Gam022*Gam103*invg02*invg23 + 8*Gam003*Gam122*invg02*invg23 +
+       8*Gam002*Gam123*invg02*invg23 + 8*Gam033*Gam102*invg03*invg23 +
+       8*Gam023*Gam103*invg03*invg23 + 8*Gam003*Gam123*invg03*invg23 +
+       8*Gam002*Gam133*invg03*invg23 + 8*Gam013*Gam112*invg11*invg23 +
+       8*Gam012*Gam113*invg11*invg23 + 8*Gam023*Gam112*invg12*invg23 +
+       8*Gam022*Gam113*invg12*invg23 + 8*Gam013*Gam122*invg12*invg23 +
+       8*Gam012*Gam123*invg12*invg23 + 8*Gam033*Gam112*invg13*invg23 +
+       8*Gam023*Gam113*invg13*invg23 + 8*Gam013*Gam123*invg13*invg23 +
+       8*Gam012*Gam133*invg13*invg23 + 8*Gam023*Gam122*invg22*invg23 +
+       8*Gam022*Gam123*invg22*invg23 + 4*Gam033*Gam122*Power(invg23,2) +
+       8*Gam023*Gam123*Power(invg23,2) + 4*Gam022*Gam133*Power(invg23,2) +
+       8*Gam003*Gam103*invg00*invg33 + 8*Gam013*Gam103*invg01*invg33 +
+       8*Gam003*Gam113*invg01*invg33 + 8*Gam023*Gam103*invg02*invg33 +
+       8*Gam003*Gam123*invg02*invg33 + 8*Gam033*Gam103*invg03*invg33 +
+       8*Gam003*Gam133*invg03*invg33 + 8*Gam013*Gam113*invg11*invg33 +
+       8*Gam023*Gam113*invg12*invg33 + 8*Gam013*Gam123*invg12*invg33 +
+       8*Gam033*Gam113*invg13*invg33 + 8*Gam013*Gam133*invg13*invg33 +
+       8*Gam023*Gam123*invg22*invg33 + 8*Gam033*Gam123*invg23*invg33 +
+       8*Gam023*Gam133*invg23*invg33 + 4*Gam033*Gam133*Power(invg33,2) -
+       2*gamma0*ndua1*trGam0 - 2*gamma0*ndua0*trGam1 -
+       2*(2*Gam001*invg00 + 2*Gam101*invg01 + 2*Gam201*invg02 +
+          2*Gam301*invg03 + gamma0*ndua1)*H0[ijk] -
+       4*Gam001*invg01*H1[ijk] - 4*Gam101*invg11*H1[ijk] -
+       4*Gam201*invg12*H1[ijk] - 4*Gam301*invg13*H1[ijk] -
+       2*gamma0*ndua0*H1[ijk] - 4*Gam001*invg02*H2[ijk] -
+       4*Gam101*invg12*H2[ijk] - 4*Gam201*invg22*H2[ijk] -
+       4*Gam301*invg23*H2[ijk] - 4*Gam001*invg03*H3[ijk] -
+       4*Gam101*invg13*H3[ijk] - 4*Gam201*invg23*H3[ijk] -
+       4*Gam301*invg33*H3[ijk] +
+       2*gamma0*g01[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Phi100[ijk]*Phi101[ijk] -
+       4*invg01*invh11*Power(Phi101[ijk],2) -
+       4*invg02*invh11*Phi101[ijk]*Phi102[ijk] -
+       4*invg03*invh11*Phi101[ijk]*Phi103[ijk] -
+       4*invg01*invh11*Phi100[ijk]*Phi111[ijk] -
+       4*invg11*invh11*Phi101[ijk]*Phi111[ijk] -
+       4*invg12*invh11*Phi102[ijk]*Phi111[ijk] -
+       4*invg13*invh11*Phi103[ijk]*Phi111[ijk] -
+       4*invg02*invh11*Phi100[ijk]*Phi112[ijk] -
+       4*invg12*invh11*Phi101[ijk]*Phi112[ijk] -
+       4*invg22*invh11*Phi102[ijk]*Phi112[ijk] -
+       4*invg23*invh11*Phi103[ijk]*Phi112[ijk] -
+       4*invg03*invh11*Phi100[ijk]*Phi113[ijk] -
+       4*invg13*invh11*Phi101[ijk]*Phi113[ijk] -
+       4*invg23*invh11*Phi102[ijk]*Phi113[ijk] -
+       4*invg33*invh11*Phi103[ijk]*Phi113[ijk] -
+       4*invg00*invh12*Phi101[ijk]*Phi200[ijk] -
+       4*invg01*invh12*Phi111[ijk]*Phi200[ijk] -
+       4*invg02*invh12*Phi112[ijk]*Phi200[ijk] -
+       4*invg03*invh12*Phi113[ijk]*Phi200[ijk] -
+       4*invg00*invh12*Phi100[ijk]*Phi201[ijk] -
+       8*invg01*invh12*Phi101[ijk]*Phi201[ijk] -
+       4*invg02*invh12*Phi102[ijk]*Phi201[ijk] -
+       4*invg03*invh12*Phi103[ijk]*Phi201[ijk] -
+       4*invg11*invh12*Phi111[ijk]*Phi201[ijk] -
+       4*invg12*invh12*Phi112[ijk]*Phi201[ijk] -
+       4*invg13*invh12*Phi113[ijk]*Phi201[ijk] -
+       4*invg00*invh22*Phi200[ijk]*Phi201[ijk] -
+       4*invg01*invh22*Power(Phi201[ijk],2) -
+       4*invg02*invh12*Phi101[ijk]*Phi202[ijk] -
+       4*invg12*invh12*Phi111[ijk]*Phi202[ijk] -
+       4*invg22*invh12*Phi112[ijk]*Phi202[ijk] -
+       4*invg23*invh12*Phi113[ijk]*Phi202[ijk] -
+       4*invg02*invh22*Phi201[ijk]*Phi202[ijk] -
+       4*invg03*invh12*Phi101[ijk]*Phi203[ijk] -
+       4*invg13*invh12*Phi111[ijk]*Phi203[ijk] -
+       4*invg23*invh12*Phi112[ijk]*Phi203[ijk] -
+       4*invg33*invh12*Phi113[ijk]*Phi203[ijk] -
+       4*invg03*invh22*Phi201[ijk]*Phi203[ijk] -
+       4*invg01*invh12*Phi100[ijk]*Phi211[ijk] -
+       4*invg11*invh12*Phi101[ijk]*Phi211[ijk] -
+       4*invg12*invh12*Phi102[ijk]*Phi211[ijk] -
+       4*invg13*invh12*Phi103[ijk]*Phi211[ijk] -
+       4*invg01*invh22*Phi200[ijk]*Phi211[ijk] -
+       4*invg11*invh22*Phi201[ijk]*Phi211[ijk] -
+       4*invg12*invh22*Phi202[ijk]*Phi211[ijk] -
+       4*invg13*invh22*Phi203[ijk]*Phi211[ijk] -
+       4*invg02*invh12*Phi100[ijk]*Phi212[ijk] -
+       4*invg12*invh12*Phi101[ijk]*Phi212[ijk] -
+       4*invg22*invh12*Phi102[ijk]*Phi212[ijk] -
+       4*invg23*invh12*Phi103[ijk]*Phi212[ijk] -
+       4*invg02*invh22*Phi200[ijk]*Phi212[ijk] -
+       4*invg12*invh22*Phi201[ijk]*Phi212[ijk] -
+       4*invg22*invh22*Phi202[ijk]*Phi212[ijk] -
+       4*invg23*invh22*Phi203[ijk]*Phi212[ijk] -
+       4*invg03*invh12*Phi100[ijk]*Phi213[ijk] -
+       4*invg13*invh12*Phi101[ijk]*Phi213[ijk] -
+       4*invg23*invh12*Phi102[ijk]*Phi213[ijk] -
+       4*invg33*invh12*Phi103[ijk]*Phi213[ijk] -
+       4*invg03*invh22*Phi200[ijk]*Phi213[ijk] -
+       4*invg13*invh22*Phi201[ijk]*Phi213[ijk] -
+       4*invg23*invh22*Phi202[ijk]*Phi213[ijk] -
+       4*invg33*invh22*Phi203[ijk]*Phi213[ijk] -
+       4*invg00*invh13*Phi101[ijk]*Phi300[ijk] -
+       4*invg01*invh13*Phi111[ijk]*Phi300[ijk] -
+       4*invg02*invh13*Phi112[ijk]*Phi300[ijk] -
+       4*invg03*invh13*Phi113[ijk]*Phi300[ijk] -
+       4*invg00*invh23*Phi201[ijk]*Phi300[ijk] -
+       4*invg01*invh23*Phi211[ijk]*Phi300[ijk] -
+       4*invg02*invh23*Phi212[ijk]*Phi300[ijk] -
+       4*invg03*invh23*Phi213[ijk]*Phi300[ijk] -
+       4*invg00*invh13*Phi100[ijk]*Phi301[ijk] -
+       8*invg01*invh13*Phi101[ijk]*Phi301[ijk] -
+       4*invg02*invh13*Phi102[ijk]*Phi301[ijk] -
+       4*invg03*invh13*Phi103[ijk]*Phi301[ijk] -
+       4*invg11*invh13*Phi111[ijk]*Phi301[ijk] -
+       4*invg12*invh13*Phi112[ijk]*Phi301[ijk] -
+       4*invg13*invh13*Phi113[ijk]*Phi301[ijk] -
+       4*invg00*invh23*Phi200[ijk]*Phi301[ijk] -
+       8*invg01*invh23*Phi201[ijk]*Phi301[ijk] -
+       4*invg02*invh23*Phi202[ijk]*Phi301[ijk] -
+       4*invg03*invh23*Phi203[ijk]*Phi301[ijk] -
+       4*invg11*invh23*Phi211[ijk]*Phi301[ijk] -
+       4*invg12*invh23*Phi212[ijk]*Phi301[ijk] -
+       4*invg13*invh23*Phi213[ijk]*Phi301[ijk] -
+       4*invg00*invh33*Phi300[ijk]*Phi301[ijk] -
+       4*invg01*invh33*Power(Phi301[ijk],2) -
+       4*invg02*invh13*Phi101[ijk]*Phi302[ijk] -
+       4*invg12*invh13*Phi111[ijk]*Phi302[ijk] -
+       4*invg22*invh13*Phi112[ijk]*Phi302[ijk] -
+       4*invg23*invh13*Phi113[ijk]*Phi302[ijk] -
+       4*invg02*invh23*Phi201[ijk]*Phi302[ijk] -
+       4*invg12*invh23*Phi211[ijk]*Phi302[ijk] -
+       4*invg22*invh23*Phi212[ijk]*Phi302[ijk] -
+       4*invg23*invh23*Phi213[ijk]*Phi302[ijk] -
+       4*invg02*invh33*Phi301[ijk]*Phi302[ijk] -
+       4*invg03*invh13*Phi101[ijk]*Phi303[ijk] -
+       4*invg13*invh13*Phi111[ijk]*Phi303[ijk] -
+       4*invg23*invh13*Phi112[ijk]*Phi303[ijk] -
+       4*invg33*invh13*Phi113[ijk]*Phi303[ijk] -
+       4*invg03*invh23*Phi201[ijk]*Phi303[ijk] -
+       4*invg13*invh23*Phi211[ijk]*Phi303[ijk] -
+       4*invg23*invh23*Phi212[ijk]*Phi303[ijk] -
+       4*invg33*invh23*Phi213[ijk]*Phi303[ijk] -
+       4*invg03*invh33*Phi301[ijk]*Phi303[ijk] -
+       4*invg01*invh13*Phi100[ijk]*Phi311[ijk] -
+       4*invg11*invh13*Phi101[ijk]*Phi311[ijk] -
+       4*invg12*invh13*Phi102[ijk]*Phi311[ijk] -
+       4*invg13*invh13*Phi103[ijk]*Phi311[ijk] -
+       4*invg01*invh23*Phi200[ijk]*Phi311[ijk] -
+       4*invg11*invh23*Phi201[ijk]*Phi311[ijk] -
+       4*invg12*invh23*Phi202[ijk]*Phi311[ijk] -
+       4*invg13*invh23*Phi203[ijk]*Phi311[ijk] -
+       4*invg01*invh33*Phi300[ijk]*Phi311[ijk] -
+       4*invg11*invh33*Phi301[ijk]*Phi311[ijk] -
+       4*invg12*invh33*Phi302[ijk]*Phi311[ijk] -
+       4*invg13*invh33*Phi303[ijk]*Phi311[ijk] -
+       4*invg02*invh13*Phi100[ijk]*Phi312[ijk] -
+       4*invg12*invh13*Phi101[ijk]*Phi312[ijk] -
+       4*invg22*invh13*Phi102[ijk]*Phi312[ijk] -
+       4*invg23*invh13*Phi103[ijk]*Phi312[ijk] -
+       4*invg02*invh23*Phi200[ijk]*Phi312[ijk] -
+       4*invg12*invh23*Phi201[ijk]*Phi312[ijk] -
+       4*invg22*invh23*Phi202[ijk]*Phi312[ijk] -
+       4*invg23*invh23*Phi203[ijk]*Phi312[ijk] -
+       4*invg02*invh33*Phi300[ijk]*Phi312[ijk] -
+       4*invg12*invh33*Phi301[ijk]*Phi312[ijk] -
+       4*invg22*invh33*Phi302[ijk]*Phi312[ijk] -
+       4*invg23*invh33*Phi303[ijk]*Phi312[ijk] -
+       4*invg03*invh13*Phi100[ijk]*Phi313[ijk] -
+       4*invg13*invh13*Phi101[ijk]*Phi313[ijk] -
+       4*invg23*invh13*Phi102[ijk]*Phi313[ijk] -
+       4*invg33*invh13*Phi103[ijk]*Phi313[ijk] -
+       4*invg03*invh23*Phi200[ijk]*Phi313[ijk] -
+       4*invg13*invh23*Phi201[ijk]*Phi313[ijk] -
+       4*invg23*invh23*Phi202[ijk]*Phi313[ijk] -
+       4*invg33*invh23*Phi203[ijk]*Phi313[ijk] -
+       4*invg03*invh33*Phi300[ijk]*Phi313[ijk] -
+       4*invg13*invh33*Phi301[ijk]*Phi313[ijk] -
+       4*invg23*invh33*Phi302[ijk]*Phi313[ijk] -
+       4*invg33*invh33*Phi303[ijk]*Phi313[ijk] +
+       2*invh11*nvec0*Phi101[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi201[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi301[ijk]*Pi01[ijk] +
+       4*invg00*Pi00[ijk]*Pi01[ijk] + Power(nvec0,2)*Pi00[ijk]*Pi01[ijk] +
+       4*invg01*Power(Pi01[ijk],2) + 2*nvec0*nvec1*Power(Pi01[ijk],2) +
+       2*invh12*nvec0*Phi101[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi201[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi301[ijk]*Pi02[ijk] +
+       4*invg02*Pi01[ijk]*Pi02[ijk] + 2*nvec0*nvec2*Pi01[ijk]*Pi02[ijk] +
+       2*invh13*nvec0*Phi101[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi201[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi301[ijk]*Pi03[ijk] +
+       4*invg03*Pi01[ijk]*Pi03[ijk] + 2*nvec0*nvec3*Pi01[ijk]*Pi03[ijk] +
+       2*invh11*nvec1*Phi101[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi201[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi301[ijk]*Pi11[ijk] +
+       4*invg01*Pi00[ijk]*Pi11[ijk] + 4*invg11*Pi01[ijk]*Pi11[ijk] +
+       Power(nvec1,2)*Pi01[ijk]*Pi11[ijk] + 4*invg12*Pi02[ijk]*Pi11[ijk] +
+       4*invg13*Pi03[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi101[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi101[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi201[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi201[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi301[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi301[ijk]*Pi12[ijk] +
+       4*invg02*Pi00[ijk]*Pi12[ijk] + 4*invg12*Pi01[ijk]*Pi12[ijk] +
+       2*nvec1*nvec2*Pi01[ijk]*Pi12[ijk] + 4*invg22*Pi02[ijk]*Pi12[ijk] +
+       4*invg23*Pi03[ijk]*Pi12[ijk] +
+       2*invh13*nvec1*Phi101[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi101[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi201[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi201[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi301[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi301[ijk]*Pi13[ijk] +
+       4*invg03*Pi00[ijk]*Pi13[ijk] + 4*invg13*Pi01[ijk]*Pi13[ijk] +
+       2*nvec1*nvec3*Pi01[ijk]*Pi13[ijk] + 4*invg23*Pi02[ijk]*Pi13[ijk] +
+       4*invg33*Pi03[ijk]*Pi13[ijk] +
+       2*invh12*nvec2*Phi101[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi201[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi301[ijk]*Pi22[ijk] +
+       Power(nvec2,2)*Pi01[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi101[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi101[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi201[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi201[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi301[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi301[ijk]*Pi23[ijk] +
+       2*nvec2*nvec3*Pi01[ijk]*Pi23[ijk] +
+       2*invh13*nvec3*Phi101[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi201[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi301[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi01[ijk]*Pi33[ijk]) -
+    2*(gamma1*gamma2*beta1[ijk]*Phi101[ijk] +
+       gamma1*gamma2*beta2[ijk]*Phi201[ijk] +
+       gamma1*gamma2*beta3[ijk]*Phi301[ijk] + srcSdH01[ijk]))/2.
+;
+
+dtPi02[ijk]
+=
+(-2*interior*AdPi02[ijk] - alpha[ijk]*
+     (4*Gam000*Gam200*Power(invg00,2) + 8*Gam001*Gam200*invg00*invg01 +
+       8*Gam000*Gam201*invg00*invg01 + 4*Gam011*Gam200*Power(invg01,2) +
+       8*Gam001*Gam201*Power(invg01,2) + 4*Gam000*Gam211*Power(invg01,2) +
+       8*Gam002*Gam200*invg00*invg02 + 8*Gam000*Gam202*invg00*invg02 +
+       8*Gam012*Gam200*invg01*invg02 + 8*Gam002*Gam201*invg01*invg02 +
+       8*Gam001*Gam202*invg01*invg02 + 8*Gam000*Gam212*invg01*invg02 +
+       4*Gam022*Gam200*Power(invg02,2) + 8*Gam002*Gam202*Power(invg02,2) +
+       4*Gam000*Gam222*Power(invg02,2) + 8*Gam003*Gam200*invg00*invg03 +
+       8*Gam000*Gam203*invg00*invg03 + 8*Gam013*Gam200*invg01*invg03 +
+       8*Gam003*Gam201*invg01*invg03 + 8*Gam001*Gam203*invg01*invg03 +
+       8*Gam000*Gam213*invg01*invg03 + 8*Gam023*Gam200*invg02*invg03 +
+       8*Gam003*Gam202*invg02*invg03 + 8*Gam002*Gam203*invg02*invg03 +
+       8*Gam000*Gam223*invg02*invg03 + 4*Gam033*Gam200*Power(invg03,2) +
+       8*Gam003*Gam203*Power(invg03,2) + 4*Gam000*Gam233*Power(invg03,2) +
+       8*Gam001*Gam201*invg00*invg11 + 8*Gam011*Gam201*invg01*invg11 +
+       8*Gam001*Gam211*invg01*invg11 + 8*Gam012*Gam201*invg02*invg11 +
+       8*Gam001*Gam212*invg02*invg11 + 8*Gam013*Gam201*invg03*invg11 +
+       8*Gam001*Gam213*invg03*invg11 + 4*Gam011*Gam211*Power(invg11,2) +
+       8*Gam002*Gam201*invg00*invg12 + 8*Gam001*Gam202*invg00*invg12 +
+       8*Gam012*Gam201*invg01*invg12 + 8*Gam011*Gam202*invg01*invg12 +
+       8*Gam002*Gam211*invg01*invg12 + 8*Gam001*Gam212*invg01*invg12 +
+       8*Gam022*Gam201*invg02*invg12 + 8*Gam012*Gam202*invg02*invg12 +
+       8*Gam002*Gam212*invg02*invg12 + 8*Gam001*Gam222*invg02*invg12 +
+       8*Gam023*Gam201*invg03*invg12 + 8*Gam013*Gam202*invg03*invg12 +
+       8*Gam002*Gam213*invg03*invg12 + 8*Gam001*Gam223*invg03*invg12 +
+       8*Gam012*Gam211*invg11*invg12 + 8*Gam011*Gam212*invg11*invg12 +
+       4*Gam022*Gam211*Power(invg12,2) + 8*Gam012*Gam212*Power(invg12,2) +
+       4*Gam011*Gam222*Power(invg12,2) + 8*Gam003*Gam201*invg00*invg13 +
+       8*Gam001*Gam203*invg00*invg13 + 8*Gam013*Gam201*invg01*invg13 +
+       8*Gam011*Gam203*invg01*invg13 + 8*Gam003*Gam211*invg01*invg13 +
+       8*Gam001*Gam213*invg01*invg13 + 8*Gam023*Gam201*invg02*invg13 +
+       8*Gam012*Gam203*invg02*invg13 + 8*Gam003*Gam212*invg02*invg13 +
+       8*Gam001*Gam223*invg02*invg13 + 8*Gam033*Gam201*invg03*invg13 +
+       8*Gam013*Gam203*invg03*invg13 + 8*Gam003*Gam213*invg03*invg13 +
+       8*Gam001*Gam233*invg03*invg13 + 8*Gam013*Gam211*invg11*invg13 +
+       8*Gam011*Gam213*invg11*invg13 + 8*Gam023*Gam211*invg12*invg13 +
+       8*Gam013*Gam212*invg12*invg13 + 8*Gam012*Gam213*invg12*invg13 +
+       8*Gam011*Gam223*invg12*invg13 + 4*Gam033*Gam211*Power(invg13,2) +
+       8*Gam013*Gam213*Power(invg13,2) + 4*Gam011*Gam233*Power(invg13,2) +
+       8*Gam002*Gam202*invg00*invg22 + 8*Gam012*Gam202*invg01*invg22 +
+       8*Gam002*Gam212*invg01*invg22 + 8*Gam022*Gam202*invg02*invg22 +
+       8*Gam002*Gam222*invg02*invg22 + 8*Gam023*Gam202*invg03*invg22 +
+       8*Gam002*Gam223*invg03*invg22 + 8*Gam012*Gam212*invg11*invg22 +
+       8*Gam022*Gam212*invg12*invg22 + 8*Gam012*Gam222*invg12*invg22 +
+       8*Gam023*Gam212*invg13*invg22 + 8*Gam012*Gam223*invg13*invg22 +
+       4*Gam022*Gam222*Power(invg22,2) + 8*Gam003*Gam202*invg00*invg23 +
+       8*Gam002*Gam203*invg00*invg23 + 8*Gam013*Gam202*invg01*invg23 +
+       8*Gam012*Gam203*invg01*invg23 + 8*Gam003*Gam212*invg01*invg23 +
+       8*Gam002*Gam213*invg01*invg23 + 8*Gam023*Gam202*invg02*invg23 +
+       8*Gam022*Gam203*invg02*invg23 + 8*Gam003*Gam222*invg02*invg23 +
+       8*Gam002*Gam223*invg02*invg23 + 8*Gam033*Gam202*invg03*invg23 +
+       8*Gam023*Gam203*invg03*invg23 + 8*Gam003*Gam223*invg03*invg23 +
+       8*Gam002*Gam233*invg03*invg23 + 8*Gam013*Gam212*invg11*invg23 +
+       8*Gam012*Gam213*invg11*invg23 + 8*Gam023*Gam212*invg12*invg23 +
+       8*Gam022*Gam213*invg12*invg23 + 8*Gam013*Gam222*invg12*invg23 +
+       8*Gam012*Gam223*invg12*invg23 + 8*Gam033*Gam212*invg13*invg23 +
+       8*Gam023*Gam213*invg13*invg23 + 8*Gam013*Gam223*invg13*invg23 +
+       8*Gam012*Gam233*invg13*invg23 + 8*Gam023*Gam222*invg22*invg23 +
+       8*Gam022*Gam223*invg22*invg23 + 4*Gam033*Gam222*Power(invg23,2) +
+       8*Gam023*Gam223*Power(invg23,2) + 4*Gam022*Gam233*Power(invg23,2) +
+       8*Gam003*Gam203*invg00*invg33 + 8*Gam013*Gam203*invg01*invg33 +
+       8*Gam003*Gam213*invg01*invg33 + 8*Gam023*Gam203*invg02*invg33 +
+       8*Gam003*Gam223*invg02*invg33 + 8*Gam033*Gam203*invg03*invg33 +
+       8*Gam003*Gam233*invg03*invg33 + 8*Gam013*Gam213*invg11*invg33 +
+       8*Gam023*Gam213*invg12*invg33 + 8*Gam013*Gam223*invg12*invg33 +
+       8*Gam033*Gam213*invg13*invg33 + 8*Gam013*Gam233*invg13*invg33 +
+       8*Gam023*Gam223*invg22*invg33 + 8*Gam033*Gam223*invg23*invg33 +
+       8*Gam023*Gam233*invg23*invg33 + 4*Gam033*Gam233*Power(invg33,2) -
+       2*gamma0*ndua2*trGam0 - 2*gamma0*ndua0*trGam2 -
+       2*(2*Gam002*invg00 + 2*Gam102*invg01 + 2*Gam202*invg02 +
+          2*Gam302*invg03 + gamma0*ndua2)*H0[ijk] -
+       4*Gam002*invg01*H1[ijk] - 4*Gam102*invg11*H1[ijk] -
+       4*Gam202*invg12*H1[ijk] - 4*Gam302*invg13*H1[ijk] -
+       4*Gam002*invg02*H2[ijk] - 4*Gam102*invg12*H2[ijk] -
+       4*Gam202*invg22*H2[ijk] - 4*Gam302*invg23*H2[ijk] -
+       2*gamma0*ndua0*H2[ijk] - 4*Gam002*invg03*H3[ijk] -
+       4*Gam102*invg13*H3[ijk] - 4*Gam202*invg23*H3[ijk] -
+       4*Gam302*invg33*H3[ijk] +
+       2*gamma0*g02[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Phi100[ijk]*Phi102[ijk] -
+       4*invg01*invh11*Phi101[ijk]*Phi102[ijk] -
+       4*invg02*invh11*Power(Phi102[ijk],2) -
+       4*invg03*invh11*Phi102[ijk]*Phi103[ijk] -
+       4*invg01*invh11*Phi100[ijk]*Phi112[ijk] -
+       4*invg11*invh11*Phi101[ijk]*Phi112[ijk] -
+       4*invg12*invh11*Phi102[ijk]*Phi112[ijk] -
+       4*invg13*invh11*Phi103[ijk]*Phi112[ijk] -
+       4*invg02*invh11*Phi100[ijk]*Phi122[ijk] -
+       4*invg12*invh11*Phi101[ijk]*Phi122[ijk] -
+       4*invg22*invh11*Phi102[ijk]*Phi122[ijk] -
+       4*invg23*invh11*Phi103[ijk]*Phi122[ijk] -
+       4*invg03*invh11*Phi100[ijk]*Phi123[ijk] -
+       4*invg13*invh11*Phi101[ijk]*Phi123[ijk] -
+       4*invg23*invh11*Phi102[ijk]*Phi123[ijk] -
+       4*invg33*invh11*Phi103[ijk]*Phi123[ijk] -
+       4*invg00*invh12*Phi102[ijk]*Phi200[ijk] -
+       4*invg01*invh12*Phi112[ijk]*Phi200[ijk] -
+       4*invg02*invh12*Phi122[ijk]*Phi200[ijk] -
+       4*invg03*invh12*Phi123[ijk]*Phi200[ijk] -
+       4*invg01*invh12*Phi102[ijk]*Phi201[ijk] -
+       4*invg11*invh12*Phi112[ijk]*Phi201[ijk] -
+       4*invg12*invh12*Phi122[ijk]*Phi201[ijk] -
+       4*invg13*invh12*Phi123[ijk]*Phi201[ijk] -
+       4*invg00*invh12*Phi100[ijk]*Phi202[ijk] -
+       4*invg01*invh12*Phi101[ijk]*Phi202[ijk] -
+       8*invg02*invh12*Phi102[ijk]*Phi202[ijk] -
+       4*invg03*invh12*Phi103[ijk]*Phi202[ijk] -
+       4*invg12*invh12*Phi112[ijk]*Phi202[ijk] -
+       4*invg22*invh12*Phi122[ijk]*Phi202[ijk] -
+       4*invg23*invh12*Phi123[ijk]*Phi202[ijk] -
+       4*invg00*invh22*Phi200[ijk]*Phi202[ijk] -
+       4*invg01*invh22*Phi201[ijk]*Phi202[ijk] -
+       4*invg02*invh22*Power(Phi202[ijk],2) -
+       4*invg03*invh12*Phi102[ijk]*Phi203[ijk] -
+       4*invg13*invh12*Phi112[ijk]*Phi203[ijk] -
+       4*invg23*invh12*Phi122[ijk]*Phi203[ijk] -
+       4*invg33*invh12*Phi123[ijk]*Phi203[ijk] -
+       4*invg03*invh22*Phi202[ijk]*Phi203[ijk] -
+       4*invg01*invh12*Phi100[ijk]*Phi212[ijk] -
+       4*invg11*invh12*Phi101[ijk]*Phi212[ijk] -
+       4*invg12*invh12*Phi102[ijk]*Phi212[ijk] -
+       4*invg13*invh12*Phi103[ijk]*Phi212[ijk] -
+       4*invg01*invh22*Phi200[ijk]*Phi212[ijk] -
+       4*invg11*invh22*Phi201[ijk]*Phi212[ijk] -
+       4*invg12*invh22*Phi202[ijk]*Phi212[ijk] -
+       4*invg13*invh22*Phi203[ijk]*Phi212[ijk] -
+       4*invg02*invh12*Phi100[ijk]*Phi222[ijk] -
+       4*invg12*invh12*Phi101[ijk]*Phi222[ijk] -
+       4*invg22*invh12*Phi102[ijk]*Phi222[ijk] -
+       4*invg23*invh12*Phi103[ijk]*Phi222[ijk] -
+       4*invg02*invh22*Phi200[ijk]*Phi222[ijk] -
+       4*invg12*invh22*Phi201[ijk]*Phi222[ijk] -
+       4*invg22*invh22*Phi202[ijk]*Phi222[ijk] -
+       4*invg23*invh22*Phi203[ijk]*Phi222[ijk] -
+       4*invg03*invh12*Phi100[ijk]*Phi223[ijk] -
+       4*invg13*invh12*Phi101[ijk]*Phi223[ijk] -
+       4*invg23*invh12*Phi102[ijk]*Phi223[ijk] -
+       4*invg33*invh12*Phi103[ijk]*Phi223[ijk] -
+       4*invg03*invh22*Phi200[ijk]*Phi223[ijk] -
+       4*invg13*invh22*Phi201[ijk]*Phi223[ijk] -
+       4*invg23*invh22*Phi202[ijk]*Phi223[ijk] -
+       4*invg33*invh22*Phi203[ijk]*Phi223[ijk] -
+       4*invg00*invh13*Phi102[ijk]*Phi300[ijk] -
+       4*invg01*invh13*Phi112[ijk]*Phi300[ijk] -
+       4*invg02*invh13*Phi122[ijk]*Phi300[ijk] -
+       4*invg03*invh13*Phi123[ijk]*Phi300[ijk] -
+       4*invg00*invh23*Phi202[ijk]*Phi300[ijk] -
+       4*invg01*invh23*Phi212[ijk]*Phi300[ijk] -
+       4*invg02*invh23*Phi222[ijk]*Phi300[ijk] -
+       4*invg03*invh23*Phi223[ijk]*Phi300[ijk] -
+       4*invg01*invh13*Phi102[ijk]*Phi301[ijk] -
+       4*invg11*invh13*Phi112[ijk]*Phi301[ijk] -
+       4*invg12*invh13*Phi122[ijk]*Phi301[ijk] -
+       4*invg13*invh13*Phi123[ijk]*Phi301[ijk] -
+       4*invg01*invh23*Phi202[ijk]*Phi301[ijk] -
+       4*invg11*invh23*Phi212[ijk]*Phi301[ijk] -
+       4*invg12*invh23*Phi222[ijk]*Phi301[ijk] -
+       4*invg13*invh23*Phi223[ijk]*Phi301[ijk] -
+       4*invg00*invh13*Phi100[ijk]*Phi302[ijk] -
+       4*invg01*invh13*Phi101[ijk]*Phi302[ijk] -
+       8*invg02*invh13*Phi102[ijk]*Phi302[ijk] -
+       4*invg03*invh13*Phi103[ijk]*Phi302[ijk] -
+       4*invg12*invh13*Phi112[ijk]*Phi302[ijk] -
+       4*invg22*invh13*Phi122[ijk]*Phi302[ijk] -
+       4*invg23*invh13*Phi123[ijk]*Phi302[ijk] -
+       4*invg00*invh23*Phi200[ijk]*Phi302[ijk] -
+       4*invg01*invh23*Phi201[ijk]*Phi302[ijk] -
+       8*invg02*invh23*Phi202[ijk]*Phi302[ijk] -
+       4*invg03*invh23*Phi203[ijk]*Phi302[ijk] -
+       4*invg12*invh23*Phi212[ijk]*Phi302[ijk] -
+       4*invg22*invh23*Phi222[ijk]*Phi302[ijk] -
+       4*invg23*invh23*Phi223[ijk]*Phi302[ijk] -
+       4*invg00*invh33*Phi300[ijk]*Phi302[ijk] -
+       4*invg01*invh33*Phi301[ijk]*Phi302[ijk] -
+       4*invg02*invh33*Power(Phi302[ijk],2) -
+       4*invg03*invh13*Phi102[ijk]*Phi303[ijk] -
+       4*invg13*invh13*Phi112[ijk]*Phi303[ijk] -
+       4*invg23*invh13*Phi122[ijk]*Phi303[ijk] -
+       4*invg33*invh13*Phi123[ijk]*Phi303[ijk] -
+       4*invg03*invh23*Phi202[ijk]*Phi303[ijk] -
+       4*invg13*invh23*Phi212[ijk]*Phi303[ijk] -
+       4*invg23*invh23*Phi222[ijk]*Phi303[ijk] -
+       4*invg33*invh23*Phi223[ijk]*Phi303[ijk] -
+       4*invg03*invh33*Phi302[ijk]*Phi303[ijk] -
+       4*invg01*invh13*Phi100[ijk]*Phi312[ijk] -
+       4*invg11*invh13*Phi101[ijk]*Phi312[ijk] -
+       4*invg12*invh13*Phi102[ijk]*Phi312[ijk] -
+       4*invg13*invh13*Phi103[ijk]*Phi312[ijk] -
+       4*invg01*invh23*Phi200[ijk]*Phi312[ijk] -
+       4*invg11*invh23*Phi201[ijk]*Phi312[ijk] -
+       4*invg12*invh23*Phi202[ijk]*Phi312[ijk] -
+       4*invg13*invh23*Phi203[ijk]*Phi312[ijk] -
+       4*invg01*invh33*Phi300[ijk]*Phi312[ijk] -
+       4*invg11*invh33*Phi301[ijk]*Phi312[ijk] -
+       4*invg12*invh33*Phi302[ijk]*Phi312[ijk] -
+       4*invg13*invh33*Phi303[ijk]*Phi312[ijk] -
+       4*invg02*invh13*Phi100[ijk]*Phi322[ijk] -
+       4*invg12*invh13*Phi101[ijk]*Phi322[ijk] -
+       4*invg22*invh13*Phi102[ijk]*Phi322[ijk] -
+       4*invg23*invh13*Phi103[ijk]*Phi322[ijk] -
+       4*invg02*invh23*Phi200[ijk]*Phi322[ijk] -
+       4*invg12*invh23*Phi201[ijk]*Phi322[ijk] -
+       4*invg22*invh23*Phi202[ijk]*Phi322[ijk] -
+       4*invg23*invh23*Phi203[ijk]*Phi322[ijk] -
+       4*invg02*invh33*Phi300[ijk]*Phi322[ijk] -
+       4*invg12*invh33*Phi301[ijk]*Phi322[ijk] -
+       4*invg22*invh33*Phi302[ijk]*Phi322[ijk] -
+       4*invg23*invh33*Phi303[ijk]*Phi322[ijk] -
+       4*invg03*invh13*Phi100[ijk]*Phi323[ijk] -
+       4*invg13*invh13*Phi101[ijk]*Phi323[ijk] -
+       4*invg23*invh13*Phi102[ijk]*Phi323[ijk] -
+       4*invg33*invh13*Phi103[ijk]*Phi323[ijk] -
+       4*invg03*invh23*Phi200[ijk]*Phi323[ijk] -
+       4*invg13*invh23*Phi201[ijk]*Phi323[ijk] -
+       4*invg23*invh23*Phi202[ijk]*Phi323[ijk] -
+       4*invg33*invh23*Phi203[ijk]*Phi323[ijk] -
+       4*invg03*invh33*Phi300[ijk]*Phi323[ijk] -
+       4*invg13*invh33*Phi301[ijk]*Phi323[ijk] -
+       4*invg23*invh33*Phi302[ijk]*Phi323[ijk] -
+       4*invg33*invh33*Phi303[ijk]*Phi323[ijk] +
+       2*invh11*nvec0*Phi102[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi202[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi302[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi102[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi202[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi302[ijk]*Pi02[ijk] +
+       4*invg00*Pi00[ijk]*Pi02[ijk] + Power(nvec0,2)*Pi00[ijk]*Pi02[ijk] +
+       4*invg01*Pi01[ijk]*Pi02[ijk] + 2*nvec0*nvec1*Pi01[ijk]*Pi02[ijk] +
+       4*invg02*Power(Pi02[ijk],2) + 2*nvec0*nvec2*Power(Pi02[ijk],2) +
+       2*invh13*nvec0*Phi102[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi202[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi302[ijk]*Pi03[ijk] +
+       4*invg03*Pi02[ijk]*Pi03[ijk] + 2*nvec0*nvec3*Pi02[ijk]*Pi03[ijk] +
+       2*invh11*nvec1*Phi102[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi202[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi302[ijk]*Pi11[ijk] +
+       Power(nvec1,2)*Pi02[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi102[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi102[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi202[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi202[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi302[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi302[ijk]*Pi12[ijk] +
+       4*invg01*Pi00[ijk]*Pi12[ijk] + 4*invg11*Pi01[ijk]*Pi12[ijk] +
+       4*invg12*Pi02[ijk]*Pi12[ijk] + 2*nvec1*nvec2*Pi02[ijk]*Pi12[ijk] +
+       4*invg13*Pi03[ijk]*Pi12[ijk] +
+       2*invh13*nvec1*Phi102[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi102[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi202[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi202[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi302[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi302[ijk]*Pi13[ijk] +
+       2*nvec1*nvec3*Pi02[ijk]*Pi13[ijk] +
+       2*invh12*nvec2*Phi102[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi202[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi302[ijk]*Pi22[ijk] +
+       4*invg02*Pi00[ijk]*Pi22[ijk] + 4*invg12*Pi01[ijk]*Pi22[ijk] +
+       4*invg22*Pi02[ijk]*Pi22[ijk] + Power(nvec2,2)*Pi02[ijk]*Pi22[ijk] +
+       4*invg23*Pi03[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi102[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi102[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi202[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi202[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi302[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi302[ijk]*Pi23[ijk] +
+       4*invg03*Pi00[ijk]*Pi23[ijk] + 4*invg13*Pi01[ijk]*Pi23[ijk] +
+       4*invg23*Pi02[ijk]*Pi23[ijk] + 2*nvec2*nvec3*Pi02[ijk]*Pi23[ijk] +
+       4*invg33*Pi03[ijk]*Pi23[ijk] +
+       2*invh13*nvec3*Phi102[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi202[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi302[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi02[ijk]*Pi33[ijk]) -
+    2*(gamma1*gamma2*beta1[ijk]*Phi102[ijk] +
+       gamma1*gamma2*beta2[ijk]*Phi202[ijk] +
+       gamma1*gamma2*beta3[ijk]*Phi302[ijk] + srcSdH02[ijk]))/2.
+;
+
+dtPi03[ijk]
+=
+(-2*interior*AdPi03[ijk] - alpha[ijk]*
+     (4*Gam000*Gam300*Power(invg00,2) + 8*Gam001*Gam300*invg00*invg01 +
+       8*Gam000*Gam301*invg00*invg01 + 4*Gam011*Gam300*Power(invg01,2) +
+       8*Gam001*Gam301*Power(invg01,2) + 4*Gam000*Gam311*Power(invg01,2) +
+       8*Gam002*Gam300*invg00*invg02 + 8*Gam000*Gam302*invg00*invg02 +
+       8*Gam012*Gam300*invg01*invg02 + 8*Gam002*Gam301*invg01*invg02 +
+       8*Gam001*Gam302*invg01*invg02 + 8*Gam000*Gam312*invg01*invg02 +
+       4*Gam022*Gam300*Power(invg02,2) + 8*Gam002*Gam302*Power(invg02,2) +
+       4*Gam000*Gam322*Power(invg02,2) + 8*Gam003*Gam300*invg00*invg03 +
+       8*Gam000*Gam303*invg00*invg03 + 8*Gam013*Gam300*invg01*invg03 +
+       8*Gam003*Gam301*invg01*invg03 + 8*Gam001*Gam303*invg01*invg03 +
+       8*Gam000*Gam313*invg01*invg03 + 8*Gam023*Gam300*invg02*invg03 +
+       8*Gam003*Gam302*invg02*invg03 + 8*Gam002*Gam303*invg02*invg03 +
+       8*Gam000*Gam323*invg02*invg03 + 4*Gam033*Gam300*Power(invg03,2) +
+       8*Gam003*Gam303*Power(invg03,2) + 4*Gam000*Gam333*Power(invg03,2) +
+       8*Gam001*Gam301*invg00*invg11 + 8*Gam011*Gam301*invg01*invg11 +
+       8*Gam001*Gam311*invg01*invg11 + 8*Gam012*Gam301*invg02*invg11 +
+       8*Gam001*Gam312*invg02*invg11 + 8*Gam013*Gam301*invg03*invg11 +
+       8*Gam001*Gam313*invg03*invg11 + 4*Gam011*Gam311*Power(invg11,2) +
+       8*Gam002*Gam301*invg00*invg12 + 8*Gam001*Gam302*invg00*invg12 +
+       8*Gam012*Gam301*invg01*invg12 + 8*Gam011*Gam302*invg01*invg12 +
+       8*Gam002*Gam311*invg01*invg12 + 8*Gam001*Gam312*invg01*invg12 +
+       8*Gam022*Gam301*invg02*invg12 + 8*Gam012*Gam302*invg02*invg12 +
+       8*Gam002*Gam312*invg02*invg12 + 8*Gam001*Gam322*invg02*invg12 +
+       8*Gam023*Gam301*invg03*invg12 + 8*Gam013*Gam302*invg03*invg12 +
+       8*Gam002*Gam313*invg03*invg12 + 8*Gam001*Gam323*invg03*invg12 +
+       8*Gam012*Gam311*invg11*invg12 + 8*Gam011*Gam312*invg11*invg12 +
+       4*Gam022*Gam311*Power(invg12,2) + 8*Gam012*Gam312*Power(invg12,2) +
+       4*Gam011*Gam322*Power(invg12,2) + 8*Gam003*Gam301*invg00*invg13 +
+       8*Gam001*Gam303*invg00*invg13 + 8*Gam013*Gam301*invg01*invg13 +
+       8*Gam011*Gam303*invg01*invg13 + 8*Gam003*Gam311*invg01*invg13 +
+       8*Gam001*Gam313*invg01*invg13 + 8*Gam023*Gam301*invg02*invg13 +
+       8*Gam012*Gam303*invg02*invg13 + 8*Gam003*Gam312*invg02*invg13 +
+       8*Gam001*Gam323*invg02*invg13 + 8*Gam033*Gam301*invg03*invg13 +
+       8*Gam013*Gam303*invg03*invg13 + 8*Gam003*Gam313*invg03*invg13 +
+       8*Gam001*Gam333*invg03*invg13 + 8*Gam013*Gam311*invg11*invg13 +
+       8*Gam011*Gam313*invg11*invg13 + 8*Gam023*Gam311*invg12*invg13 +
+       8*Gam013*Gam312*invg12*invg13 + 8*Gam012*Gam313*invg12*invg13 +
+       8*Gam011*Gam323*invg12*invg13 + 4*Gam033*Gam311*Power(invg13,2) +
+       8*Gam013*Gam313*Power(invg13,2) + 4*Gam011*Gam333*Power(invg13,2) +
+       8*Gam002*Gam302*invg00*invg22 + 8*Gam012*Gam302*invg01*invg22 +
+       8*Gam002*Gam312*invg01*invg22 + 8*Gam022*Gam302*invg02*invg22 +
+       8*Gam002*Gam322*invg02*invg22 + 8*Gam023*Gam302*invg03*invg22 +
+       8*Gam002*Gam323*invg03*invg22 + 8*Gam012*Gam312*invg11*invg22 +
+       8*Gam022*Gam312*invg12*invg22 + 8*Gam012*Gam322*invg12*invg22 +
+       8*Gam023*Gam312*invg13*invg22 + 8*Gam012*Gam323*invg13*invg22 +
+       4*Gam022*Gam322*Power(invg22,2) + 8*Gam003*Gam302*invg00*invg23 +
+       8*Gam002*Gam303*invg00*invg23 + 8*Gam013*Gam302*invg01*invg23 +
+       8*Gam012*Gam303*invg01*invg23 + 8*Gam003*Gam312*invg01*invg23 +
+       8*Gam002*Gam313*invg01*invg23 + 8*Gam023*Gam302*invg02*invg23 +
+       8*Gam022*Gam303*invg02*invg23 + 8*Gam003*Gam322*invg02*invg23 +
+       8*Gam002*Gam323*invg02*invg23 + 8*Gam033*Gam302*invg03*invg23 +
+       8*Gam023*Gam303*invg03*invg23 + 8*Gam003*Gam323*invg03*invg23 +
+       8*Gam002*Gam333*invg03*invg23 + 8*Gam013*Gam312*invg11*invg23 +
+       8*Gam012*Gam313*invg11*invg23 + 8*Gam023*Gam312*invg12*invg23 +
+       8*Gam022*Gam313*invg12*invg23 + 8*Gam013*Gam322*invg12*invg23 +
+       8*Gam012*Gam323*invg12*invg23 + 8*Gam033*Gam312*invg13*invg23 +
+       8*Gam023*Gam313*invg13*invg23 + 8*Gam013*Gam323*invg13*invg23 +
+       8*Gam012*Gam333*invg13*invg23 + 8*Gam023*Gam322*invg22*invg23 +
+       8*Gam022*Gam323*invg22*invg23 + 4*Gam033*Gam322*Power(invg23,2) +
+       8*Gam023*Gam323*Power(invg23,2) + 4*Gam022*Gam333*Power(invg23,2) +
+       8*Gam003*Gam303*invg00*invg33 + 8*Gam013*Gam303*invg01*invg33 +
+       8*Gam003*Gam313*invg01*invg33 + 8*Gam023*Gam303*invg02*invg33 +
+       8*Gam003*Gam323*invg02*invg33 + 8*Gam033*Gam303*invg03*invg33 +
+       8*Gam003*Gam333*invg03*invg33 + 8*Gam013*Gam313*invg11*invg33 +
+       8*Gam023*Gam313*invg12*invg33 + 8*Gam013*Gam323*invg12*invg33 +
+       8*Gam033*Gam313*invg13*invg33 + 8*Gam013*Gam333*invg13*invg33 +
+       8*Gam023*Gam323*invg22*invg33 + 8*Gam033*Gam323*invg23*invg33 +
+       8*Gam023*Gam333*invg23*invg33 + 4*Gam033*Gam333*Power(invg33,2) -
+       2*gamma0*ndua3*trGam0 - 2*gamma0*ndua0*trGam3 -
+       2*(2*Gam003*invg00 + 2*Gam103*invg01 + 2*Gam203*invg02 +
+          2*Gam303*invg03 + gamma0*ndua3)*H0[ijk] -
+       4*Gam003*invg01*H1[ijk] - 4*Gam103*invg11*H1[ijk] -
+       4*Gam203*invg12*H1[ijk] - 4*Gam303*invg13*H1[ijk] -
+       4*Gam003*invg02*H2[ijk] - 4*Gam103*invg12*H2[ijk] -
+       4*Gam203*invg22*H2[ijk] - 4*Gam303*invg23*H2[ijk] -
+       4*Gam003*invg03*H3[ijk] - 4*Gam103*invg13*H3[ijk] -
+       4*Gam203*invg23*H3[ijk] - 4*Gam303*invg33*H3[ijk] -
+       2*gamma0*ndua0*H3[ijk] +
+       2*gamma0*g03[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Phi100[ijk]*Phi103[ijk] -
+       4*invg01*invh11*Phi101[ijk]*Phi103[ijk] -
+       4*invg02*invh11*Phi102[ijk]*Phi103[ijk] -
+       4*invg03*invh11*Power(Phi103[ijk],2) -
+       4*invg01*invh11*Phi100[ijk]*Phi113[ijk] -
+       4*invg11*invh11*Phi101[ijk]*Phi113[ijk] -
+       4*invg12*invh11*Phi102[ijk]*Phi113[ijk] -
+       4*invg13*invh11*Phi103[ijk]*Phi113[ijk] -
+       4*invg02*invh11*Phi100[ijk]*Phi123[ijk] -
+       4*invg12*invh11*Phi101[ijk]*Phi123[ijk] -
+       4*invg22*invh11*Phi102[ijk]*Phi123[ijk] -
+       4*invg23*invh11*Phi103[ijk]*Phi123[ijk] -
+       4*invg03*invh11*Phi100[ijk]*Phi133[ijk] -
+       4*invg13*invh11*Phi101[ijk]*Phi133[ijk] -
+       4*invg23*invh11*Phi102[ijk]*Phi133[ijk] -
+       4*invg33*invh11*Phi103[ijk]*Phi133[ijk] -
+       4*invg00*invh12*Phi103[ijk]*Phi200[ijk] -
+       4*invg01*invh12*Phi113[ijk]*Phi200[ijk] -
+       4*invg02*invh12*Phi123[ijk]*Phi200[ijk] -
+       4*invg03*invh12*Phi133[ijk]*Phi200[ijk] -
+       4*invg01*invh12*Phi103[ijk]*Phi201[ijk] -
+       4*invg11*invh12*Phi113[ijk]*Phi201[ijk] -
+       4*invg12*invh12*Phi123[ijk]*Phi201[ijk] -
+       4*invg13*invh12*Phi133[ijk]*Phi201[ijk] -
+       4*invg02*invh12*Phi103[ijk]*Phi202[ijk] -
+       4*invg12*invh12*Phi113[ijk]*Phi202[ijk] -
+       4*invg22*invh12*Phi123[ijk]*Phi202[ijk] -
+       4*invg23*invh12*Phi133[ijk]*Phi202[ijk] -
+       4*invg00*invh12*Phi100[ijk]*Phi203[ijk] -
+       4*invg01*invh12*Phi101[ijk]*Phi203[ijk] -
+       4*invg02*invh12*Phi102[ijk]*Phi203[ijk] -
+       8*invg03*invh12*Phi103[ijk]*Phi203[ijk] -
+       4*invg13*invh12*Phi113[ijk]*Phi203[ijk] -
+       4*invg23*invh12*Phi123[ijk]*Phi203[ijk] -
+       4*invg33*invh12*Phi133[ijk]*Phi203[ijk] -
+       4*invg00*invh22*Phi200[ijk]*Phi203[ijk] -
+       4*invg01*invh22*Phi201[ijk]*Phi203[ijk] -
+       4*invg02*invh22*Phi202[ijk]*Phi203[ijk] -
+       4*invg03*invh22*Power(Phi203[ijk],2) -
+       4*invg01*invh12*Phi100[ijk]*Phi213[ijk] -
+       4*invg11*invh12*Phi101[ijk]*Phi213[ijk] -
+       4*invg12*invh12*Phi102[ijk]*Phi213[ijk] -
+       4*invg13*invh12*Phi103[ijk]*Phi213[ijk] -
+       4*invg01*invh22*Phi200[ijk]*Phi213[ijk] -
+       4*invg11*invh22*Phi201[ijk]*Phi213[ijk] -
+       4*invg12*invh22*Phi202[ijk]*Phi213[ijk] -
+       4*invg13*invh22*Phi203[ijk]*Phi213[ijk] -
+       4*invg02*invh12*Phi100[ijk]*Phi223[ijk] -
+       4*invg12*invh12*Phi101[ijk]*Phi223[ijk] -
+       4*invg22*invh12*Phi102[ijk]*Phi223[ijk] -
+       4*invg23*invh12*Phi103[ijk]*Phi223[ijk] -
+       4*invg02*invh22*Phi200[ijk]*Phi223[ijk] -
+       4*invg12*invh22*Phi201[ijk]*Phi223[ijk] -
+       4*invg22*invh22*Phi202[ijk]*Phi223[ijk] -
+       4*invg23*invh22*Phi203[ijk]*Phi223[ijk] -
+       4*invg03*invh12*Phi100[ijk]*Phi233[ijk] -
+       4*invg13*invh12*Phi101[ijk]*Phi233[ijk] -
+       4*invg23*invh12*Phi102[ijk]*Phi233[ijk] -
+       4*invg33*invh12*Phi103[ijk]*Phi233[ijk] -
+       4*invg03*invh22*Phi200[ijk]*Phi233[ijk] -
+       4*invg13*invh22*Phi201[ijk]*Phi233[ijk] -
+       4*invg23*invh22*Phi202[ijk]*Phi233[ijk] -
+       4*invg33*invh22*Phi203[ijk]*Phi233[ijk] -
+       4*invg00*invh13*Phi103[ijk]*Phi300[ijk] -
+       4*invg01*invh13*Phi113[ijk]*Phi300[ijk] -
+       4*invg02*invh13*Phi123[ijk]*Phi300[ijk] -
+       4*invg03*invh13*Phi133[ijk]*Phi300[ijk] -
+       4*invg00*invh23*Phi203[ijk]*Phi300[ijk] -
+       4*invg01*invh23*Phi213[ijk]*Phi300[ijk] -
+       4*invg02*invh23*Phi223[ijk]*Phi300[ijk] -
+       4*invg03*invh23*Phi233[ijk]*Phi300[ijk] -
+       4*invg01*invh13*Phi103[ijk]*Phi301[ijk] -
+       4*invg11*invh13*Phi113[ijk]*Phi301[ijk] -
+       4*invg12*invh13*Phi123[ijk]*Phi301[ijk] -
+       4*invg13*invh13*Phi133[ijk]*Phi301[ijk] -
+       4*invg01*invh23*Phi203[ijk]*Phi301[ijk] -
+       4*invg11*invh23*Phi213[ijk]*Phi301[ijk] -
+       4*invg12*invh23*Phi223[ijk]*Phi301[ijk] -
+       4*invg13*invh23*Phi233[ijk]*Phi301[ijk] -
+       4*invg02*invh13*Phi103[ijk]*Phi302[ijk] -
+       4*invg12*invh13*Phi113[ijk]*Phi302[ijk] -
+       4*invg22*invh13*Phi123[ijk]*Phi302[ijk] -
+       4*invg23*invh13*Phi133[ijk]*Phi302[ijk] -
+       4*invg02*invh23*Phi203[ijk]*Phi302[ijk] -
+       4*invg12*invh23*Phi213[ijk]*Phi302[ijk] -
+       4*invg22*invh23*Phi223[ijk]*Phi302[ijk] -
+       4*invg23*invh23*Phi233[ijk]*Phi302[ijk] -
+       4*invg00*invh13*Phi100[ijk]*Phi303[ijk] -
+       4*invg01*invh13*Phi101[ijk]*Phi303[ijk] -
+       4*invg02*invh13*Phi102[ijk]*Phi303[ijk] -
+       8*invg03*invh13*Phi103[ijk]*Phi303[ijk] -
+       4*invg13*invh13*Phi113[ijk]*Phi303[ijk] -
+       4*invg23*invh13*Phi123[ijk]*Phi303[ijk] -
+       4*invg33*invh13*Phi133[ijk]*Phi303[ijk] -
+       4*invg00*invh23*Phi200[ijk]*Phi303[ijk] -
+       4*invg01*invh23*Phi201[ijk]*Phi303[ijk] -
+       4*invg02*invh23*Phi202[ijk]*Phi303[ijk] -
+       8*invg03*invh23*Phi203[ijk]*Phi303[ijk] -
+       4*invg13*invh23*Phi213[ijk]*Phi303[ijk] -
+       4*invg23*invh23*Phi223[ijk]*Phi303[ijk] -
+       4*invg33*invh23*Phi233[ijk]*Phi303[ijk] -
+       4*invg00*invh33*Phi300[ijk]*Phi303[ijk] -
+       4*invg01*invh33*Phi301[ijk]*Phi303[ijk] -
+       4*invg02*invh33*Phi302[ijk]*Phi303[ijk] -
+       4*invg03*invh33*Power(Phi303[ijk],2) -
+       4*invg01*invh13*Phi100[ijk]*Phi313[ijk] -
+       4*invg11*invh13*Phi101[ijk]*Phi313[ijk] -
+       4*invg12*invh13*Phi102[ijk]*Phi313[ijk] -
+       4*invg13*invh13*Phi103[ijk]*Phi313[ijk] -
+       4*invg01*invh23*Phi200[ijk]*Phi313[ijk] -
+       4*invg11*invh23*Phi201[ijk]*Phi313[ijk] -
+       4*invg12*invh23*Phi202[ijk]*Phi313[ijk] -
+       4*invg13*invh23*Phi203[ijk]*Phi313[ijk] -
+       4*invg01*invh33*Phi300[ijk]*Phi313[ijk] -
+       4*invg11*invh33*Phi301[ijk]*Phi313[ijk] -
+       4*invg12*invh33*Phi302[ijk]*Phi313[ijk] -
+       4*invg13*invh33*Phi303[ijk]*Phi313[ijk] -
+       4*invg02*invh13*Phi100[ijk]*Phi323[ijk] -
+       4*invg12*invh13*Phi101[ijk]*Phi323[ijk] -
+       4*invg22*invh13*Phi102[ijk]*Phi323[ijk] -
+       4*invg23*invh13*Phi103[ijk]*Phi323[ijk] -
+       4*invg02*invh23*Phi200[ijk]*Phi323[ijk] -
+       4*invg12*invh23*Phi201[ijk]*Phi323[ijk] -
+       4*invg22*invh23*Phi202[ijk]*Phi323[ijk] -
+       4*invg23*invh23*Phi203[ijk]*Phi323[ijk] -
+       4*invg02*invh33*Phi300[ijk]*Phi323[ijk] -
+       4*invg12*invh33*Phi301[ijk]*Phi323[ijk] -
+       4*invg22*invh33*Phi302[ijk]*Phi323[ijk] -
+       4*invg23*invh33*Phi303[ijk]*Phi323[ijk] -
+       4*invg03*invh13*Phi100[ijk]*Phi333[ijk] -
+       4*invg13*invh13*Phi101[ijk]*Phi333[ijk] -
+       4*invg23*invh13*Phi102[ijk]*Phi333[ijk] -
+       4*invg33*invh13*Phi103[ijk]*Phi333[ijk] -
+       4*invg03*invh23*Phi200[ijk]*Phi333[ijk] -
+       4*invg13*invh23*Phi201[ijk]*Phi333[ijk] -
+       4*invg23*invh23*Phi202[ijk]*Phi333[ijk] -
+       4*invg33*invh23*Phi203[ijk]*Phi333[ijk] -
+       4*invg03*invh33*Phi300[ijk]*Phi333[ijk] -
+       4*invg13*invh33*Phi301[ijk]*Phi333[ijk] -
+       4*invg23*invh33*Phi302[ijk]*Phi333[ijk] -
+       4*invg33*invh33*Phi303[ijk]*Phi333[ijk] +
+       2*invh11*nvec0*Phi103[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi203[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi303[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi103[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi203[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi303[ijk]*Pi02[ijk] +
+       2*invh13*nvec0*Phi103[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi203[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi303[ijk]*Pi03[ijk] +
+       4*invg00*Pi00[ijk]*Pi03[ijk] + Power(nvec0,2)*Pi00[ijk]*Pi03[ijk] +
+       4*invg01*Pi01[ijk]*Pi03[ijk] + 2*nvec0*nvec1*Pi01[ijk]*Pi03[ijk] +
+       4*invg02*Pi02[ijk]*Pi03[ijk] + 2*nvec0*nvec2*Pi02[ijk]*Pi03[ijk] +
+       4*invg03*Power(Pi03[ijk],2) + 2*nvec0*nvec3*Power(Pi03[ijk],2) +
+       2*invh11*nvec1*Phi103[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi203[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi303[ijk]*Pi11[ijk] +
+       Power(nvec1,2)*Pi03[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi103[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi103[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi203[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi203[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi303[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi303[ijk]*Pi12[ijk] +
+       2*nvec1*nvec2*Pi03[ijk]*Pi12[ijk] +
+       2*invh13*nvec1*Phi103[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi103[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi203[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi203[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi303[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi303[ijk]*Pi13[ijk] +
+       4*invg01*Pi00[ijk]*Pi13[ijk] + 4*invg11*Pi01[ijk]*Pi13[ijk] +
+       4*invg12*Pi02[ijk]*Pi13[ijk] + 4*invg13*Pi03[ijk]*Pi13[ijk] +
+       2*nvec1*nvec3*Pi03[ijk]*Pi13[ijk] +
+       2*invh12*nvec2*Phi103[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi203[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi303[ijk]*Pi22[ijk] +
+       Power(nvec2,2)*Pi03[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi103[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi103[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi203[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi203[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi303[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi303[ijk]*Pi23[ijk] +
+       4*invg02*Pi00[ijk]*Pi23[ijk] + 4*invg12*Pi01[ijk]*Pi23[ijk] +
+       4*invg22*Pi02[ijk]*Pi23[ijk] + 4*invg23*Pi03[ijk]*Pi23[ijk] +
+       2*nvec2*nvec3*Pi03[ijk]*Pi23[ijk] +
+       2*invh13*nvec3*Phi103[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi203[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi303[ijk]*Pi33[ijk] +
+       4*invg03*Pi00[ijk]*Pi33[ijk] + 4*invg13*Pi01[ijk]*Pi33[ijk] +
+       4*invg23*Pi02[ijk]*Pi33[ijk] + 4*invg33*Pi03[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi03[ijk]*Pi33[ijk]) -
+    2*(gamma1*gamma2*beta1[ijk]*Phi103[ijk] +
+       gamma1*gamma2*beta2[ijk]*Phi203[ijk] +
+       gamma1*gamma2*beta3[ijk]*Phi303[ijk] + srcSdH03[ijk]))/2.
+;
+
+dtPi11[ijk]
+=
+-(interior*AdPi11[ijk]) - gamma1*gamma2*beta1[ijk]*Phi111[ijk] -
+  gamma1*gamma2*beta2[ijk]*Phi211[ijk] -
+  gamma1*gamma2*beta3[ijk]*Phi311[ijk] -
+  (alpha[ijk]*(4*Power(Gam100,2)*Power(invg00,2) +
+       16*Gam100*Gam101*invg00*invg01 +
+       8*Power(Gam101,2)*Power(invg01,2) +
+       8*Gam100*Gam111*Power(invg01,2) + 16*Gam100*Gam102*invg00*invg02 +
+       16*Gam101*Gam102*invg01*invg02 + 16*Gam100*Gam112*invg01*invg02 +
+       8*Power(Gam102,2)*Power(invg02,2) +
+       8*Gam100*Gam122*Power(invg02,2) + 16*Gam100*Gam103*invg00*invg03 +
+       16*Gam101*Gam103*invg01*invg03 + 16*Gam100*Gam113*invg01*invg03 +
+       16*Gam102*Gam103*invg02*invg03 + 16*Gam100*Gam123*invg02*invg03 +
+       8*Power(Gam103,2)*Power(invg03,2) +
+       8*Gam100*Gam133*Power(invg03,2) + 8*Power(Gam101,2)*invg00*invg11 +
+       16*Gam101*Gam111*invg01*invg11 + 16*Gam101*Gam112*invg02*invg11 +
+       16*Gam101*Gam113*invg03*invg11 +
+       4*Power(Gam111,2)*Power(invg11,2) +
+       16*Gam101*Gam102*invg00*invg12 + 16*Gam102*Gam111*invg01*invg12 +
+       16*Gam101*Gam112*invg01*invg12 + 16*Gam102*Gam112*invg02*invg12 +
+       16*Gam101*Gam122*invg02*invg12 + 16*Gam102*Gam113*invg03*invg12 +
+       16*Gam101*Gam123*invg03*invg12 + 16*Gam111*Gam112*invg11*invg12 +
+       8*Power(Gam112,2)*Power(invg12,2) +
+       8*Gam111*Gam122*Power(invg12,2) + 16*Gam101*Gam103*invg00*invg13 +
+       16*Gam103*Gam111*invg01*invg13 + 16*Gam101*Gam113*invg01*invg13 +
+       16*Gam103*Gam112*invg02*invg13 + 16*Gam101*Gam123*invg02*invg13 +
+       16*Gam103*Gam113*invg03*invg13 + 16*Gam101*Gam133*invg03*invg13 +
+       16*Gam111*Gam113*invg11*invg13 + 16*Gam112*Gam113*invg12*invg13 +
+       16*Gam111*Gam123*invg12*invg13 +
+       8*Power(Gam113,2)*Power(invg13,2) +
+       8*Gam111*Gam133*Power(invg13,2) + 8*Power(Gam102,2)*invg00*invg22 +
+       16*Gam102*Gam112*invg01*invg22 + 16*Gam102*Gam122*invg02*invg22 +
+       16*Gam102*Gam123*invg03*invg22 + 8*Power(Gam112,2)*invg11*invg22 +
+       16*Gam112*Gam122*invg12*invg22 + 16*Gam112*Gam123*invg13*invg22 +
+       4*Power(Gam122,2)*Power(invg22,2) +
+       16*Gam102*Gam103*invg00*invg23 + 16*Gam103*Gam112*invg01*invg23 +
+       16*Gam102*Gam113*invg01*invg23 + 16*Gam103*Gam122*invg02*invg23 +
+       16*Gam102*Gam123*invg02*invg23 + 16*Gam103*Gam123*invg03*invg23 +
+       16*Gam102*Gam133*invg03*invg23 + 16*Gam112*Gam113*invg11*invg23 +
+       16*Gam113*Gam122*invg12*invg23 + 16*Gam112*Gam123*invg12*invg23 +
+       16*Gam113*Gam123*invg13*invg23 + 16*Gam112*Gam133*invg13*invg23 +
+       16*Gam122*Gam123*invg22*invg23 +
+       8*Power(Gam123,2)*Power(invg23,2) +
+       8*Gam122*Gam133*Power(invg23,2) + 8*Power(Gam103,2)*invg00*invg33 +
+       16*Gam103*Gam113*invg01*invg33 + 16*Gam103*Gam123*invg02*invg33 +
+       16*Gam103*Gam133*invg03*invg33 + 8*Power(Gam113,2)*invg11*invg33 +
+       16*Gam113*Gam123*invg12*invg33 + 16*Gam113*Gam133*invg13*invg33 +
+       8*Power(Gam123,2)*invg22*invg33 + 16*Gam123*Gam133*invg23*invg33 +
+       4*Power(Gam133,2)*Power(invg33,2) - 4*gamma0*ndua1*trGam1 -
+       4*(Gam011*invg00 + Gam111*invg01 + Gam211*invg02 + Gam311*invg03)*
+        H0[ijk] - 4*Gam011*invg01*H1[ijk] - 4*Gam111*invg11*H1[ijk] -
+       4*Gam211*invg12*H1[ijk] - 4*Gam311*invg13*H1[ijk] -
+       4*gamma0*ndua1*H1[ijk] - 4*Gam011*invg02*H2[ijk] -
+       4*Gam111*invg12*H2[ijk] - 4*Gam211*invg22*H2[ijk] -
+       4*Gam311*invg23*H2[ijk] - 4*Gam011*invg03*H3[ijk] -
+       4*Gam111*invg13*H3[ijk] - 4*Gam211*invg23*H3[ijk] -
+       4*Gam311*invg33*H3[ijk] +
+       2*gamma0*g11[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Power(Phi101[ijk],2) -
+       8*invg01*invh11*Phi101[ijk]*Phi111[ijk] -
+       4*invg11*invh11*Power(Phi111[ijk],2) -
+       8*invg02*invh11*Phi101[ijk]*Phi112[ijk] -
+       8*invg12*invh11*Phi111[ijk]*Phi112[ijk] -
+       4*invg22*invh11*Power(Phi112[ijk],2) -
+       8*invg03*invh11*Phi101[ijk]*Phi113[ijk] -
+       8*invg13*invh11*Phi111[ijk]*Phi113[ijk] -
+       8*invg23*invh11*Phi112[ijk]*Phi113[ijk] -
+       4*invg33*invh11*Power(Phi113[ijk],2) -
+       8*invg00*invh12*Phi101[ijk]*Phi201[ijk] -
+       8*invg01*invh12*Phi111[ijk]*Phi201[ijk] -
+       8*invg02*invh12*Phi112[ijk]*Phi201[ijk] -
+       8*invg03*invh12*Phi113[ijk]*Phi201[ijk] -
+       4*invg00*invh22*Power(Phi201[ijk],2) -
+       8*invg01*invh12*Phi101[ijk]*Phi211[ijk] -
+       8*invg11*invh12*Phi111[ijk]*Phi211[ijk] -
+       8*invg12*invh12*Phi112[ijk]*Phi211[ijk] -
+       8*invg13*invh12*Phi113[ijk]*Phi211[ijk] -
+       8*invg01*invh22*Phi201[ijk]*Phi211[ijk] -
+       4*invg11*invh22*Power(Phi211[ijk],2) -
+       8*invg02*invh12*Phi101[ijk]*Phi212[ijk] -
+       8*invg12*invh12*Phi111[ijk]*Phi212[ijk] -
+       8*invg22*invh12*Phi112[ijk]*Phi212[ijk] -
+       8*invg23*invh12*Phi113[ijk]*Phi212[ijk] -
+       8*invg02*invh22*Phi201[ijk]*Phi212[ijk] -
+       8*invg12*invh22*Phi211[ijk]*Phi212[ijk] -
+       4*invg22*invh22*Power(Phi212[ijk],2) -
+       8*invg03*invh12*Phi101[ijk]*Phi213[ijk] -
+       8*invg13*invh12*Phi111[ijk]*Phi213[ijk] -
+       8*invg23*invh12*Phi112[ijk]*Phi213[ijk] -
+       8*invg33*invh12*Phi113[ijk]*Phi213[ijk] -
+       8*invg03*invh22*Phi201[ijk]*Phi213[ijk] -
+       8*invg13*invh22*Phi211[ijk]*Phi213[ijk] -
+       8*invg23*invh22*Phi212[ijk]*Phi213[ijk] -
+       4*invg33*invh22*Power(Phi213[ijk],2) -
+       8*invg00*invh13*Phi101[ijk]*Phi301[ijk] -
+       8*invg01*invh13*Phi111[ijk]*Phi301[ijk] -
+       8*invg02*invh13*Phi112[ijk]*Phi301[ijk] -
+       8*invg03*invh13*Phi113[ijk]*Phi301[ijk] -
+       8*invg00*invh23*Phi201[ijk]*Phi301[ijk] -
+       8*invg01*invh23*Phi211[ijk]*Phi301[ijk] -
+       8*invg02*invh23*Phi212[ijk]*Phi301[ijk] -
+       8*invg03*invh23*Phi213[ijk]*Phi301[ijk] -
+       4*invg00*invh33*Power(Phi301[ijk],2) -
+       8*invg01*invh13*Phi101[ijk]*Phi311[ijk] -
+       8*invg11*invh13*Phi111[ijk]*Phi311[ijk] -
+       8*invg12*invh13*Phi112[ijk]*Phi311[ijk] -
+       8*invg13*invh13*Phi113[ijk]*Phi311[ijk] -
+       8*invg01*invh23*Phi201[ijk]*Phi311[ijk] -
+       8*invg11*invh23*Phi211[ijk]*Phi311[ijk] -
+       8*invg12*invh23*Phi212[ijk]*Phi311[ijk] -
+       8*invg13*invh23*Phi213[ijk]*Phi311[ijk] -
+       8*invg01*invh33*Phi301[ijk]*Phi311[ijk] -
+       4*invg11*invh33*Power(Phi311[ijk],2) -
+       8*invg02*invh13*Phi101[ijk]*Phi312[ijk] -
+       8*invg12*invh13*Phi111[ijk]*Phi312[ijk] -
+       8*invg22*invh13*Phi112[ijk]*Phi312[ijk] -
+       8*invg23*invh13*Phi113[ijk]*Phi312[ijk] -
+       8*invg02*invh23*Phi201[ijk]*Phi312[ijk] -
+       8*invg12*invh23*Phi211[ijk]*Phi312[ijk] -
+       8*invg22*invh23*Phi212[ijk]*Phi312[ijk] -
+       8*invg23*invh23*Phi213[ijk]*Phi312[ijk] -
+       8*invg02*invh33*Phi301[ijk]*Phi312[ijk] -
+       8*invg12*invh33*Phi311[ijk]*Phi312[ijk] -
+       4*invg22*invh33*Power(Phi312[ijk],2) -
+       8*invg03*invh13*Phi101[ijk]*Phi313[ijk] -
+       8*invg13*invh13*Phi111[ijk]*Phi313[ijk] -
+       8*invg23*invh13*Phi112[ijk]*Phi313[ijk] -
+       8*invg33*invh13*Phi113[ijk]*Phi313[ijk] -
+       8*invg03*invh23*Phi201[ijk]*Phi313[ijk] -
+       8*invg13*invh23*Phi211[ijk]*Phi313[ijk] -
+       8*invg23*invh23*Phi212[ijk]*Phi313[ijk] -
+       8*invg33*invh23*Phi213[ijk]*Phi313[ijk] -
+       8*invg03*invh33*Phi301[ijk]*Phi313[ijk] -
+       8*invg13*invh33*Phi311[ijk]*Phi313[ijk] -
+       8*invg23*invh33*Phi312[ijk]*Phi313[ijk] -
+       4*invg33*invh33*Power(Phi313[ijk],2) +
+       2*invh11*nvec0*Phi111[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi211[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi311[ijk]*Pi01[ijk] +
+       4*invg00*Power(Pi01[ijk],2) +
+       2*invh12*nvec0*Phi111[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi211[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi311[ijk]*Pi02[ijk] +
+       2*invh13*nvec0*Phi111[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi211[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi311[ijk]*Pi03[ijk] +
+       2*invh11*nvec1*Phi111[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi211[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi311[ijk]*Pi11[ijk] +
+       Power(nvec0,2)*Pi00[ijk]*Pi11[ijk] + 8*invg01*Pi01[ijk]*Pi11[ijk] +
+       2*nvec0*nvec1*Pi01[ijk]*Pi11[ijk] +
+       2*nvec0*nvec2*Pi02[ijk]*Pi11[ijk] +
+       2*nvec0*nvec3*Pi03[ijk]*Pi11[ijk] + 4*invg11*Power(Pi11[ijk],2) +
+       Power(nvec1,2)*Power(Pi11[ijk],2) +
+       2*invh12*nvec1*Phi111[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi111[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi211[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi211[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi311[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi311[ijk]*Pi12[ijk] +
+       8*invg02*Pi01[ijk]*Pi12[ijk] + 8*invg12*Pi11[ijk]*Pi12[ijk] +
+       2*nvec1*nvec2*Pi11[ijk]*Pi12[ijk] + 4*invg22*Power(Pi12[ijk],2) +
+       2*invh13*nvec1*Phi111[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi111[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi211[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi211[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi311[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi311[ijk]*Pi13[ijk] +
+       8*invg03*Pi01[ijk]*Pi13[ijk] + 8*invg13*Pi11[ijk]*Pi13[ijk] +
+       2*nvec1*nvec3*Pi11[ijk]*Pi13[ijk] + 8*invg23*Pi12[ijk]*Pi13[ijk] +
+       4*invg33*Power(Pi13[ijk],2) +
+       2*invh12*nvec2*Phi111[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi211[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi311[ijk]*Pi22[ijk] +
+       Power(nvec2,2)*Pi11[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi111[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi111[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi211[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi211[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi311[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi311[ijk]*Pi23[ijk] +
+       2*nvec2*nvec3*Pi11[ijk]*Pi23[ijk] +
+       2*invh13*nvec3*Phi111[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi211[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi311[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi11[ijk]*Pi33[ijk]))/2. - srcSdH11[ijk]
+;
+
+dtPi12[ijk]
+=
+(-2*interior*AdPi12[ijk] - alpha[ijk]*
+     (4*Gam100*Gam200*Power(invg00,2) + 8*Gam101*Gam200*invg00*invg01 +
+       8*Gam100*Gam201*invg00*invg01 + 4*Gam111*Gam200*Power(invg01,2) +
+       8*Gam101*Gam201*Power(invg01,2) + 4*Gam100*Gam211*Power(invg01,2) +
+       8*Gam102*Gam200*invg00*invg02 + 8*Gam100*Gam202*invg00*invg02 +
+       8*Gam112*Gam200*invg01*invg02 + 8*Gam102*Gam201*invg01*invg02 +
+       8*Gam101*Gam202*invg01*invg02 + 8*Gam100*Gam212*invg01*invg02 +
+       4*Gam122*Gam200*Power(invg02,2) + 8*Gam102*Gam202*Power(invg02,2) +
+       4*Gam100*Gam222*Power(invg02,2) + 8*Gam103*Gam200*invg00*invg03 +
+       8*Gam100*Gam203*invg00*invg03 + 8*Gam113*Gam200*invg01*invg03 +
+       8*Gam103*Gam201*invg01*invg03 + 8*Gam101*Gam203*invg01*invg03 +
+       8*Gam100*Gam213*invg01*invg03 + 8*Gam123*Gam200*invg02*invg03 +
+       8*Gam103*Gam202*invg02*invg03 + 8*Gam102*Gam203*invg02*invg03 +
+       8*Gam100*Gam223*invg02*invg03 + 4*Gam133*Gam200*Power(invg03,2) +
+       8*Gam103*Gam203*Power(invg03,2) + 4*Gam100*Gam233*Power(invg03,2) +
+       8*Gam101*Gam201*invg00*invg11 + 8*Gam111*Gam201*invg01*invg11 +
+       8*Gam101*Gam211*invg01*invg11 + 8*Gam112*Gam201*invg02*invg11 +
+       8*Gam101*Gam212*invg02*invg11 + 8*Gam113*Gam201*invg03*invg11 +
+       8*Gam101*Gam213*invg03*invg11 + 4*Gam111*Gam211*Power(invg11,2) +
+       8*Gam102*Gam201*invg00*invg12 + 8*Gam101*Gam202*invg00*invg12 +
+       8*Gam112*Gam201*invg01*invg12 + 8*Gam111*Gam202*invg01*invg12 +
+       8*Gam102*Gam211*invg01*invg12 + 8*Gam101*Gam212*invg01*invg12 +
+       8*Gam122*Gam201*invg02*invg12 + 8*Gam112*Gam202*invg02*invg12 +
+       8*Gam102*Gam212*invg02*invg12 + 8*Gam101*Gam222*invg02*invg12 +
+       8*Gam123*Gam201*invg03*invg12 + 8*Gam113*Gam202*invg03*invg12 +
+       8*Gam102*Gam213*invg03*invg12 + 8*Gam101*Gam223*invg03*invg12 +
+       8*Gam112*Gam211*invg11*invg12 + 8*Gam111*Gam212*invg11*invg12 +
+       4*Gam122*Gam211*Power(invg12,2) + 8*Gam112*Gam212*Power(invg12,2) +
+       4*Gam111*Gam222*Power(invg12,2) + 8*Gam103*Gam201*invg00*invg13 +
+       8*Gam101*Gam203*invg00*invg13 + 8*Gam113*Gam201*invg01*invg13 +
+       8*Gam111*Gam203*invg01*invg13 + 8*Gam103*Gam211*invg01*invg13 +
+       8*Gam101*Gam213*invg01*invg13 + 8*Gam123*Gam201*invg02*invg13 +
+       8*Gam112*Gam203*invg02*invg13 + 8*Gam103*Gam212*invg02*invg13 +
+       8*Gam101*Gam223*invg02*invg13 + 8*Gam133*Gam201*invg03*invg13 +
+       8*Gam113*Gam203*invg03*invg13 + 8*Gam103*Gam213*invg03*invg13 +
+       8*Gam101*Gam233*invg03*invg13 + 8*Gam113*Gam211*invg11*invg13 +
+       8*Gam111*Gam213*invg11*invg13 + 8*Gam123*Gam211*invg12*invg13 +
+       8*Gam113*Gam212*invg12*invg13 + 8*Gam112*Gam213*invg12*invg13 +
+       8*Gam111*Gam223*invg12*invg13 + 4*Gam133*Gam211*Power(invg13,2) +
+       8*Gam113*Gam213*Power(invg13,2) + 4*Gam111*Gam233*Power(invg13,2) +
+       8*Gam102*Gam202*invg00*invg22 + 8*Gam112*Gam202*invg01*invg22 +
+       8*Gam102*Gam212*invg01*invg22 + 8*Gam122*Gam202*invg02*invg22 +
+       8*Gam102*Gam222*invg02*invg22 + 8*Gam123*Gam202*invg03*invg22 +
+       8*Gam102*Gam223*invg03*invg22 + 8*Gam112*Gam212*invg11*invg22 +
+       8*Gam122*Gam212*invg12*invg22 + 8*Gam112*Gam222*invg12*invg22 +
+       8*Gam123*Gam212*invg13*invg22 + 8*Gam112*Gam223*invg13*invg22 +
+       4*Gam122*Gam222*Power(invg22,2) + 8*Gam103*Gam202*invg00*invg23 +
+       8*Gam102*Gam203*invg00*invg23 + 8*Gam113*Gam202*invg01*invg23 +
+       8*Gam112*Gam203*invg01*invg23 + 8*Gam103*Gam212*invg01*invg23 +
+       8*Gam102*Gam213*invg01*invg23 + 8*Gam123*Gam202*invg02*invg23 +
+       8*Gam122*Gam203*invg02*invg23 + 8*Gam103*Gam222*invg02*invg23 +
+       8*Gam102*Gam223*invg02*invg23 + 8*Gam133*Gam202*invg03*invg23 +
+       8*Gam123*Gam203*invg03*invg23 + 8*Gam103*Gam223*invg03*invg23 +
+       8*Gam102*Gam233*invg03*invg23 + 8*Gam113*Gam212*invg11*invg23 +
+       8*Gam112*Gam213*invg11*invg23 + 8*Gam123*Gam212*invg12*invg23 +
+       8*Gam122*Gam213*invg12*invg23 + 8*Gam113*Gam222*invg12*invg23 +
+       8*Gam112*Gam223*invg12*invg23 + 8*Gam133*Gam212*invg13*invg23 +
+       8*Gam123*Gam213*invg13*invg23 + 8*Gam113*Gam223*invg13*invg23 +
+       8*Gam112*Gam233*invg13*invg23 + 8*Gam123*Gam222*invg22*invg23 +
+       8*Gam122*Gam223*invg22*invg23 + 4*Gam133*Gam222*Power(invg23,2) +
+       8*Gam123*Gam223*Power(invg23,2) + 4*Gam122*Gam233*Power(invg23,2) +
+       8*Gam103*Gam203*invg00*invg33 + 8*Gam113*Gam203*invg01*invg33 +
+       8*Gam103*Gam213*invg01*invg33 + 8*Gam123*Gam203*invg02*invg33 +
+       8*Gam103*Gam223*invg02*invg33 + 8*Gam133*Gam203*invg03*invg33 +
+       8*Gam103*Gam233*invg03*invg33 + 8*Gam113*Gam213*invg11*invg33 +
+       8*Gam123*Gam213*invg12*invg33 + 8*Gam113*Gam223*invg12*invg33 +
+       8*Gam133*Gam213*invg13*invg33 + 8*Gam113*Gam233*invg13*invg33 +
+       8*Gam123*Gam223*invg22*invg33 + 8*Gam133*Gam223*invg23*invg33 +
+       8*Gam123*Gam233*invg23*invg33 + 4*Gam133*Gam233*Power(invg33,2) -
+       2*gamma0*ndua2*trGam1 - 2*gamma0*ndua1*trGam2 -
+       4*(Gam012*invg00 + Gam112*invg01 + Gam212*invg02 + Gam312*invg03)*
+        H0[ijk] - 4*Gam012*invg01*H1[ijk] - 4*Gam112*invg11*H1[ijk] -
+       4*Gam212*invg12*H1[ijk] - 4*Gam312*invg13*H1[ijk] -
+       2*gamma0*ndua2*H1[ijk] - 4*Gam012*invg02*H2[ijk] -
+       4*Gam112*invg12*H2[ijk] - 4*Gam212*invg22*H2[ijk] -
+       4*Gam312*invg23*H2[ijk] - 2*gamma0*ndua1*H2[ijk] -
+       4*Gam012*invg03*H3[ijk] - 4*Gam112*invg13*H3[ijk] -
+       4*Gam212*invg23*H3[ijk] - 4*Gam312*invg33*H3[ijk] +
+       2*gamma0*g12[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Phi101[ijk]*Phi102[ijk] -
+       4*invg01*invh11*Phi102[ijk]*Phi111[ijk] -
+       4*invg01*invh11*Phi101[ijk]*Phi112[ijk] -
+       4*invg02*invh11*Phi102[ijk]*Phi112[ijk] -
+       4*invg11*invh11*Phi111[ijk]*Phi112[ijk] -
+       4*invg12*invh11*Power(Phi112[ijk],2) -
+       4*invg03*invh11*Phi102[ijk]*Phi113[ijk] -
+       4*invg13*invh11*Phi112[ijk]*Phi113[ijk] -
+       4*invg02*invh11*Phi101[ijk]*Phi122[ijk] -
+       4*invg12*invh11*Phi111[ijk]*Phi122[ijk] -
+       4*invg22*invh11*Phi112[ijk]*Phi122[ijk] -
+       4*invg23*invh11*Phi113[ijk]*Phi122[ijk] -
+       4*invg03*invh11*Phi101[ijk]*Phi123[ijk] -
+       4*invg13*invh11*Phi111[ijk]*Phi123[ijk] -
+       4*invg23*invh11*Phi112[ijk]*Phi123[ijk] -
+       4*invg33*invh11*Phi113[ijk]*Phi123[ijk] -
+       4*invg00*invh12*Phi102[ijk]*Phi201[ijk] -
+       4*invg01*invh12*Phi112[ijk]*Phi201[ijk] -
+       4*invg02*invh12*Phi122[ijk]*Phi201[ijk] -
+       4*invg03*invh12*Phi123[ijk]*Phi201[ijk] -
+       4*invg00*invh12*Phi101[ijk]*Phi202[ijk] -
+       4*invg01*invh12*Phi111[ijk]*Phi202[ijk] -
+       4*invg02*invh12*Phi112[ijk]*Phi202[ijk] -
+       4*invg03*invh12*Phi113[ijk]*Phi202[ijk] -
+       4*invg00*invh22*Phi201[ijk]*Phi202[ijk] -
+       4*invg01*invh12*Phi102[ijk]*Phi211[ijk] -
+       4*invg11*invh12*Phi112[ijk]*Phi211[ijk] -
+       4*invg12*invh12*Phi122[ijk]*Phi211[ijk] -
+       4*invg13*invh12*Phi123[ijk]*Phi211[ijk] -
+       4*invg01*invh22*Phi202[ijk]*Phi211[ijk] -
+       4*invg01*invh12*Phi101[ijk]*Phi212[ijk] -
+       4*invg02*invh12*Phi102[ijk]*Phi212[ijk] -
+       4*invg11*invh12*Phi111[ijk]*Phi212[ijk] -
+       8*invg12*invh12*Phi112[ijk]*Phi212[ijk] -
+       4*invg13*invh12*Phi113[ijk]*Phi212[ijk] -
+       4*invg22*invh12*Phi122[ijk]*Phi212[ijk] -
+       4*invg23*invh12*Phi123[ijk]*Phi212[ijk] -
+       4*invg01*invh22*Phi201[ijk]*Phi212[ijk] -
+       4*invg02*invh22*Phi202[ijk]*Phi212[ijk] -
+       4*invg11*invh22*Phi211[ijk]*Phi212[ijk] -
+       4*invg12*invh22*Power(Phi212[ijk],2) -
+       4*invg03*invh12*Phi102[ijk]*Phi213[ijk] -
+       4*invg13*invh12*Phi112[ijk]*Phi213[ijk] -
+       4*invg23*invh12*Phi122[ijk]*Phi213[ijk] -
+       4*invg33*invh12*Phi123[ijk]*Phi213[ijk] -
+       4*invg03*invh22*Phi202[ijk]*Phi213[ijk] -
+       4*invg13*invh22*Phi212[ijk]*Phi213[ijk] -
+       4*invg02*invh12*Phi101[ijk]*Phi222[ijk] -
+       4*invg12*invh12*Phi111[ijk]*Phi222[ijk] -
+       4*invg22*invh12*Phi112[ijk]*Phi222[ijk] -
+       4*invg23*invh12*Phi113[ijk]*Phi222[ijk] -
+       4*invg02*invh22*Phi201[ijk]*Phi222[ijk] -
+       4*invg12*invh22*Phi211[ijk]*Phi222[ijk] -
+       4*invg22*invh22*Phi212[ijk]*Phi222[ijk] -
+       4*invg23*invh22*Phi213[ijk]*Phi222[ijk] -
+       4*invg03*invh12*Phi101[ijk]*Phi223[ijk] -
+       4*invg13*invh12*Phi111[ijk]*Phi223[ijk] -
+       4*invg23*invh12*Phi112[ijk]*Phi223[ijk] -
+       4*invg33*invh12*Phi113[ijk]*Phi223[ijk] -
+       4*invg03*invh22*Phi201[ijk]*Phi223[ijk] -
+       4*invg13*invh22*Phi211[ijk]*Phi223[ijk] -
+       4*invg23*invh22*Phi212[ijk]*Phi223[ijk] -
+       4*invg33*invh22*Phi213[ijk]*Phi223[ijk] -
+       4*invg00*invh13*Phi102[ijk]*Phi301[ijk] -
+       4*invg01*invh13*Phi112[ijk]*Phi301[ijk] -
+       4*invg02*invh13*Phi122[ijk]*Phi301[ijk] -
+       4*invg03*invh13*Phi123[ijk]*Phi301[ijk] -
+       4*invg00*invh23*Phi202[ijk]*Phi301[ijk] -
+       4*invg01*invh23*Phi212[ijk]*Phi301[ijk] -
+       4*invg02*invh23*Phi222[ijk]*Phi301[ijk] -
+       4*invg03*invh23*Phi223[ijk]*Phi301[ijk] -
+       4*invg00*invh13*Phi101[ijk]*Phi302[ijk] -
+       4*invg01*invh13*Phi111[ijk]*Phi302[ijk] -
+       4*invg02*invh13*Phi112[ijk]*Phi302[ijk] -
+       4*invg03*invh13*Phi113[ijk]*Phi302[ijk] -
+       4*invg00*invh23*Phi201[ijk]*Phi302[ijk] -
+       4*invg01*invh23*Phi211[ijk]*Phi302[ijk] -
+       4*invg02*invh23*Phi212[ijk]*Phi302[ijk] -
+       4*invg03*invh23*Phi213[ijk]*Phi302[ijk] -
+       4*invg00*invh33*Phi301[ijk]*Phi302[ijk] -
+       4*invg01*invh13*Phi102[ijk]*Phi311[ijk] -
+       4*invg11*invh13*Phi112[ijk]*Phi311[ijk] -
+       4*invg12*invh13*Phi122[ijk]*Phi311[ijk] -
+       4*invg13*invh13*Phi123[ijk]*Phi311[ijk] -
+       4*invg01*invh23*Phi202[ijk]*Phi311[ijk] -
+       4*invg11*invh23*Phi212[ijk]*Phi311[ijk] -
+       4*invg12*invh23*Phi222[ijk]*Phi311[ijk] -
+       4*invg13*invh23*Phi223[ijk]*Phi311[ijk] -
+       4*invg01*invh33*Phi302[ijk]*Phi311[ijk] -
+       4*invg01*invh13*Phi101[ijk]*Phi312[ijk] -
+       4*invg02*invh13*Phi102[ijk]*Phi312[ijk] -
+       4*invg11*invh13*Phi111[ijk]*Phi312[ijk] -
+       8*invg12*invh13*Phi112[ijk]*Phi312[ijk] -
+       4*invg13*invh13*Phi113[ijk]*Phi312[ijk] -
+       4*invg22*invh13*Phi122[ijk]*Phi312[ijk] -
+       4*invg23*invh13*Phi123[ijk]*Phi312[ijk] -
+       4*invg01*invh23*Phi201[ijk]*Phi312[ijk] -
+       4*invg02*invh23*Phi202[ijk]*Phi312[ijk] -
+       4*invg11*invh23*Phi211[ijk]*Phi312[ijk] -
+       8*invg12*invh23*Phi212[ijk]*Phi312[ijk] -
+       4*invg13*invh23*Phi213[ijk]*Phi312[ijk] -
+       4*invg22*invh23*Phi222[ijk]*Phi312[ijk] -
+       4*invg23*invh23*Phi223[ijk]*Phi312[ijk] -
+       4*invg01*invh33*Phi301[ijk]*Phi312[ijk] -
+       4*invg02*invh33*Phi302[ijk]*Phi312[ijk] -
+       4*invg11*invh33*Phi311[ijk]*Phi312[ijk] -
+       4*invg12*invh33*Power(Phi312[ijk],2) -
+       4*invg03*invh13*Phi102[ijk]*Phi313[ijk] -
+       4*invg13*invh13*Phi112[ijk]*Phi313[ijk] -
+       4*invg23*invh13*Phi122[ijk]*Phi313[ijk] -
+       4*invg33*invh13*Phi123[ijk]*Phi313[ijk] -
+       4*invg03*invh23*Phi202[ijk]*Phi313[ijk] -
+       4*invg13*invh23*Phi212[ijk]*Phi313[ijk] -
+       4*invg23*invh23*Phi222[ijk]*Phi313[ijk] -
+       4*invg33*invh23*Phi223[ijk]*Phi313[ijk] -
+       4*invg03*invh33*Phi302[ijk]*Phi313[ijk] -
+       4*invg13*invh33*Phi312[ijk]*Phi313[ijk] -
+       4*invg02*invh13*Phi101[ijk]*Phi322[ijk] -
+       4*invg12*invh13*Phi111[ijk]*Phi322[ijk] -
+       4*invg22*invh13*Phi112[ijk]*Phi322[ijk] -
+       4*invg23*invh13*Phi113[ijk]*Phi322[ijk] -
+       4*invg02*invh23*Phi201[ijk]*Phi322[ijk] -
+       4*invg12*invh23*Phi211[ijk]*Phi322[ijk] -
+       4*invg22*invh23*Phi212[ijk]*Phi322[ijk] -
+       4*invg23*invh23*Phi213[ijk]*Phi322[ijk] -
+       4*invg02*invh33*Phi301[ijk]*Phi322[ijk] -
+       4*invg12*invh33*Phi311[ijk]*Phi322[ijk] -
+       4*invg22*invh33*Phi312[ijk]*Phi322[ijk] -
+       4*invg23*invh33*Phi313[ijk]*Phi322[ijk] -
+       4*invg03*invh13*Phi101[ijk]*Phi323[ijk] -
+       4*invg13*invh13*Phi111[ijk]*Phi323[ijk] -
+       4*invg23*invh13*Phi112[ijk]*Phi323[ijk] -
+       4*invg33*invh13*Phi113[ijk]*Phi323[ijk] -
+       4*invg03*invh23*Phi201[ijk]*Phi323[ijk] -
+       4*invg13*invh23*Phi211[ijk]*Phi323[ijk] -
+       4*invg23*invh23*Phi212[ijk]*Phi323[ijk] -
+       4*invg33*invh23*Phi213[ijk]*Phi323[ijk] -
+       4*invg03*invh33*Phi301[ijk]*Phi323[ijk] -
+       4*invg13*invh33*Phi311[ijk]*Phi323[ijk] -
+       4*invg23*invh33*Phi312[ijk]*Phi323[ijk] -
+       4*invg33*invh33*Phi313[ijk]*Phi323[ijk] +
+       2*invh11*nvec0*Phi112[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi212[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi312[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi112[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi212[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi312[ijk]*Pi02[ijk] +
+       4*invg00*Pi01[ijk]*Pi02[ijk] +
+       2*invh13*nvec0*Phi112[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi212[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi312[ijk]*Pi03[ijk] +
+       2*invh11*nvec1*Phi112[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi212[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi312[ijk]*Pi11[ijk] +
+       4*invg01*Pi02[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi112[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi112[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi212[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi212[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi312[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi312[ijk]*Pi12[ijk] +
+       Power(nvec0,2)*Pi00[ijk]*Pi12[ijk] + 4*invg01*Pi01[ijk]*Pi12[ijk] +
+       2*nvec0*nvec1*Pi01[ijk]*Pi12[ijk] + 4*invg02*Pi02[ijk]*Pi12[ijk] +
+       2*nvec0*nvec2*Pi02[ijk]*Pi12[ijk] +
+       2*nvec0*nvec3*Pi03[ijk]*Pi12[ijk] + 4*invg11*Pi11[ijk]*Pi12[ijk] +
+       Power(nvec1,2)*Pi11[ijk]*Pi12[ijk] + 4*invg12*Power(Pi12[ijk],2) +
+       2*nvec1*nvec2*Power(Pi12[ijk],2) +
+       2*invh13*nvec1*Phi112[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi112[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi212[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi212[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi312[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi312[ijk]*Pi13[ijk] +
+       4*invg03*Pi02[ijk]*Pi13[ijk] + 4*invg13*Pi12[ijk]*Pi13[ijk] +
+       2*nvec1*nvec3*Pi12[ijk]*Pi13[ijk] +
+       2*invh12*nvec2*Phi112[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi212[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi312[ijk]*Pi22[ijk] +
+       4*invg02*Pi01[ijk]*Pi22[ijk] + 4*invg12*Pi11[ijk]*Pi22[ijk] +
+       4*invg22*Pi12[ijk]*Pi22[ijk] + Power(nvec2,2)*Pi12[ijk]*Pi22[ijk] +
+       4*invg23*Pi13[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi112[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi112[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi212[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi212[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi312[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi312[ijk]*Pi23[ijk] +
+       4*invg03*Pi01[ijk]*Pi23[ijk] + 4*invg13*Pi11[ijk]*Pi23[ijk] +
+       4*invg23*Pi12[ijk]*Pi23[ijk] + 2*nvec2*nvec3*Pi12[ijk]*Pi23[ijk] +
+       4*invg33*Pi13[ijk]*Pi23[ijk] +
+       2*invh13*nvec3*Phi112[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi212[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi312[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi12[ijk]*Pi33[ijk]) -
+    2*(gamma1*gamma2*beta1[ijk]*Phi112[ijk] +
+       gamma1*gamma2*beta2[ijk]*Phi212[ijk] +
+       gamma1*gamma2*beta3[ijk]*Phi312[ijk] + srcSdH12[ijk]))/2.
+;
+
+dtPi13[ijk]
+=
+(-2*interior*AdPi13[ijk] - alpha[ijk]*
+     (4*Gam100*Gam300*Power(invg00,2) + 8*Gam101*Gam300*invg00*invg01 +
+       8*Gam100*Gam301*invg00*invg01 + 4*Gam111*Gam300*Power(invg01,2) +
+       8*Gam101*Gam301*Power(invg01,2) + 4*Gam100*Gam311*Power(invg01,2) +
+       8*Gam102*Gam300*invg00*invg02 + 8*Gam100*Gam302*invg00*invg02 +
+       8*Gam112*Gam300*invg01*invg02 + 8*Gam102*Gam301*invg01*invg02 +
+       8*Gam101*Gam302*invg01*invg02 + 8*Gam100*Gam312*invg01*invg02 +
+       4*Gam122*Gam300*Power(invg02,2) + 8*Gam102*Gam302*Power(invg02,2) +
+       4*Gam100*Gam322*Power(invg02,2) + 8*Gam103*Gam300*invg00*invg03 +
+       8*Gam100*Gam303*invg00*invg03 + 8*Gam113*Gam300*invg01*invg03 +
+       8*Gam103*Gam301*invg01*invg03 + 8*Gam101*Gam303*invg01*invg03 +
+       8*Gam100*Gam313*invg01*invg03 + 8*Gam123*Gam300*invg02*invg03 +
+       8*Gam103*Gam302*invg02*invg03 + 8*Gam102*Gam303*invg02*invg03 +
+       8*Gam100*Gam323*invg02*invg03 + 4*Gam133*Gam300*Power(invg03,2) +
+       8*Gam103*Gam303*Power(invg03,2) + 4*Gam100*Gam333*Power(invg03,2) +
+       8*Gam101*Gam301*invg00*invg11 + 8*Gam111*Gam301*invg01*invg11 +
+       8*Gam101*Gam311*invg01*invg11 + 8*Gam112*Gam301*invg02*invg11 +
+       8*Gam101*Gam312*invg02*invg11 + 8*Gam113*Gam301*invg03*invg11 +
+       8*Gam101*Gam313*invg03*invg11 + 4*Gam111*Gam311*Power(invg11,2) +
+       8*Gam102*Gam301*invg00*invg12 + 8*Gam101*Gam302*invg00*invg12 +
+       8*Gam112*Gam301*invg01*invg12 + 8*Gam111*Gam302*invg01*invg12 +
+       8*Gam102*Gam311*invg01*invg12 + 8*Gam101*Gam312*invg01*invg12 +
+       8*Gam122*Gam301*invg02*invg12 + 8*Gam112*Gam302*invg02*invg12 +
+       8*Gam102*Gam312*invg02*invg12 + 8*Gam101*Gam322*invg02*invg12 +
+       8*Gam123*Gam301*invg03*invg12 + 8*Gam113*Gam302*invg03*invg12 +
+       8*Gam102*Gam313*invg03*invg12 + 8*Gam101*Gam323*invg03*invg12 +
+       8*Gam112*Gam311*invg11*invg12 + 8*Gam111*Gam312*invg11*invg12 +
+       4*Gam122*Gam311*Power(invg12,2) + 8*Gam112*Gam312*Power(invg12,2) +
+       4*Gam111*Gam322*Power(invg12,2) + 8*Gam103*Gam301*invg00*invg13 +
+       8*Gam101*Gam303*invg00*invg13 + 8*Gam113*Gam301*invg01*invg13 +
+       8*Gam111*Gam303*invg01*invg13 + 8*Gam103*Gam311*invg01*invg13 +
+       8*Gam101*Gam313*invg01*invg13 + 8*Gam123*Gam301*invg02*invg13 +
+       8*Gam112*Gam303*invg02*invg13 + 8*Gam103*Gam312*invg02*invg13 +
+       8*Gam101*Gam323*invg02*invg13 + 8*Gam133*Gam301*invg03*invg13 +
+       8*Gam113*Gam303*invg03*invg13 + 8*Gam103*Gam313*invg03*invg13 +
+       8*Gam101*Gam333*invg03*invg13 + 8*Gam113*Gam311*invg11*invg13 +
+       8*Gam111*Gam313*invg11*invg13 + 8*Gam123*Gam311*invg12*invg13 +
+       8*Gam113*Gam312*invg12*invg13 + 8*Gam112*Gam313*invg12*invg13 +
+       8*Gam111*Gam323*invg12*invg13 + 4*Gam133*Gam311*Power(invg13,2) +
+       8*Gam113*Gam313*Power(invg13,2) + 4*Gam111*Gam333*Power(invg13,2) +
+       8*Gam102*Gam302*invg00*invg22 + 8*Gam112*Gam302*invg01*invg22 +
+       8*Gam102*Gam312*invg01*invg22 + 8*Gam122*Gam302*invg02*invg22 +
+       8*Gam102*Gam322*invg02*invg22 + 8*Gam123*Gam302*invg03*invg22 +
+       8*Gam102*Gam323*invg03*invg22 + 8*Gam112*Gam312*invg11*invg22 +
+       8*Gam122*Gam312*invg12*invg22 + 8*Gam112*Gam322*invg12*invg22 +
+       8*Gam123*Gam312*invg13*invg22 + 8*Gam112*Gam323*invg13*invg22 +
+       4*Gam122*Gam322*Power(invg22,2) + 8*Gam103*Gam302*invg00*invg23 +
+       8*Gam102*Gam303*invg00*invg23 + 8*Gam113*Gam302*invg01*invg23 +
+       8*Gam112*Gam303*invg01*invg23 + 8*Gam103*Gam312*invg01*invg23 +
+       8*Gam102*Gam313*invg01*invg23 + 8*Gam123*Gam302*invg02*invg23 +
+       8*Gam122*Gam303*invg02*invg23 + 8*Gam103*Gam322*invg02*invg23 +
+       8*Gam102*Gam323*invg02*invg23 + 8*Gam133*Gam302*invg03*invg23 +
+       8*Gam123*Gam303*invg03*invg23 + 8*Gam103*Gam323*invg03*invg23 +
+       8*Gam102*Gam333*invg03*invg23 + 8*Gam113*Gam312*invg11*invg23 +
+       8*Gam112*Gam313*invg11*invg23 + 8*Gam123*Gam312*invg12*invg23 +
+       8*Gam122*Gam313*invg12*invg23 + 8*Gam113*Gam322*invg12*invg23 +
+       8*Gam112*Gam323*invg12*invg23 + 8*Gam133*Gam312*invg13*invg23 +
+       8*Gam123*Gam313*invg13*invg23 + 8*Gam113*Gam323*invg13*invg23 +
+       8*Gam112*Gam333*invg13*invg23 + 8*Gam123*Gam322*invg22*invg23 +
+       8*Gam122*Gam323*invg22*invg23 + 4*Gam133*Gam322*Power(invg23,2) +
+       8*Gam123*Gam323*Power(invg23,2) + 4*Gam122*Gam333*Power(invg23,2) +
+       8*Gam103*Gam303*invg00*invg33 + 8*Gam113*Gam303*invg01*invg33 +
+       8*Gam103*Gam313*invg01*invg33 + 8*Gam123*Gam303*invg02*invg33 +
+       8*Gam103*Gam323*invg02*invg33 + 8*Gam133*Gam303*invg03*invg33 +
+       8*Gam103*Gam333*invg03*invg33 + 8*Gam113*Gam313*invg11*invg33 +
+       8*Gam123*Gam313*invg12*invg33 + 8*Gam113*Gam323*invg12*invg33 +
+       8*Gam133*Gam313*invg13*invg33 + 8*Gam113*Gam333*invg13*invg33 +
+       8*Gam123*Gam323*invg22*invg33 + 8*Gam133*Gam323*invg23*invg33 +
+       8*Gam123*Gam333*invg23*invg33 + 4*Gam133*Gam333*Power(invg33,2) -
+       2*gamma0*ndua3*trGam1 - 2*gamma0*ndua1*trGam3 -
+       4*(Gam013*invg00 + Gam113*invg01 + Gam213*invg02 + Gam313*invg03)*
+        H0[ijk] - 4*Gam013*invg01*H1[ijk] - 4*Gam113*invg11*H1[ijk] -
+       4*Gam213*invg12*H1[ijk] - 4*Gam313*invg13*H1[ijk] -
+       2*gamma0*ndua3*H1[ijk] - 4*Gam013*invg02*H2[ijk] -
+       4*Gam113*invg12*H2[ijk] - 4*Gam213*invg22*H2[ijk] -
+       4*Gam313*invg23*H2[ijk] - 4*Gam013*invg03*H3[ijk] -
+       4*Gam113*invg13*H3[ijk] - 4*Gam213*invg23*H3[ijk] -
+       4*Gam313*invg33*H3[ijk] - 2*gamma0*ndua1*H3[ijk] +
+       2*gamma0*g13[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Phi101[ijk]*Phi103[ijk] -
+       4*invg01*invh11*Phi103[ijk]*Phi111[ijk] -
+       4*invg02*invh11*Phi103[ijk]*Phi112[ijk] -
+       4*invg01*invh11*Phi101[ijk]*Phi113[ijk] -
+       4*invg03*invh11*Phi103[ijk]*Phi113[ijk] -
+       4*invg11*invh11*Phi111[ijk]*Phi113[ijk] -
+       4*invg12*invh11*Phi112[ijk]*Phi113[ijk] -
+       4*invg13*invh11*Power(Phi113[ijk],2) -
+       4*invg02*invh11*Phi101[ijk]*Phi123[ijk] -
+       4*invg12*invh11*Phi111[ijk]*Phi123[ijk] -
+       4*invg22*invh11*Phi112[ijk]*Phi123[ijk] -
+       4*invg23*invh11*Phi113[ijk]*Phi123[ijk] -
+       4*invg03*invh11*Phi101[ijk]*Phi133[ijk] -
+       4*invg13*invh11*Phi111[ijk]*Phi133[ijk] -
+       4*invg23*invh11*Phi112[ijk]*Phi133[ijk] -
+       4*invg33*invh11*Phi113[ijk]*Phi133[ijk] -
+       4*invg00*invh12*Phi103[ijk]*Phi201[ijk] -
+       4*invg01*invh12*Phi113[ijk]*Phi201[ijk] -
+       4*invg02*invh12*Phi123[ijk]*Phi201[ijk] -
+       4*invg03*invh12*Phi133[ijk]*Phi201[ijk] -
+       4*invg00*invh12*Phi101[ijk]*Phi203[ijk] -
+       4*invg01*invh12*Phi111[ijk]*Phi203[ijk] -
+       4*invg02*invh12*Phi112[ijk]*Phi203[ijk] -
+       4*invg03*invh12*Phi113[ijk]*Phi203[ijk] -
+       4*invg00*invh22*Phi201[ijk]*Phi203[ijk] -
+       4*invg01*invh12*Phi103[ijk]*Phi211[ijk] -
+       4*invg11*invh12*Phi113[ijk]*Phi211[ijk] -
+       4*invg12*invh12*Phi123[ijk]*Phi211[ijk] -
+       4*invg13*invh12*Phi133[ijk]*Phi211[ijk] -
+       4*invg01*invh22*Phi203[ijk]*Phi211[ijk] -
+       4*invg02*invh12*Phi103[ijk]*Phi212[ijk] -
+       4*invg12*invh12*Phi113[ijk]*Phi212[ijk] -
+       4*invg22*invh12*Phi123[ijk]*Phi212[ijk] -
+       4*invg23*invh12*Phi133[ijk]*Phi212[ijk] -
+       4*invg02*invh22*Phi203[ijk]*Phi212[ijk] -
+       4*invg01*invh12*Phi101[ijk]*Phi213[ijk] -
+       4*invg03*invh12*Phi103[ijk]*Phi213[ijk] -
+       4*invg11*invh12*Phi111[ijk]*Phi213[ijk] -
+       4*invg12*invh12*Phi112[ijk]*Phi213[ijk] -
+       8*invg13*invh12*Phi113[ijk]*Phi213[ijk] -
+       4*invg23*invh12*Phi123[ijk]*Phi213[ijk] -
+       4*invg33*invh12*Phi133[ijk]*Phi213[ijk] -
+       4*invg01*invh22*Phi201[ijk]*Phi213[ijk] -
+       4*invg03*invh22*Phi203[ijk]*Phi213[ijk] -
+       4*invg11*invh22*Phi211[ijk]*Phi213[ijk] -
+       4*invg12*invh22*Phi212[ijk]*Phi213[ijk] -
+       4*invg13*invh22*Power(Phi213[ijk],2) -
+       4*invg02*invh12*Phi101[ijk]*Phi223[ijk] -
+       4*invg12*invh12*Phi111[ijk]*Phi223[ijk] -
+       4*invg22*invh12*Phi112[ijk]*Phi223[ijk] -
+       4*invg23*invh12*Phi113[ijk]*Phi223[ijk] -
+       4*invg02*invh22*Phi201[ijk]*Phi223[ijk] -
+       4*invg12*invh22*Phi211[ijk]*Phi223[ijk] -
+       4*invg22*invh22*Phi212[ijk]*Phi223[ijk] -
+       4*invg23*invh22*Phi213[ijk]*Phi223[ijk] -
+       4*invg03*invh12*Phi101[ijk]*Phi233[ijk] -
+       4*invg13*invh12*Phi111[ijk]*Phi233[ijk] -
+       4*invg23*invh12*Phi112[ijk]*Phi233[ijk] -
+       4*invg33*invh12*Phi113[ijk]*Phi233[ijk] -
+       4*invg03*invh22*Phi201[ijk]*Phi233[ijk] -
+       4*invg13*invh22*Phi211[ijk]*Phi233[ijk] -
+       4*invg23*invh22*Phi212[ijk]*Phi233[ijk] -
+       4*invg33*invh22*Phi213[ijk]*Phi233[ijk] -
+       4*invg00*invh13*Phi103[ijk]*Phi301[ijk] -
+       4*invg01*invh13*Phi113[ijk]*Phi301[ijk] -
+       4*invg02*invh13*Phi123[ijk]*Phi301[ijk] -
+       4*invg03*invh13*Phi133[ijk]*Phi301[ijk] -
+       4*invg00*invh23*Phi203[ijk]*Phi301[ijk] -
+       4*invg01*invh23*Phi213[ijk]*Phi301[ijk] -
+       4*invg02*invh23*Phi223[ijk]*Phi301[ijk] -
+       4*invg03*invh23*Phi233[ijk]*Phi301[ijk] -
+       4*invg00*invh13*Phi101[ijk]*Phi303[ijk] -
+       4*invg01*invh13*Phi111[ijk]*Phi303[ijk] -
+       4*invg02*invh13*Phi112[ijk]*Phi303[ijk] -
+       4*invg03*invh13*Phi113[ijk]*Phi303[ijk] -
+       4*invg00*invh23*Phi201[ijk]*Phi303[ijk] -
+       4*invg01*invh23*Phi211[ijk]*Phi303[ijk] -
+       4*invg02*invh23*Phi212[ijk]*Phi303[ijk] -
+       4*invg03*invh23*Phi213[ijk]*Phi303[ijk] -
+       4*invg00*invh33*Phi301[ijk]*Phi303[ijk] -
+       4*invg01*invh13*Phi103[ijk]*Phi311[ijk] -
+       4*invg11*invh13*Phi113[ijk]*Phi311[ijk] -
+       4*invg12*invh13*Phi123[ijk]*Phi311[ijk] -
+       4*invg13*invh13*Phi133[ijk]*Phi311[ijk] -
+       4*invg01*invh23*Phi203[ijk]*Phi311[ijk] -
+       4*invg11*invh23*Phi213[ijk]*Phi311[ijk] -
+       4*invg12*invh23*Phi223[ijk]*Phi311[ijk] -
+       4*invg13*invh23*Phi233[ijk]*Phi311[ijk] -
+       4*invg01*invh33*Phi303[ijk]*Phi311[ijk] -
+       4*invg02*invh13*Phi103[ijk]*Phi312[ijk] -
+       4*invg12*invh13*Phi113[ijk]*Phi312[ijk] -
+       4*invg22*invh13*Phi123[ijk]*Phi312[ijk] -
+       4*invg23*invh13*Phi133[ijk]*Phi312[ijk] -
+       4*invg02*invh23*Phi203[ijk]*Phi312[ijk] -
+       4*invg12*invh23*Phi213[ijk]*Phi312[ijk] -
+       4*invg22*invh23*Phi223[ijk]*Phi312[ijk] -
+       4*invg23*invh23*Phi233[ijk]*Phi312[ijk] -
+       4*invg02*invh33*Phi303[ijk]*Phi312[ijk] -
+       4*invg01*invh13*Phi101[ijk]*Phi313[ijk] -
+       4*invg03*invh13*Phi103[ijk]*Phi313[ijk] -
+       4*invg11*invh13*Phi111[ijk]*Phi313[ijk] -
+       4*invg12*invh13*Phi112[ijk]*Phi313[ijk] -
+       8*invg13*invh13*Phi113[ijk]*Phi313[ijk] -
+       4*invg23*invh13*Phi123[ijk]*Phi313[ijk] -
+       4*invg33*invh13*Phi133[ijk]*Phi313[ijk] -
+       4*invg01*invh23*Phi201[ijk]*Phi313[ijk] -
+       4*invg03*invh23*Phi203[ijk]*Phi313[ijk] -
+       4*invg11*invh23*Phi211[ijk]*Phi313[ijk] -
+       4*invg12*invh23*Phi212[ijk]*Phi313[ijk] -
+       8*invg13*invh23*Phi213[ijk]*Phi313[ijk] -
+       4*invg23*invh23*Phi223[ijk]*Phi313[ijk] -
+       4*invg33*invh23*Phi233[ijk]*Phi313[ijk] -
+       4*invg01*invh33*Phi301[ijk]*Phi313[ijk] -
+       4*invg03*invh33*Phi303[ijk]*Phi313[ijk] -
+       4*invg11*invh33*Phi311[ijk]*Phi313[ijk] -
+       4*invg12*invh33*Phi312[ijk]*Phi313[ijk] -
+       4*invg13*invh33*Power(Phi313[ijk],2) -
+       4*invg02*invh13*Phi101[ijk]*Phi323[ijk] -
+       4*invg12*invh13*Phi111[ijk]*Phi323[ijk] -
+       4*invg22*invh13*Phi112[ijk]*Phi323[ijk] -
+       4*invg23*invh13*Phi113[ijk]*Phi323[ijk] -
+       4*invg02*invh23*Phi201[ijk]*Phi323[ijk] -
+       4*invg12*invh23*Phi211[ijk]*Phi323[ijk] -
+       4*invg22*invh23*Phi212[ijk]*Phi323[ijk] -
+       4*invg23*invh23*Phi213[ijk]*Phi323[ijk] -
+       4*invg02*invh33*Phi301[ijk]*Phi323[ijk] -
+       4*invg12*invh33*Phi311[ijk]*Phi323[ijk] -
+       4*invg22*invh33*Phi312[ijk]*Phi323[ijk] -
+       4*invg23*invh33*Phi313[ijk]*Phi323[ijk] -
+       4*invg03*invh13*Phi101[ijk]*Phi333[ijk] -
+       4*invg13*invh13*Phi111[ijk]*Phi333[ijk] -
+       4*invg23*invh13*Phi112[ijk]*Phi333[ijk] -
+       4*invg33*invh13*Phi113[ijk]*Phi333[ijk] -
+       4*invg03*invh23*Phi201[ijk]*Phi333[ijk] -
+       4*invg13*invh23*Phi211[ijk]*Phi333[ijk] -
+       4*invg23*invh23*Phi212[ijk]*Phi333[ijk] -
+       4*invg33*invh23*Phi213[ijk]*Phi333[ijk] -
+       4*invg03*invh33*Phi301[ijk]*Phi333[ijk] -
+       4*invg13*invh33*Phi311[ijk]*Phi333[ijk] -
+       4*invg23*invh33*Phi312[ijk]*Phi333[ijk] -
+       4*invg33*invh33*Phi313[ijk]*Phi333[ijk] +
+       2*invh11*nvec0*Phi113[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi213[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi313[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi113[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi213[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi313[ijk]*Pi02[ijk] +
+       2*invh13*nvec0*Phi113[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi213[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi313[ijk]*Pi03[ijk] +
+       4*invg00*Pi01[ijk]*Pi03[ijk] +
+       2*invh11*nvec1*Phi113[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi213[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi313[ijk]*Pi11[ijk] +
+       4*invg01*Pi03[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi113[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi113[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi213[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi213[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi313[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi313[ijk]*Pi12[ijk] +
+       4*invg02*Pi03[ijk]*Pi12[ijk] +
+       2*invh13*nvec1*Phi113[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi113[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi213[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi213[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi313[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi313[ijk]*Pi13[ijk] +
+       Power(nvec0,2)*Pi00[ijk]*Pi13[ijk] + 4*invg01*Pi01[ijk]*Pi13[ijk] +
+       2*nvec0*nvec1*Pi01[ijk]*Pi13[ijk] +
+       2*nvec0*nvec2*Pi02[ijk]*Pi13[ijk] + 4*invg03*Pi03[ijk]*Pi13[ijk] +
+       2*nvec0*nvec3*Pi03[ijk]*Pi13[ijk] + 4*invg11*Pi11[ijk]*Pi13[ijk] +
+       Power(nvec1,2)*Pi11[ijk]*Pi13[ijk] + 4*invg12*Pi12[ijk]*Pi13[ijk] +
+       2*nvec1*nvec2*Pi12[ijk]*Pi13[ijk] + 4*invg13*Power(Pi13[ijk],2) +
+       2*nvec1*nvec3*Power(Pi13[ijk],2) +
+       2*invh12*nvec2*Phi113[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi213[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi313[ijk]*Pi22[ijk] +
+       Power(nvec2,2)*Pi13[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi113[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi113[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi213[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi213[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi313[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi313[ijk]*Pi23[ijk] +
+       4*invg02*Pi01[ijk]*Pi23[ijk] + 4*invg12*Pi11[ijk]*Pi23[ijk] +
+       4*invg22*Pi12[ijk]*Pi23[ijk] + 4*invg23*Pi13[ijk]*Pi23[ijk] +
+       2*nvec2*nvec3*Pi13[ijk]*Pi23[ijk] +
+       2*invh13*nvec3*Phi113[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi213[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi313[ijk]*Pi33[ijk] +
+       4*invg03*Pi01[ijk]*Pi33[ijk] + 4*invg13*Pi11[ijk]*Pi33[ijk] +
+       4*invg23*Pi12[ijk]*Pi33[ijk] + 4*invg33*Pi13[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi13[ijk]*Pi33[ijk]) -
+    2*(gamma1*gamma2*beta1[ijk]*Phi113[ijk] +
+       gamma1*gamma2*beta2[ijk]*Phi213[ijk] +
+       gamma1*gamma2*beta3[ijk]*Phi313[ijk] + srcSdH13[ijk]))/2.
+;
+
+dtPi22[ijk]
+=
+-(interior*AdPi22[ijk]) - gamma1*gamma2*beta1[ijk]*Phi122[ijk] -
+  gamma1*gamma2*beta2[ijk]*Phi222[ijk] -
+  gamma1*gamma2*beta3[ijk]*Phi322[ijk] -
+  (alpha[ijk]*(4*Power(Gam200,2)*Power(invg00,2) +
+       16*Gam200*Gam201*invg00*invg01 +
+       8*Power(Gam201,2)*Power(invg01,2) +
+       8*Gam200*Gam211*Power(invg01,2) + 16*Gam200*Gam202*invg00*invg02 +
+       16*Gam201*Gam202*invg01*invg02 + 16*Gam200*Gam212*invg01*invg02 +
+       8*Power(Gam202,2)*Power(invg02,2) +
+       8*Gam200*Gam222*Power(invg02,2) + 16*Gam200*Gam203*invg00*invg03 +
+       16*Gam201*Gam203*invg01*invg03 + 16*Gam200*Gam213*invg01*invg03 +
+       16*Gam202*Gam203*invg02*invg03 + 16*Gam200*Gam223*invg02*invg03 +
+       8*Power(Gam203,2)*Power(invg03,2) +
+       8*Gam200*Gam233*Power(invg03,2) + 8*Power(Gam201,2)*invg00*invg11 +
+       16*Gam201*Gam211*invg01*invg11 + 16*Gam201*Gam212*invg02*invg11 +
+       16*Gam201*Gam213*invg03*invg11 +
+       4*Power(Gam211,2)*Power(invg11,2) +
+       16*Gam201*Gam202*invg00*invg12 + 16*Gam202*Gam211*invg01*invg12 +
+       16*Gam201*Gam212*invg01*invg12 + 16*Gam202*Gam212*invg02*invg12 +
+       16*Gam201*Gam222*invg02*invg12 + 16*Gam202*Gam213*invg03*invg12 +
+       16*Gam201*Gam223*invg03*invg12 + 16*Gam211*Gam212*invg11*invg12 +
+       8*Power(Gam212,2)*Power(invg12,2) +
+       8*Gam211*Gam222*Power(invg12,2) + 16*Gam201*Gam203*invg00*invg13 +
+       16*Gam203*Gam211*invg01*invg13 + 16*Gam201*Gam213*invg01*invg13 +
+       16*Gam203*Gam212*invg02*invg13 + 16*Gam201*Gam223*invg02*invg13 +
+       16*Gam203*Gam213*invg03*invg13 + 16*Gam201*Gam233*invg03*invg13 +
+       16*Gam211*Gam213*invg11*invg13 + 16*Gam212*Gam213*invg12*invg13 +
+       16*Gam211*Gam223*invg12*invg13 +
+       8*Power(Gam213,2)*Power(invg13,2) +
+       8*Gam211*Gam233*Power(invg13,2) + 8*Power(Gam202,2)*invg00*invg22 +
+       16*Gam202*Gam212*invg01*invg22 + 16*Gam202*Gam222*invg02*invg22 +
+       16*Gam202*Gam223*invg03*invg22 + 8*Power(Gam212,2)*invg11*invg22 +
+       16*Gam212*Gam222*invg12*invg22 + 16*Gam212*Gam223*invg13*invg22 +
+       4*Power(Gam222,2)*Power(invg22,2) +
+       16*Gam202*Gam203*invg00*invg23 + 16*Gam203*Gam212*invg01*invg23 +
+       16*Gam202*Gam213*invg01*invg23 + 16*Gam203*Gam222*invg02*invg23 +
+       16*Gam202*Gam223*invg02*invg23 + 16*Gam203*Gam223*invg03*invg23 +
+       16*Gam202*Gam233*invg03*invg23 + 16*Gam212*Gam213*invg11*invg23 +
+       16*Gam213*Gam222*invg12*invg23 + 16*Gam212*Gam223*invg12*invg23 +
+       16*Gam213*Gam223*invg13*invg23 + 16*Gam212*Gam233*invg13*invg23 +
+       16*Gam222*Gam223*invg22*invg23 +
+       8*Power(Gam223,2)*Power(invg23,2) +
+       8*Gam222*Gam233*Power(invg23,2) + 8*Power(Gam203,2)*invg00*invg33 +
+       16*Gam203*Gam213*invg01*invg33 + 16*Gam203*Gam223*invg02*invg33 +
+       16*Gam203*Gam233*invg03*invg33 + 8*Power(Gam213,2)*invg11*invg33 +
+       16*Gam213*Gam223*invg12*invg33 + 16*Gam213*Gam233*invg13*invg33 +
+       8*Power(Gam223,2)*invg22*invg33 + 16*Gam223*Gam233*invg23*invg33 +
+       4*Power(Gam233,2)*Power(invg33,2) - 4*gamma0*ndua2*trGam2 -
+       4*(Gam022*invg00 + Gam122*invg01 + Gam222*invg02 + Gam322*invg03)*
+        H0[ijk] - 4*Gam022*invg01*H1[ijk] - 4*Gam122*invg11*H1[ijk] -
+       4*Gam222*invg12*H1[ijk] - 4*Gam322*invg13*H1[ijk] -
+       4*Gam022*invg02*H2[ijk] - 4*Gam122*invg12*H2[ijk] -
+       4*Gam222*invg22*H2[ijk] - 4*Gam322*invg23*H2[ijk] -
+       4*gamma0*ndua2*H2[ijk] - 4*Gam022*invg03*H3[ijk] -
+       4*Gam122*invg13*H3[ijk] - 4*Gam222*invg23*H3[ijk] -
+       4*Gam322*invg33*H3[ijk] +
+       2*gamma0*g22[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Power(Phi102[ijk],2) -
+       8*invg01*invh11*Phi102[ijk]*Phi112[ijk] -
+       4*invg11*invh11*Power(Phi112[ijk],2) -
+       8*invg02*invh11*Phi102[ijk]*Phi122[ijk] -
+       8*invg12*invh11*Phi112[ijk]*Phi122[ijk] -
+       4*invg22*invh11*Power(Phi122[ijk],2) -
+       8*invg03*invh11*Phi102[ijk]*Phi123[ijk] -
+       8*invg13*invh11*Phi112[ijk]*Phi123[ijk] -
+       8*invg23*invh11*Phi122[ijk]*Phi123[ijk] -
+       4*invg33*invh11*Power(Phi123[ijk],2) -
+       8*invg00*invh12*Phi102[ijk]*Phi202[ijk] -
+       8*invg01*invh12*Phi112[ijk]*Phi202[ijk] -
+       8*invg02*invh12*Phi122[ijk]*Phi202[ijk] -
+       8*invg03*invh12*Phi123[ijk]*Phi202[ijk] -
+       4*invg00*invh22*Power(Phi202[ijk],2) -
+       8*invg01*invh12*Phi102[ijk]*Phi212[ijk] -
+       8*invg11*invh12*Phi112[ijk]*Phi212[ijk] -
+       8*invg12*invh12*Phi122[ijk]*Phi212[ijk] -
+       8*invg13*invh12*Phi123[ijk]*Phi212[ijk] -
+       8*invg01*invh22*Phi202[ijk]*Phi212[ijk] -
+       4*invg11*invh22*Power(Phi212[ijk],2) -
+       8*invg02*invh12*Phi102[ijk]*Phi222[ijk] -
+       8*invg12*invh12*Phi112[ijk]*Phi222[ijk] -
+       8*invg22*invh12*Phi122[ijk]*Phi222[ijk] -
+       8*invg23*invh12*Phi123[ijk]*Phi222[ijk] -
+       8*invg02*invh22*Phi202[ijk]*Phi222[ijk] -
+       8*invg12*invh22*Phi212[ijk]*Phi222[ijk] -
+       4*invg22*invh22*Power(Phi222[ijk],2) -
+       8*invg03*invh12*Phi102[ijk]*Phi223[ijk] -
+       8*invg13*invh12*Phi112[ijk]*Phi223[ijk] -
+       8*invg23*invh12*Phi122[ijk]*Phi223[ijk] -
+       8*invg33*invh12*Phi123[ijk]*Phi223[ijk] -
+       8*invg03*invh22*Phi202[ijk]*Phi223[ijk] -
+       8*invg13*invh22*Phi212[ijk]*Phi223[ijk] -
+       8*invg23*invh22*Phi222[ijk]*Phi223[ijk] -
+       4*invg33*invh22*Power(Phi223[ijk],2) -
+       8*invg00*invh13*Phi102[ijk]*Phi302[ijk] -
+       8*invg01*invh13*Phi112[ijk]*Phi302[ijk] -
+       8*invg02*invh13*Phi122[ijk]*Phi302[ijk] -
+       8*invg03*invh13*Phi123[ijk]*Phi302[ijk] -
+       8*invg00*invh23*Phi202[ijk]*Phi302[ijk] -
+       8*invg01*invh23*Phi212[ijk]*Phi302[ijk] -
+       8*invg02*invh23*Phi222[ijk]*Phi302[ijk] -
+       8*invg03*invh23*Phi223[ijk]*Phi302[ijk] -
+       4*invg00*invh33*Power(Phi302[ijk],2) -
+       8*invg01*invh13*Phi102[ijk]*Phi312[ijk] -
+       8*invg11*invh13*Phi112[ijk]*Phi312[ijk] -
+       8*invg12*invh13*Phi122[ijk]*Phi312[ijk] -
+       8*invg13*invh13*Phi123[ijk]*Phi312[ijk] -
+       8*invg01*invh23*Phi202[ijk]*Phi312[ijk] -
+       8*invg11*invh23*Phi212[ijk]*Phi312[ijk] -
+       8*invg12*invh23*Phi222[ijk]*Phi312[ijk] -
+       8*invg13*invh23*Phi223[ijk]*Phi312[ijk] -
+       8*invg01*invh33*Phi302[ijk]*Phi312[ijk] -
+       4*invg11*invh33*Power(Phi312[ijk],2) -
+       8*invg02*invh13*Phi102[ijk]*Phi322[ijk] -
+       8*invg12*invh13*Phi112[ijk]*Phi322[ijk] -
+       8*invg22*invh13*Phi122[ijk]*Phi322[ijk] -
+       8*invg23*invh13*Phi123[ijk]*Phi322[ijk] -
+       8*invg02*invh23*Phi202[ijk]*Phi322[ijk] -
+       8*invg12*invh23*Phi212[ijk]*Phi322[ijk] -
+       8*invg22*invh23*Phi222[ijk]*Phi322[ijk] -
+       8*invg23*invh23*Phi223[ijk]*Phi322[ijk] -
+       8*invg02*invh33*Phi302[ijk]*Phi322[ijk] -
+       8*invg12*invh33*Phi312[ijk]*Phi322[ijk] -
+       4*invg22*invh33*Power(Phi322[ijk],2) -
+       8*invg03*invh13*Phi102[ijk]*Phi323[ijk] -
+       8*invg13*invh13*Phi112[ijk]*Phi323[ijk] -
+       8*invg23*invh13*Phi122[ijk]*Phi323[ijk] -
+       8*invg33*invh13*Phi123[ijk]*Phi323[ijk] -
+       8*invg03*invh23*Phi202[ijk]*Phi323[ijk] -
+       8*invg13*invh23*Phi212[ijk]*Phi323[ijk] -
+       8*invg23*invh23*Phi222[ijk]*Phi323[ijk] -
+       8*invg33*invh23*Phi223[ijk]*Phi323[ijk] -
+       8*invg03*invh33*Phi302[ijk]*Phi323[ijk] -
+       8*invg13*invh33*Phi312[ijk]*Phi323[ijk] -
+       8*invg23*invh33*Phi322[ijk]*Phi323[ijk] -
+       4*invg33*invh33*Power(Phi323[ijk],2) +
+       2*invh11*nvec0*Phi122[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi222[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi322[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi122[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi222[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi322[ijk]*Pi02[ijk] +
+       4*invg00*Power(Pi02[ijk],2) +
+       2*invh13*nvec0*Phi122[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi222[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi322[ijk]*Pi03[ijk] +
+       2*invh11*nvec1*Phi122[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi222[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi322[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi122[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi122[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi222[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi222[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi322[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi322[ijk]*Pi12[ijk] +
+       8*invg01*Pi02[ijk]*Pi12[ijk] + 4*invg11*Power(Pi12[ijk],2) +
+       2*invh13*nvec1*Phi122[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi122[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi222[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi222[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi322[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi322[ijk]*Pi13[ijk] +
+       2*invh12*nvec2*Phi122[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi222[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi322[ijk]*Pi22[ijk] +
+       Power(nvec0,2)*Pi00[ijk]*Pi22[ijk] +
+       2*nvec0*nvec1*Pi01[ijk]*Pi22[ijk] + 8*invg02*Pi02[ijk]*Pi22[ijk] +
+       2*nvec0*nvec2*Pi02[ijk]*Pi22[ijk] +
+       2*nvec0*nvec3*Pi03[ijk]*Pi22[ijk] +
+       Power(nvec1,2)*Pi11[ijk]*Pi22[ijk] + 8*invg12*Pi12[ijk]*Pi22[ijk] +
+       2*nvec1*nvec2*Pi12[ijk]*Pi22[ijk] +
+       2*nvec1*nvec3*Pi13[ijk]*Pi22[ijk] + 4*invg22*Power(Pi22[ijk],2) +
+       Power(nvec2,2)*Power(Pi22[ijk],2) +
+       2*invh13*nvec2*Phi122[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi122[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi222[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi222[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi322[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi322[ijk]*Pi23[ijk] +
+       8*invg03*Pi02[ijk]*Pi23[ijk] + 8*invg13*Pi12[ijk]*Pi23[ijk] +
+       8*invg23*Pi22[ijk]*Pi23[ijk] + 2*nvec2*nvec3*Pi22[ijk]*Pi23[ijk] +
+       4*invg33*Power(Pi23[ijk],2) +
+       2*invh13*nvec3*Phi122[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi222[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi322[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi22[ijk]*Pi33[ijk]))/2. - srcSdH22[ijk]
+;
+
+dtPi23[ijk]
+=
+(-2*interior*AdPi23[ijk] - alpha[ijk]*
+     (4*Gam200*Gam300*Power(invg00,2) + 8*Gam201*Gam300*invg00*invg01 +
+       8*Gam200*Gam301*invg00*invg01 + 4*Gam211*Gam300*Power(invg01,2) +
+       8*Gam201*Gam301*Power(invg01,2) + 4*Gam200*Gam311*Power(invg01,2) +
+       8*Gam202*Gam300*invg00*invg02 + 8*Gam200*Gam302*invg00*invg02 +
+       8*Gam212*Gam300*invg01*invg02 + 8*Gam202*Gam301*invg01*invg02 +
+       8*Gam201*Gam302*invg01*invg02 + 8*Gam200*Gam312*invg01*invg02 +
+       4*Gam222*Gam300*Power(invg02,2) + 8*Gam202*Gam302*Power(invg02,2) +
+       4*Gam200*Gam322*Power(invg02,2) + 8*Gam203*Gam300*invg00*invg03 +
+       8*Gam200*Gam303*invg00*invg03 + 8*Gam213*Gam300*invg01*invg03 +
+       8*Gam203*Gam301*invg01*invg03 + 8*Gam201*Gam303*invg01*invg03 +
+       8*Gam200*Gam313*invg01*invg03 + 8*Gam223*Gam300*invg02*invg03 +
+       8*Gam203*Gam302*invg02*invg03 + 8*Gam202*Gam303*invg02*invg03 +
+       8*Gam200*Gam323*invg02*invg03 + 4*Gam233*Gam300*Power(invg03,2) +
+       8*Gam203*Gam303*Power(invg03,2) + 4*Gam200*Gam333*Power(invg03,2) +
+       8*Gam201*Gam301*invg00*invg11 + 8*Gam211*Gam301*invg01*invg11 +
+       8*Gam201*Gam311*invg01*invg11 + 8*Gam212*Gam301*invg02*invg11 +
+       8*Gam201*Gam312*invg02*invg11 + 8*Gam213*Gam301*invg03*invg11 +
+       8*Gam201*Gam313*invg03*invg11 + 4*Gam211*Gam311*Power(invg11,2) +
+       8*Gam202*Gam301*invg00*invg12 + 8*Gam201*Gam302*invg00*invg12 +
+       8*Gam212*Gam301*invg01*invg12 + 8*Gam211*Gam302*invg01*invg12 +
+       8*Gam202*Gam311*invg01*invg12 + 8*Gam201*Gam312*invg01*invg12 +
+       8*Gam222*Gam301*invg02*invg12 + 8*Gam212*Gam302*invg02*invg12 +
+       8*Gam202*Gam312*invg02*invg12 + 8*Gam201*Gam322*invg02*invg12 +
+       8*Gam223*Gam301*invg03*invg12 + 8*Gam213*Gam302*invg03*invg12 +
+       8*Gam202*Gam313*invg03*invg12 + 8*Gam201*Gam323*invg03*invg12 +
+       8*Gam212*Gam311*invg11*invg12 + 8*Gam211*Gam312*invg11*invg12 +
+       4*Gam222*Gam311*Power(invg12,2) + 8*Gam212*Gam312*Power(invg12,2) +
+       4*Gam211*Gam322*Power(invg12,2) + 8*Gam203*Gam301*invg00*invg13 +
+       8*Gam201*Gam303*invg00*invg13 + 8*Gam213*Gam301*invg01*invg13 +
+       8*Gam211*Gam303*invg01*invg13 + 8*Gam203*Gam311*invg01*invg13 +
+       8*Gam201*Gam313*invg01*invg13 + 8*Gam223*Gam301*invg02*invg13 +
+       8*Gam212*Gam303*invg02*invg13 + 8*Gam203*Gam312*invg02*invg13 +
+       8*Gam201*Gam323*invg02*invg13 + 8*Gam233*Gam301*invg03*invg13 +
+       8*Gam213*Gam303*invg03*invg13 + 8*Gam203*Gam313*invg03*invg13 +
+       8*Gam201*Gam333*invg03*invg13 + 8*Gam213*Gam311*invg11*invg13 +
+       8*Gam211*Gam313*invg11*invg13 + 8*Gam223*Gam311*invg12*invg13 +
+       8*Gam213*Gam312*invg12*invg13 + 8*Gam212*Gam313*invg12*invg13 +
+       8*Gam211*Gam323*invg12*invg13 + 4*Gam233*Gam311*Power(invg13,2) +
+       8*Gam213*Gam313*Power(invg13,2) + 4*Gam211*Gam333*Power(invg13,2) +
+       8*Gam202*Gam302*invg00*invg22 + 8*Gam212*Gam302*invg01*invg22 +
+       8*Gam202*Gam312*invg01*invg22 + 8*Gam222*Gam302*invg02*invg22 +
+       8*Gam202*Gam322*invg02*invg22 + 8*Gam223*Gam302*invg03*invg22 +
+       8*Gam202*Gam323*invg03*invg22 + 8*Gam212*Gam312*invg11*invg22 +
+       8*Gam222*Gam312*invg12*invg22 + 8*Gam212*Gam322*invg12*invg22 +
+       8*Gam223*Gam312*invg13*invg22 + 8*Gam212*Gam323*invg13*invg22 +
+       4*Gam222*Gam322*Power(invg22,2) + 8*Gam203*Gam302*invg00*invg23 +
+       8*Gam202*Gam303*invg00*invg23 + 8*Gam213*Gam302*invg01*invg23 +
+       8*Gam212*Gam303*invg01*invg23 + 8*Gam203*Gam312*invg01*invg23 +
+       8*Gam202*Gam313*invg01*invg23 + 8*Gam223*Gam302*invg02*invg23 +
+       8*Gam222*Gam303*invg02*invg23 + 8*Gam203*Gam322*invg02*invg23 +
+       8*Gam202*Gam323*invg02*invg23 + 8*Gam233*Gam302*invg03*invg23 +
+       8*Gam223*Gam303*invg03*invg23 + 8*Gam203*Gam323*invg03*invg23 +
+       8*Gam202*Gam333*invg03*invg23 + 8*Gam213*Gam312*invg11*invg23 +
+       8*Gam212*Gam313*invg11*invg23 + 8*Gam223*Gam312*invg12*invg23 +
+       8*Gam222*Gam313*invg12*invg23 + 8*Gam213*Gam322*invg12*invg23 +
+       8*Gam212*Gam323*invg12*invg23 + 8*Gam233*Gam312*invg13*invg23 +
+       8*Gam223*Gam313*invg13*invg23 + 8*Gam213*Gam323*invg13*invg23 +
+       8*Gam212*Gam333*invg13*invg23 + 8*Gam223*Gam322*invg22*invg23 +
+       8*Gam222*Gam323*invg22*invg23 + 4*Gam233*Gam322*Power(invg23,2) +
+       8*Gam223*Gam323*Power(invg23,2) + 4*Gam222*Gam333*Power(invg23,2) +
+       8*Gam203*Gam303*invg00*invg33 + 8*Gam213*Gam303*invg01*invg33 +
+       8*Gam203*Gam313*invg01*invg33 + 8*Gam223*Gam303*invg02*invg33 +
+       8*Gam203*Gam323*invg02*invg33 + 8*Gam233*Gam303*invg03*invg33 +
+       8*Gam203*Gam333*invg03*invg33 + 8*Gam213*Gam313*invg11*invg33 +
+       8*Gam223*Gam313*invg12*invg33 + 8*Gam213*Gam323*invg12*invg33 +
+       8*Gam233*Gam313*invg13*invg33 + 8*Gam213*Gam333*invg13*invg33 +
+       8*Gam223*Gam323*invg22*invg33 + 8*Gam233*Gam323*invg23*invg33 +
+       8*Gam223*Gam333*invg23*invg33 + 4*Gam233*Gam333*Power(invg33,2) -
+       2*gamma0*ndua3*trGam2 - 2*gamma0*ndua2*trGam3 -
+       4*(Gam023*invg00 + Gam123*invg01 + Gam223*invg02 + Gam323*invg03)*
+        H0[ijk] - 4*Gam023*invg01*H1[ijk] - 4*Gam123*invg11*H1[ijk] -
+       4*Gam223*invg12*H1[ijk] - 4*Gam323*invg13*H1[ijk] -
+       4*Gam023*invg02*H2[ijk] - 4*Gam123*invg12*H2[ijk] -
+       4*Gam223*invg22*H2[ijk] - 4*Gam323*invg23*H2[ijk] -
+       2*gamma0*ndua3*H2[ijk] - 4*Gam023*invg03*H3[ijk] -
+       4*Gam123*invg13*H3[ijk] - 4*Gam223*invg23*H3[ijk] -
+       4*Gam323*invg33*H3[ijk] - 2*gamma0*ndua2*H3[ijk] +
+       2*gamma0*g23[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Phi102[ijk]*Phi103[ijk] -
+       4*invg01*invh11*Phi103[ijk]*Phi112[ijk] -
+       4*invg01*invh11*Phi102[ijk]*Phi113[ijk] -
+       4*invg11*invh11*Phi112[ijk]*Phi113[ijk] -
+       4*invg02*invh11*Phi103[ijk]*Phi122[ijk] -
+       4*invg12*invh11*Phi113[ijk]*Phi122[ijk] -
+       4*invg02*invh11*Phi102[ijk]*Phi123[ijk] -
+       4*invg03*invh11*Phi103[ijk]*Phi123[ijk] -
+       4*invg12*invh11*Phi112[ijk]*Phi123[ijk] -
+       4*invg13*invh11*Phi113[ijk]*Phi123[ijk] -
+       4*invg22*invh11*Phi122[ijk]*Phi123[ijk] -
+       4*invg23*invh11*Power(Phi123[ijk],2) -
+       4*invg03*invh11*Phi102[ijk]*Phi133[ijk] -
+       4*invg13*invh11*Phi112[ijk]*Phi133[ijk] -
+       4*invg23*invh11*Phi122[ijk]*Phi133[ijk] -
+       4*invg33*invh11*Phi123[ijk]*Phi133[ijk] -
+       4*invg00*invh12*Phi103[ijk]*Phi202[ijk] -
+       4*invg01*invh12*Phi113[ijk]*Phi202[ijk] -
+       4*invg02*invh12*Phi123[ijk]*Phi202[ijk] -
+       4*invg03*invh12*Phi133[ijk]*Phi202[ijk] -
+       4*invg00*invh12*Phi102[ijk]*Phi203[ijk] -
+       4*invg01*invh12*Phi112[ijk]*Phi203[ijk] -
+       4*invg02*invh12*Phi122[ijk]*Phi203[ijk] -
+       4*invg03*invh12*Phi123[ijk]*Phi203[ijk] -
+       4*invg00*invh22*Phi202[ijk]*Phi203[ijk] -
+       4*invg01*invh12*Phi103[ijk]*Phi212[ijk] -
+       4*invg11*invh12*Phi113[ijk]*Phi212[ijk] -
+       4*invg12*invh12*Phi123[ijk]*Phi212[ijk] -
+       4*invg13*invh12*Phi133[ijk]*Phi212[ijk] -
+       4*invg01*invh22*Phi203[ijk]*Phi212[ijk] -
+       4*invg01*invh12*Phi102[ijk]*Phi213[ijk] -
+       4*invg11*invh12*Phi112[ijk]*Phi213[ijk] -
+       4*invg12*invh12*Phi122[ijk]*Phi213[ijk] -
+       4*invg13*invh12*Phi123[ijk]*Phi213[ijk] -
+       4*invg01*invh22*Phi202[ijk]*Phi213[ijk] -
+       4*invg11*invh22*Phi212[ijk]*Phi213[ijk] -
+       4*invg02*invh12*Phi103[ijk]*Phi222[ijk] -
+       4*invg12*invh12*Phi113[ijk]*Phi222[ijk] -
+       4*invg22*invh12*Phi123[ijk]*Phi222[ijk] -
+       4*invg23*invh12*Phi133[ijk]*Phi222[ijk] -
+       4*invg02*invh22*Phi203[ijk]*Phi222[ijk] -
+       4*invg12*invh22*Phi213[ijk]*Phi222[ijk] -
+       4*invg02*invh12*Phi102[ijk]*Phi223[ijk] -
+       4*invg03*invh12*Phi103[ijk]*Phi223[ijk] -
+       4*invg12*invh12*Phi112[ijk]*Phi223[ijk] -
+       4*invg13*invh12*Phi113[ijk]*Phi223[ijk] -
+       4*invg22*invh12*Phi122[ijk]*Phi223[ijk] -
+       8*invg23*invh12*Phi123[ijk]*Phi223[ijk] -
+       4*invg33*invh12*Phi133[ijk]*Phi223[ijk] -
+       4*invg02*invh22*Phi202[ijk]*Phi223[ijk] -
+       4*invg03*invh22*Phi203[ijk]*Phi223[ijk] -
+       4*invg12*invh22*Phi212[ijk]*Phi223[ijk] -
+       4*invg13*invh22*Phi213[ijk]*Phi223[ijk] -
+       4*invg22*invh22*Phi222[ijk]*Phi223[ijk] -
+       4*invg23*invh22*Power(Phi223[ijk],2) -
+       4*invg03*invh12*Phi102[ijk]*Phi233[ijk] -
+       4*invg13*invh12*Phi112[ijk]*Phi233[ijk] -
+       4*invg23*invh12*Phi122[ijk]*Phi233[ijk] -
+       4*invg33*invh12*Phi123[ijk]*Phi233[ijk] -
+       4*invg03*invh22*Phi202[ijk]*Phi233[ijk] -
+       4*invg13*invh22*Phi212[ijk]*Phi233[ijk] -
+       4*invg23*invh22*Phi222[ijk]*Phi233[ijk] -
+       4*invg33*invh22*Phi223[ijk]*Phi233[ijk] -
+       4*invg00*invh13*Phi103[ijk]*Phi302[ijk] -
+       4*invg01*invh13*Phi113[ijk]*Phi302[ijk] -
+       4*invg02*invh13*Phi123[ijk]*Phi302[ijk] -
+       4*invg03*invh13*Phi133[ijk]*Phi302[ijk] -
+       4*invg00*invh23*Phi203[ijk]*Phi302[ijk] -
+       4*invg01*invh23*Phi213[ijk]*Phi302[ijk] -
+       4*invg02*invh23*Phi223[ijk]*Phi302[ijk] -
+       4*invg03*invh23*Phi233[ijk]*Phi302[ijk] -
+       4*invg00*invh13*Phi102[ijk]*Phi303[ijk] -
+       4*invg01*invh13*Phi112[ijk]*Phi303[ijk] -
+       4*invg02*invh13*Phi122[ijk]*Phi303[ijk] -
+       4*invg03*invh13*Phi123[ijk]*Phi303[ijk] -
+       4*invg00*invh23*Phi202[ijk]*Phi303[ijk] -
+       4*invg01*invh23*Phi212[ijk]*Phi303[ijk] -
+       4*invg02*invh23*Phi222[ijk]*Phi303[ijk] -
+       4*invg03*invh23*Phi223[ijk]*Phi303[ijk] -
+       4*invg00*invh33*Phi302[ijk]*Phi303[ijk] -
+       4*invg01*invh13*Phi103[ijk]*Phi312[ijk] -
+       4*invg11*invh13*Phi113[ijk]*Phi312[ijk] -
+       4*invg12*invh13*Phi123[ijk]*Phi312[ijk] -
+       4*invg13*invh13*Phi133[ijk]*Phi312[ijk] -
+       4*invg01*invh23*Phi203[ijk]*Phi312[ijk] -
+       4*invg11*invh23*Phi213[ijk]*Phi312[ijk] -
+       4*invg12*invh23*Phi223[ijk]*Phi312[ijk] -
+       4*invg13*invh23*Phi233[ijk]*Phi312[ijk] -
+       4*invg01*invh33*Phi303[ijk]*Phi312[ijk] -
+       4*invg01*invh13*Phi102[ijk]*Phi313[ijk] -
+       4*invg11*invh13*Phi112[ijk]*Phi313[ijk] -
+       4*invg12*invh13*Phi122[ijk]*Phi313[ijk] -
+       4*invg13*invh13*Phi123[ijk]*Phi313[ijk] -
+       4*invg01*invh23*Phi202[ijk]*Phi313[ijk] -
+       4*invg11*invh23*Phi212[ijk]*Phi313[ijk] -
+       4*invg12*invh23*Phi222[ijk]*Phi313[ijk] -
+       4*invg13*invh23*Phi223[ijk]*Phi313[ijk] -
+       4*invg01*invh33*Phi302[ijk]*Phi313[ijk] -
+       4*invg11*invh33*Phi312[ijk]*Phi313[ijk] -
+       4*invg02*invh13*Phi103[ijk]*Phi322[ijk] -
+       4*invg12*invh13*Phi113[ijk]*Phi322[ijk] -
+       4*invg22*invh13*Phi123[ijk]*Phi322[ijk] -
+       4*invg23*invh13*Phi133[ijk]*Phi322[ijk] -
+       4*invg02*invh23*Phi203[ijk]*Phi322[ijk] -
+       4*invg12*invh23*Phi213[ijk]*Phi322[ijk] -
+       4*invg22*invh23*Phi223[ijk]*Phi322[ijk] -
+       4*invg23*invh23*Phi233[ijk]*Phi322[ijk] -
+       4*invg02*invh33*Phi303[ijk]*Phi322[ijk] -
+       4*invg12*invh33*Phi313[ijk]*Phi322[ijk] -
+       4*invg02*invh13*Phi102[ijk]*Phi323[ijk] -
+       4*invg03*invh13*Phi103[ijk]*Phi323[ijk] -
+       4*invg12*invh13*Phi112[ijk]*Phi323[ijk] -
+       4*invg13*invh13*Phi113[ijk]*Phi323[ijk] -
+       4*invg22*invh13*Phi122[ijk]*Phi323[ijk] -
+       8*invg23*invh13*Phi123[ijk]*Phi323[ijk] -
+       4*invg33*invh13*Phi133[ijk]*Phi323[ijk] -
+       4*invg02*invh23*Phi202[ijk]*Phi323[ijk] -
+       4*invg03*invh23*Phi203[ijk]*Phi323[ijk] -
+       4*invg12*invh23*Phi212[ijk]*Phi323[ijk] -
+       4*invg13*invh23*Phi213[ijk]*Phi323[ijk] -
+       4*invg22*invh23*Phi222[ijk]*Phi323[ijk] -
+       8*invg23*invh23*Phi223[ijk]*Phi323[ijk] -
+       4*invg33*invh23*Phi233[ijk]*Phi323[ijk] -
+       4*invg02*invh33*Phi302[ijk]*Phi323[ijk] -
+       4*invg03*invh33*Phi303[ijk]*Phi323[ijk] -
+       4*invg12*invh33*Phi312[ijk]*Phi323[ijk] -
+       4*invg13*invh33*Phi313[ijk]*Phi323[ijk] -
+       4*invg22*invh33*Phi322[ijk]*Phi323[ijk] -
+       4*invg23*invh33*Power(Phi323[ijk],2) -
+       4*invg03*invh13*Phi102[ijk]*Phi333[ijk] -
+       4*invg13*invh13*Phi112[ijk]*Phi333[ijk] -
+       4*invg23*invh13*Phi122[ijk]*Phi333[ijk] -
+       4*invg33*invh13*Phi123[ijk]*Phi333[ijk] -
+       4*invg03*invh23*Phi202[ijk]*Phi333[ijk] -
+       4*invg13*invh23*Phi212[ijk]*Phi333[ijk] -
+       4*invg23*invh23*Phi222[ijk]*Phi333[ijk] -
+       4*invg33*invh23*Phi223[ijk]*Phi333[ijk] -
+       4*invg03*invh33*Phi302[ijk]*Phi333[ijk] -
+       4*invg13*invh33*Phi312[ijk]*Phi333[ijk] -
+       4*invg23*invh33*Phi322[ijk]*Phi333[ijk] -
+       4*invg33*invh33*Phi323[ijk]*Phi333[ijk] +
+       2*invh11*nvec0*Phi123[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi223[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi323[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi123[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi223[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi323[ijk]*Pi02[ijk] +
+       2*invh13*nvec0*Phi123[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi223[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi323[ijk]*Pi03[ijk] +
+       4*invg00*Pi02[ijk]*Pi03[ijk] +
+       2*invh11*nvec1*Phi123[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi223[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi323[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi123[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi123[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi223[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi223[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi323[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi323[ijk]*Pi12[ijk] +
+       4*invg01*Pi03[ijk]*Pi12[ijk] +
+       2*invh13*nvec1*Phi123[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi123[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi223[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi223[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi323[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi323[ijk]*Pi13[ijk] +
+       4*invg01*Pi02[ijk]*Pi13[ijk] + 4*invg11*Pi12[ijk]*Pi13[ijk] +
+       2*invh12*nvec2*Phi123[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi223[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi323[ijk]*Pi22[ijk] +
+       4*invg02*Pi03[ijk]*Pi22[ijk] + 4*invg12*Pi13[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi123[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi123[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi223[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi223[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi323[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi323[ijk]*Pi23[ijk] +
+       Power(nvec0,2)*Pi00[ijk]*Pi23[ijk] +
+       2*nvec0*nvec1*Pi01[ijk]*Pi23[ijk] + 4*invg02*Pi02[ijk]*Pi23[ijk] +
+       2*nvec0*nvec2*Pi02[ijk]*Pi23[ijk] + 4*invg03*Pi03[ijk]*Pi23[ijk] +
+       2*nvec0*nvec3*Pi03[ijk]*Pi23[ijk] +
+       Power(nvec1,2)*Pi11[ijk]*Pi23[ijk] + 4*invg12*Pi12[ijk]*Pi23[ijk] +
+       2*nvec1*nvec2*Pi12[ijk]*Pi23[ijk] + 4*invg13*Pi13[ijk]*Pi23[ijk] +
+       2*nvec1*nvec3*Pi13[ijk]*Pi23[ijk] + 4*invg22*Pi22[ijk]*Pi23[ijk] +
+       Power(nvec2,2)*Pi22[ijk]*Pi23[ijk] + 4*invg23*Power(Pi23[ijk],2) +
+       2*nvec2*nvec3*Power(Pi23[ijk],2) +
+       2*invh13*nvec3*Phi123[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi223[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi323[ijk]*Pi33[ijk] +
+       4*invg03*Pi02[ijk]*Pi33[ijk] + 4*invg13*Pi12[ijk]*Pi33[ijk] +
+       4*invg23*Pi22[ijk]*Pi33[ijk] + 4*invg33*Pi23[ijk]*Pi33[ijk] +
+       Power(nvec3,2)*Pi23[ijk]*Pi33[ijk]) -
+    2*(gamma1*gamma2*beta1[ijk]*Phi123[ijk] +
+       gamma1*gamma2*beta2[ijk]*Phi223[ijk] +
+       gamma1*gamma2*beta3[ijk]*Phi323[ijk] + srcSdH23[ijk]))/2.
+;
+
+dtPi33[ijk]
+=
+-(interior*AdPi33[ijk]) - gamma1*gamma2*beta1[ijk]*Phi133[ijk] -
+  gamma1*gamma2*beta2[ijk]*Phi233[ijk] -
+  gamma1*gamma2*beta3[ijk]*Phi333[ijk] -
+  (alpha[ijk]*(4*Power(Gam300,2)*Power(invg00,2) +
+       16*Gam300*Gam301*invg00*invg01 +
+       8*Power(Gam301,2)*Power(invg01,2) +
+       8*Gam300*Gam311*Power(invg01,2) + 16*Gam300*Gam302*invg00*invg02 +
+       16*Gam301*Gam302*invg01*invg02 + 16*Gam300*Gam312*invg01*invg02 +
+       8*Power(Gam302,2)*Power(invg02,2) +
+       8*Gam300*Gam322*Power(invg02,2) + 16*Gam300*Gam303*invg00*invg03 +
+       16*Gam301*Gam303*invg01*invg03 + 16*Gam300*Gam313*invg01*invg03 +
+       16*Gam302*Gam303*invg02*invg03 + 16*Gam300*Gam323*invg02*invg03 +
+       8*Power(Gam303,2)*Power(invg03,2) +
+       8*Gam300*Gam333*Power(invg03,2) + 8*Power(Gam301,2)*invg00*invg11 +
+       16*Gam301*Gam311*invg01*invg11 + 16*Gam301*Gam312*invg02*invg11 +
+       16*Gam301*Gam313*invg03*invg11 +
+       4*Power(Gam311,2)*Power(invg11,2) +
+       16*Gam301*Gam302*invg00*invg12 + 16*Gam302*Gam311*invg01*invg12 +
+       16*Gam301*Gam312*invg01*invg12 + 16*Gam302*Gam312*invg02*invg12 +
+       16*Gam301*Gam322*invg02*invg12 + 16*Gam302*Gam313*invg03*invg12 +
+       16*Gam301*Gam323*invg03*invg12 + 16*Gam311*Gam312*invg11*invg12 +
+       8*Power(Gam312,2)*Power(invg12,2) +
+       8*Gam311*Gam322*Power(invg12,2) + 16*Gam301*Gam303*invg00*invg13 +
+       16*Gam303*Gam311*invg01*invg13 + 16*Gam301*Gam313*invg01*invg13 +
+       16*Gam303*Gam312*invg02*invg13 + 16*Gam301*Gam323*invg02*invg13 +
+       16*Gam303*Gam313*invg03*invg13 + 16*Gam301*Gam333*invg03*invg13 +
+       16*Gam311*Gam313*invg11*invg13 + 16*Gam312*Gam313*invg12*invg13 +
+       16*Gam311*Gam323*invg12*invg13 +
+       8*Power(Gam313,2)*Power(invg13,2) +
+       8*Gam311*Gam333*Power(invg13,2) + 8*Power(Gam302,2)*invg00*invg22 +
+       16*Gam302*Gam312*invg01*invg22 + 16*Gam302*Gam322*invg02*invg22 +
+       16*Gam302*Gam323*invg03*invg22 + 8*Power(Gam312,2)*invg11*invg22 +
+       16*Gam312*Gam322*invg12*invg22 + 16*Gam312*Gam323*invg13*invg22 +
+       4*Power(Gam322,2)*Power(invg22,2) +
+       16*Gam302*Gam303*invg00*invg23 + 16*Gam303*Gam312*invg01*invg23 +
+       16*Gam302*Gam313*invg01*invg23 + 16*Gam303*Gam322*invg02*invg23 +
+       16*Gam302*Gam323*invg02*invg23 + 16*Gam303*Gam323*invg03*invg23 +
+       16*Gam302*Gam333*invg03*invg23 + 16*Gam312*Gam313*invg11*invg23 +
+       16*Gam313*Gam322*invg12*invg23 + 16*Gam312*Gam323*invg12*invg23 +
+       16*Gam313*Gam323*invg13*invg23 + 16*Gam312*Gam333*invg13*invg23 +
+       16*Gam322*Gam323*invg22*invg23 +
+       8*Power(Gam323,2)*Power(invg23,2) +
+       8*Gam322*Gam333*Power(invg23,2) + 8*Power(Gam303,2)*invg00*invg33 +
+       16*Gam303*Gam313*invg01*invg33 + 16*Gam303*Gam323*invg02*invg33 +
+       16*Gam303*Gam333*invg03*invg33 + 8*Power(Gam313,2)*invg11*invg33 +
+       16*Gam313*Gam323*invg12*invg33 + 16*Gam313*Gam333*invg13*invg33 +
+       8*Power(Gam323,2)*invg22*invg33 + 16*Gam323*Gam333*invg23*invg33 +
+       4*Power(Gam333,2)*Power(invg33,2) - 4*gamma0*ndua3*trGam3 -
+       4*(Gam033*invg00 + Gam133*invg01 + Gam233*invg02 + Gam333*invg03)*
+        H0[ijk] - 4*Gam033*invg01*H1[ijk] - 4*Gam133*invg11*H1[ijk] -
+       4*Gam233*invg12*H1[ijk] - 4*Gam333*invg13*H1[ijk] -
+       4*Gam033*invg02*H2[ijk] - 4*Gam133*invg12*H2[ijk] -
+       4*Gam233*invg22*H2[ijk] - 4*Gam333*invg23*H2[ijk] -
+       4*Gam033*invg03*H3[ijk] - 4*Gam133*invg13*H3[ijk] -
+       4*Gam233*invg23*H3[ijk] - 4*Gam333*invg33*H3[ijk] -
+       4*gamma0*ndua3*H3[ijk] +
+       2*gamma0*g33[ijk]*(nvec0*trGam0 + nvec1*trGam1 + nvec2*trGam2 +
+          nvec3*trGam3 + nvec0*H0[ijk] + nvec1*H1[ijk] + nvec2*H2[ijk] +
+          nvec3*H3[ijk]) - 4*invg00*invh11*Power(Phi103[ijk],2) -
+       8*invg01*invh11*Phi103[ijk]*Phi113[ijk] -
+       4*invg11*invh11*Power(Phi113[ijk],2) -
+       8*invg02*invh11*Phi103[ijk]*Phi123[ijk] -
+       8*invg12*invh11*Phi113[ijk]*Phi123[ijk] -
+       4*invg22*invh11*Power(Phi123[ijk],2) -
+       8*invg03*invh11*Phi103[ijk]*Phi133[ijk] -
+       8*invg13*invh11*Phi113[ijk]*Phi133[ijk] -
+       8*invg23*invh11*Phi123[ijk]*Phi133[ijk] -
+       4*invg33*invh11*Power(Phi133[ijk],2) -
+       8*invg00*invh12*Phi103[ijk]*Phi203[ijk] -
+       8*invg01*invh12*Phi113[ijk]*Phi203[ijk] -
+       8*invg02*invh12*Phi123[ijk]*Phi203[ijk] -
+       8*invg03*invh12*Phi133[ijk]*Phi203[ijk] -
+       4*invg00*invh22*Power(Phi203[ijk],2) -
+       8*invg01*invh12*Phi103[ijk]*Phi213[ijk] -
+       8*invg11*invh12*Phi113[ijk]*Phi213[ijk] -
+       8*invg12*invh12*Phi123[ijk]*Phi213[ijk] -
+       8*invg13*invh12*Phi133[ijk]*Phi213[ijk] -
+       8*invg01*invh22*Phi203[ijk]*Phi213[ijk] -
+       4*invg11*invh22*Power(Phi213[ijk],2) -
+       8*invg02*invh12*Phi103[ijk]*Phi223[ijk] -
+       8*invg12*invh12*Phi113[ijk]*Phi223[ijk] -
+       8*invg22*invh12*Phi123[ijk]*Phi223[ijk] -
+       8*invg23*invh12*Phi133[ijk]*Phi223[ijk] -
+       8*invg02*invh22*Phi203[ijk]*Phi223[ijk] -
+       8*invg12*invh22*Phi213[ijk]*Phi223[ijk] -
+       4*invg22*invh22*Power(Phi223[ijk],2) -
+       8*invg03*invh12*Phi103[ijk]*Phi233[ijk] -
+       8*invg13*invh12*Phi113[ijk]*Phi233[ijk] -
+       8*invg23*invh12*Phi123[ijk]*Phi233[ijk] -
+       8*invg33*invh12*Phi133[ijk]*Phi233[ijk] -
+       8*invg03*invh22*Phi203[ijk]*Phi233[ijk] -
+       8*invg13*invh22*Phi213[ijk]*Phi233[ijk] -
+       8*invg23*invh22*Phi223[ijk]*Phi233[ijk] -
+       4*invg33*invh22*Power(Phi233[ijk],2) -
+       8*invg00*invh13*Phi103[ijk]*Phi303[ijk] -
+       8*invg01*invh13*Phi113[ijk]*Phi303[ijk] -
+       8*invg02*invh13*Phi123[ijk]*Phi303[ijk] -
+       8*invg03*invh13*Phi133[ijk]*Phi303[ijk] -
+       8*invg00*invh23*Phi203[ijk]*Phi303[ijk] -
+       8*invg01*invh23*Phi213[ijk]*Phi303[ijk] -
+       8*invg02*invh23*Phi223[ijk]*Phi303[ijk] -
+       8*invg03*invh23*Phi233[ijk]*Phi303[ijk] -
+       4*invg00*invh33*Power(Phi303[ijk],2) -
+       8*invg01*invh13*Phi103[ijk]*Phi313[ijk] -
+       8*invg11*invh13*Phi113[ijk]*Phi313[ijk] -
+       8*invg12*invh13*Phi123[ijk]*Phi313[ijk] -
+       8*invg13*invh13*Phi133[ijk]*Phi313[ijk] -
+       8*invg01*invh23*Phi203[ijk]*Phi313[ijk] -
+       8*invg11*invh23*Phi213[ijk]*Phi313[ijk] -
+       8*invg12*invh23*Phi223[ijk]*Phi313[ijk] -
+       8*invg13*invh23*Phi233[ijk]*Phi313[ijk] -
+       8*invg01*invh33*Phi303[ijk]*Phi313[ijk] -
+       4*invg11*invh33*Power(Phi313[ijk],2) -
+       8*invg02*invh13*Phi103[ijk]*Phi323[ijk] -
+       8*invg12*invh13*Phi113[ijk]*Phi323[ijk] -
+       8*invg22*invh13*Phi123[ijk]*Phi323[ijk] -
+       8*invg23*invh13*Phi133[ijk]*Phi323[ijk] -
+       8*invg02*invh23*Phi203[ijk]*Phi323[ijk] -
+       8*invg12*invh23*Phi213[ijk]*Phi323[ijk] -
+       8*invg22*invh23*Phi223[ijk]*Phi323[ijk] -
+       8*invg23*invh23*Phi233[ijk]*Phi323[ijk] -
+       8*invg02*invh33*Phi303[ijk]*Phi323[ijk] -
+       8*invg12*invh33*Phi313[ijk]*Phi323[ijk] -
+       4*invg22*invh33*Power(Phi323[ijk],2) -
+       8*invg03*invh13*Phi103[ijk]*Phi333[ijk] -
+       8*invg13*invh13*Phi113[ijk]*Phi333[ijk] -
+       8*invg23*invh13*Phi123[ijk]*Phi333[ijk] -
+       8*invg33*invh13*Phi133[ijk]*Phi333[ijk] -
+       8*invg03*invh23*Phi203[ijk]*Phi333[ijk] -
+       8*invg13*invh23*Phi213[ijk]*Phi333[ijk] -
+       8*invg23*invh23*Phi223[ijk]*Phi333[ijk] -
+       8*invg33*invh23*Phi233[ijk]*Phi333[ijk] -
+       8*invg03*invh33*Phi303[ijk]*Phi333[ijk] -
+       8*invg13*invh33*Phi313[ijk]*Phi333[ijk] -
+       8*invg23*invh33*Phi323[ijk]*Phi333[ijk] -
+       4*invg33*invh33*Power(Phi333[ijk],2) +
+       2*invh11*nvec0*Phi133[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi233[ijk]*Pi01[ijk] +
+       2*invh13*nvec0*Phi333[ijk]*Pi01[ijk] +
+       2*invh12*nvec0*Phi133[ijk]*Pi02[ijk] +
+       2*invh22*nvec0*Phi233[ijk]*Pi02[ijk] +
+       2*invh23*nvec0*Phi333[ijk]*Pi02[ijk] +
+       2*invh13*nvec0*Phi133[ijk]*Pi03[ijk] +
+       2*invh23*nvec0*Phi233[ijk]*Pi03[ijk] +
+       2*invh33*nvec0*Phi333[ijk]*Pi03[ijk] +
+       4*invg00*Power(Pi03[ijk],2) +
+       2*invh11*nvec1*Phi133[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi233[ijk]*Pi11[ijk] +
+       2*invh13*nvec1*Phi333[ijk]*Pi11[ijk] +
+       2*invh12*nvec1*Phi133[ijk]*Pi12[ijk] +
+       2*invh11*nvec2*Phi133[ijk]*Pi12[ijk] +
+       2*invh22*nvec1*Phi233[ijk]*Pi12[ijk] +
+       2*invh12*nvec2*Phi233[ijk]*Pi12[ijk] +
+       2*invh23*nvec1*Phi333[ijk]*Pi12[ijk] +
+       2*invh13*nvec2*Phi333[ijk]*Pi12[ijk] +
+       2*invh13*nvec1*Phi133[ijk]*Pi13[ijk] +
+       2*invh11*nvec3*Phi133[ijk]*Pi13[ijk] +
+       2*invh23*nvec1*Phi233[ijk]*Pi13[ijk] +
+       2*invh12*nvec3*Phi233[ijk]*Pi13[ijk] +
+       2*invh33*nvec1*Phi333[ijk]*Pi13[ijk] +
+       2*invh13*nvec3*Phi333[ijk]*Pi13[ijk] +
+       8*invg01*Pi03[ijk]*Pi13[ijk] + 4*invg11*Power(Pi13[ijk],2) +
+       2*invh12*nvec2*Phi133[ijk]*Pi22[ijk] +
+       2*invh22*nvec2*Phi233[ijk]*Pi22[ijk] +
+       2*invh23*nvec2*Phi333[ijk]*Pi22[ijk] +
+       2*invh13*nvec2*Phi133[ijk]*Pi23[ijk] +
+       2*invh12*nvec3*Phi133[ijk]*Pi23[ijk] +
+       2*invh23*nvec2*Phi233[ijk]*Pi23[ijk] +
+       2*invh22*nvec3*Phi233[ijk]*Pi23[ijk] +
+       2*invh33*nvec2*Phi333[ijk]*Pi23[ijk] +
+       2*invh23*nvec3*Phi333[ijk]*Pi23[ijk] +
+       8*invg02*Pi03[ijk]*Pi23[ijk] + 8*invg12*Pi13[ijk]*Pi23[ijk] +
+       4*invg22*Power(Pi23[ijk],2) +
+       2*invh13*nvec3*Phi133[ijk]*Pi33[ijk] +
+       2*invh23*nvec3*Phi233[ijk]*Pi33[ijk] +
+       2*invh33*nvec3*Phi333[ijk]*Pi33[ijk] +
+       Power(nvec0,2)*Pi00[ijk]*Pi33[ijk] +
+       2*nvec0*nvec1*Pi01[ijk]*Pi33[ijk] +
+       2*nvec0*nvec2*Pi02[ijk]*Pi33[ijk] + 8*invg03*Pi03[ijk]*Pi33[ijk] +
+       2*nvec0*nvec3*Pi03[ijk]*Pi33[ijk] +
+       Power(nvec1,2)*Pi11[ijk]*Pi33[ijk] +
+       2*nvec1*nvec2*Pi12[ijk]*Pi33[ijk] + 8*invg13*Pi13[ijk]*Pi33[ijk] +
+       2*nvec1*nvec3*Pi13[ijk]*Pi33[ijk] +
+       Power(nvec2,2)*Pi22[ijk]*Pi33[ijk] + 8*invg23*Pi23[ijk]*Pi33[ijk] +
+       2*nvec2*nvec3*Pi23[ijk]*Pi33[ijk] + 4*invg33*Power(Pi33[ijk],2) +
+       Power(nvec3,2)*Power(Pi33[ijk],2)))/2. - srcSdH33[ijk]
 ;
 
 dtPhi100[ijk]

--- a/test/test_cases.txt
+++ b/test/test_cases.txt
@@ -9,7 +9,7 @@ CarpetXGPU:testDerivs:.hxx
 #Carpet:test:.hxx
 AMReX:test:.hxx
 #Nmesh:test:.c
-#Nmesh:GHG_rhs:.c
+Nmesh:GHG_rhs:.c
 Nmesh:GHG_set_profile_ADM:.c
 
 # Note: test/Nmesh/GHG_rhs.ipynb is documentation-only and not part of the test suite

--- a/test/test_cases.txt
+++ b/test/test_cases.txt
@@ -9,7 +9,7 @@ CarpetXGPU:testDerivs:.hxx
 #Carpet:test:.hxx
 AMReX:test:.hxx
 #Nmesh:test:.c
-Nmesh:GHG_rhs:.c
+#Nmesh:GHG_rhs:.c
 Nmesh:GHG_set_profile_ADM:.c
 
 # Note: test/Nmesh/GHG_rhs.ipynb is documentation-only and not part of the test suite


### PR DESCRIPTION
## Summary
- Uncomment the `dtPi` tensor definition in `GridTensors` to include it in the evolved variables
- Enable the `dtPi` evolution equation that was previously commented out
- Update the golden file with the expected generated C code output

## Test plan
- [ ] Verify regression tests pass with `wolframscript -script test/AllTests.wl`