### PR TITLE
Fix varlist index range for manifold dimension

### DIFF
--- a/src/Varlist.wl
+++ b/src/Varlist.wl
@@ -32,16 +32,18 @@ Options[ParseVarlist] :=
   {ExtraReplaceRules -> {}};
 
 ParseVarlist[OptionsPattern[], varlist_?ListQ, chartname_] :=
-  Module[{iMin, iMax = 3, var, varinfo, varname, symmetry, printname, symname, symindex, parseComponentValue, extrareplacerules},
+  Module[{dim, iMin, iMax, var, varinfo, varname, symmetry, printname, symname, symindex, parseComponentValue, extrareplacerules},
     {extrareplacerules} = OptionValue[{ExtraReplaceRules}];
     PrintVerbose["ParseVarlist..."];
-    PrintVerbose["  Dim = ", GetDim[], ", Chart = ", chartname];
+    dim = GetDim[];
+    PrintVerbose["  Dim = ", dim, ", Chart = ", chartname];
     PrintVerbose["  List: ", varlist];
-    If[GetDim[] == 3,
+    If[dim == 3,
       iMin = 1
       ,
       iMin = 0
     ];
+    iMax = dim - 1 + iMin;
     SetProcessNewVarlist[True];
     Do[
       var = varlist[[ivar]];


### PR DESCRIPTION
### Motivation
- ParseVarlist previously assumed a 4D coordinate range (hard-coded 0..3) which is incorrect for other manifold dimensions.
- This could produce incorrect index loops for non-4D manifolds and repeated calls to `GetDim[]`.

### Description
- Compute the manifold dimension once with `dim = GetDim[]` and use it for logging.
- Derive `iMin` and `iMax` from `dim` instead of hard-coding `iMax = 3` so index ranges match the manifold dimension.
- Introduced local `dim` variable and adjusted the `Module` locals in `ParseVarlist` accordingly (in `src/Varlist.wl`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968769019cc8325b1a6a1798dce54b9)