### PR TITLE
Localize `coindex` in `GetInterfaceName` to prevent variable leakage

### DIFF
--- a/src/BackendCommon.wl
+++ b/src/BackendCommon.wl
@@ -59,7 +59,7 @@ Protect[GetGFIndexNameMix2nd];
   Previously duplicated in: Carpet.wl, CarpetXGPU.wl, CarpetXPointDesc.wl
 *)
 GetInterfaceName[compname_] :=
-  Module[{intfname = ToString[compname[[0]]], colist = {"t", "x", "y", "z"}},
+  Module[{intfname = ToString[compname[[0]]], colist = {"t", "x", "y", "z"}, coindex},
     Do[
       coindex = compname[[icomp]][[1]];
       intfname = intfname <> colist[[coindex + 1]]


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage or reuse of the loop index `coindex` when generating interface names, which could cause incorrect output or cross-contamination of state during code generation.

### Description
- Add `coindex` to the `Module` local variables in `GetInterfaceName` inside `src/BackendCommon.wl`, so the index is properly localized during the `Do` loop.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968603df8c88325b415d1c92536f039)