### PR TITLE
Review codebase and fix easiest issue

### DIFF
--- a/src/stencils/FiniteDifferenceStencils.wl
+++ b/src/stencils/FiniteDifferenceStencils.wl
@@ -1,6 +1,6 @@
 (* ::Package:: *)
 
-(* stencils.wl *)
+(* FiniteDifferenceStencils.wl *)
 
 (* (c) Liwei Ji, 01/2025 *)
 


### PR DESCRIPTION
The header comment in FiniteDifferenceStencils.wl incorrectly stated "stencils.wl" instead of the actual filename "FiniteDifferenceStencils.wl".