### PR TITLE
Handle wolframscript failures in Generato script

### DIFF
--- a/Generato
+++ b/Generato
@@ -47,7 +47,10 @@ for input_file in "$@"; do
 
   # Run wolframscript on the input file
   [[ "$QUIET" != "1" ]] && echo "Processing '$input_file'..."
-  wolframscript -f "$input_file"
+  if ! wolframscript -f "$input_file"; then
+    echo "Error: Failed to process '$input_file'. Skipping output cleanup."
+    continue
+  fi
 
   # Check for any supported output file extensions and clean them
   found_output=false


### PR DESCRIPTION
### Motivation
- Prevent the `Generato` runner from attempting output cleanup when `wolframscript` fails for an input, and provide a clear error message instead.

### Description
- Add a failure check around `wolframscript -f "$input_file"` that echoes an error and `continue`s to the next file when processing fails, preserving existing `QUIET` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696867477e888325bf75f929f730e866)