### PR TITLE
Fix README prerequisites heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Wolfram Language code generator that produces C/C++ from symbolic tensor expressions using xAct. Designed for numerical relativity and computational physics applications.
 
-## Pre-Requisites
+## Prerequisites
 
 - [Wolfram Engine](https://www.wolfram.com/developer/) (free) or Mathematica
 - [xAct](http://www.xact.es) tensor algebra package


### PR DESCRIPTION
### Motivation
- Correct a minor typo and improve consistency by changing the README section heading from "Pre-Requisites" to the conventional spelling "Prerequisites".

### Description
- Rename the section heading in `README.md` from `Pre-Requisites` to `Prerequisites`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69685f2960308325864b12a41aee8b51)