### PR TITLE
Review codebase and implement high-impact fix

### DIFF
--- a/codes/AMReX.wl
+++ b/codes/AMReX.wl
@@ -93,10 +93,13 @@ PrintComponentInitialization[varinfo_, compname_] :=
             ,
             tensorname = StringDrop[ToString[compToValue], {-len, -len + offset}];
             pos1stbackwards =
-              If[StringStartsQ[tensorname, "d"],
-                fdorder
-                ,
-                StringPosition[tensorname, "d"][[-1]][[1]]
+              Which[
+                StringStartsQ[tensorname, "d"],
+                  fdorder,
+                StringContainsQ[tensorname, "d"],
+                  StringPosition[tensorname, "d"][[-1]][[1]],
+                True,
+                  Throw @ Message[PrintComponentInitialization::EDerivativeName, tensorname]
               ];
             "const auto " <> ToString[compToValue]
             <> " = calcderivs" <> ToString[fdorder] <> "_"

--- a/codes/CarpetXGPU.wl
+++ b/codes/CarpetXGPU.wl
@@ -223,10 +223,13 @@ PrintComponentInitialization[varinfo_, compname_] :=
             ,
             tensorname = StringDrop[ToString[compToValue], {-len, -len + offset}];
             pos1stbackwards =
-              If[StringStartsQ[tensorname, "d"],
-                fdorder
-                ,
-                StringPosition[tensorname, "d"][[-1]][[1]]
+              Which[
+                StringStartsQ[tensorname, "d"],
+                  fdorder,
+                StringContainsQ[tensorname, "d"],
+                  StringPosition[tensorname, "d"][[-1]][[1]],
+                True,
+                  Throw @ Message[PrintComponentInitialization::EDerivativeName, tensorname]
               ];
             "const auto " <> ToString[compToValue]
             <> " = calcderivs" <> ToString[fdorder] <> "_"

--- a/src/BackendCommon.wl
+++ b/src/BackendCommon.wl
@@ -218,6 +218,7 @@ Protect[ExtractComponentInfo];
 *)
 PrintComponentInitialization::EMode = "PrintComponentInitialization mode unrecognized!";
 PrintComponentInitialization::EVarLength = "PrintComponentInitialization variable's tensor type unsupported!";
+PrintComponentInitialization::EDerivativeName = "PrintComponentInitialization: derivative tensor name '`1`' does not contain 'd'!";
 
 End[];
 


### PR DESCRIPTION
Add defensive check before StringPosition call in AMReX.wl and CarpetXGPU.wl. Previously, if a tensorname didn't start with 'd', the code assumed it must contain 'd' somewhere. If this assumption was violated, StringPosition returned {} and [[-1]][[1]] crashed with Part::pkspec1.

Now uses Which[] to explicitly check if 'd' exists in the string before accessing its position, and throws a clear error message if the derivative tensor name is malformed.