### PR TITLE
Sanitize header guard names for generated output files

### DIFF
--- a/src/Writefile.wl
+++ b/src/Writefile.wl
@@ -24,7 +24,7 @@ Begin["`Private`"];
 
 (* WriteToFile - uses global getters *)
 WriteToFile[outputfile_String] :=
-  Module[{filepointer},
+  Module[{filepointer, headerGuard},
     If[Environment["QUIET"] =!= "1",
       System`Print["Writing to \"", outputfile, "\"...\n"]
     ];
@@ -36,6 +36,11 @@ WriteToFile[outputfile_String] :=
     ];
     (* define pr *)
     filepointer = OpenAppend[outputfile];
+    headerGuard =
+      StringReplace[
+        ToUpperCase[FileNameTake[outputfile]],
+        Except[LetterCharacter | DigitCharacter] -> "_"
+      ];
     Block[{Global`pr},
       Global`pr[x_:""] :=
         Module[{},
@@ -57,15 +62,15 @@ WriteToFile[outputfile_String] :=
       ];
       Global`pr[];
       If[GetPrintHeaderMacro[],
-        Global`pr["#ifndef " <> StringReplace[ToUpperCase[FileNameTake[outputfile]], "." -> "_"]];
-        Global`pr["#define " <> StringReplace[ToUpperCase[FileNameTake[outputfile]], "." -> "_"]];
+        Global`pr["#ifndef " <> headerGuard];
+        Global`pr["#define " <> headerGuard];
         Global`pr[]
       ];
       (* GetMainPrint[] evaluates the held main print content *)
       GetMainPrint[];
       Global`pr[];
       If[GetPrintHeaderMacro[],
-        Global`pr["#endif // #ifndef " <> StringReplace[ToUpperCase[FileNameTake[outputfile]], "." -> "_"]];
+        Global`pr["#endif // #ifndef " <> headerGuard];
         Global`pr[]
       ];
       Global`pr["/* " <> FileNameTake[outputfile] <> " */"];


### PR DESCRIPTION
### Motivation
- Prevent invalid C preprocessor macro names when generating header guards from output filenames by normalizing non-alphanumeric characters.

### Description
- Updated `WriteToFile` in `src/Writefile.wl` to compute a `headerGuard` by uppercasing `FileNameTake[outputfile]` and replacing any non-letter/digit characters with underscores, and used `headerGuard` for the emitted `#ifndef`, `#define`, and `#endif` lines.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696864e8c3b08325a289ddeccd672353)